### PR TITLE
feat(release): ship a portable binary and an accelerated one per target

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -99,6 +99,12 @@ jobs:
             "$ARCHIVE.sha256" \
             --clobber
 
+  # The portable build: default features, no `local-inference`. This is the
+  # artifact `yolop-<target>.tar.gz` names and the one the Homebrew formula
+  # points at, because it is the only one that runs anywhere the target does.
+  # An engine build is ~28 MB against a few MB here, and the accelerated ones
+  # below additionally need a vendor runtime present on the machine, which is
+  # not a thing to hand someone who typed `brew install`.
   build:
     name: Build CLI (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
@@ -130,15 +136,9 @@ jobs:
         with:
           shared-key: "cli-${{ matrix.target }}"
 
-      # `local-inference` is off in the crate's default features so
-      # `cargo install yolop` and the contributor loop stay fast. The shipped
-      # artifacts are the opposite trade: they are built once here, so they
-      # carry the engine and the Homebrew formula (generated from these
-      # tarballs) gets it for free.
       - name: Build release binary
         run: |
-          cargo build --release --target ${{ matrix.target }} -p yolop --locked \
-            --features local-inference
+          cargo build --release --target ${{ matrix.target }} -p yolop --locked
 
       - name: Package binary
         env:
@@ -151,6 +151,105 @@ jobs:
           # macOS ships shasum but not sha256sum by default; Linux is the
           # opposite. Pick the one that exists so the workflow doesn't break
           # if a runner image drops the other.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+          fi
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          gh release upload "$TAG" \
+            "$ARCHIVE" \
+            "$ARCHIVE.sha256" \
+            --clobber
+
+  # The accelerated builds: `local-inference` plus the GPU backend the target
+  # can actually use. Kept out of `build` on purpose. They are a separate
+  # download, not the default, because each carries a runtime requirement the
+  # portable build does not: a `cuda` binary needs an NVIDIA driver on the
+  # machine, and neither is worth ~28 MB to someone who will never run
+  # `--provider local`. Kept out of `update-homebrew`'s `needs` for the same
+  # reason: `cuda` is the least proven build in the release, and it must not be
+  # able to hold back the formula.
+  build-accelerated:
+    name: Build CLI (${{ matrix.target }}, ${{ matrix.backend }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            backend: metal
+            archive: yolop-aarch64-apple-darwin-metal.tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            backend: metal
+            archive: yolop-x86_64-apple-darwin-metal.tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            backend: cuda
+            archive: yolop-x86_64-unknown-linux-gnu-cuda.tar.gz
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      # The engine plus the CUDA toolkit does not fit next to the runner's
+      # preinstalled SDKs. These are the four largest and nothing here uses
+      # them.
+      - name: Free disk space
+        if: matrix.backend == 'cuda'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet \
+                      /opt/ghc /usr/local/share/boost
+          df -h /
+
+      # `nvcc` is what `cudarc`'s build script looks for; without it the build
+      # panics rather than degrading. Ubuntu's own package is used instead of a
+      # third-party action so the release depends on one less external repo.
+      - name: Install the CUDA toolkit
+        if: matrix.backend == 'cuda'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit
+          nvcc --version
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "cli-${{ matrix.target }}-${{ matrix.backend }}"
+
+      - name: Build release binary
+        env:
+          # The kernels are compiled for one compute capability, and the usual
+          # way that is chosen is by asking `nvidia-smi` what the build machine
+          # has. No runner has a GPU, so it has to be named. 7.5 (Turing, 2018)
+          # is the floor that still covers everything newer through PTX.
+          CUDA_COMPUTE_CAP: 75
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p yolop --locked \
+            --features ${{ matrix.backend }}
+
+      - name: Package binary
+        env:
+          TARGET: ${{ matrix.target }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          cd "target/$TARGET/release"
+          tar czf "$GITHUB_WORKSPACE/$ARCHIVE" yolop
+          cd "$GITHUB_WORKSPACE"
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
           else

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -235,9 +235,12 @@ jobs:
         env:
           # The kernels are compiled for one compute capability, and the usual
           # way that is chosen is by asking `nvidia-smi` what the build machine
-          # has. No runner has a GPU, so it has to be named. 7.5 (Turing, 2018)
-          # is the floor that still covers everything newer through PTX.
-          CUDA_COMPUTE_CAP: 75
+          # has. No runner has a GPU, so it has to be named. 8.0 is the floor
+          # candle compiles at, not a preference: its kernels call `__hmax_nan`
+          # and `__hmin_nan`, which nvcc only defines for `__CUDA_ARCH__ >= 800`,
+          # so 7.5 fails outright in `compatibility.cuh`. Anything newer than
+          # Ampere reaches the binary through PTX.
+          CUDA_COMPUTE_CAP: 80
         run: |
           cargo build --release --target ${{ matrix.target }} -p yolop --locked \
             --features ${{ matrix.backend }}

--- a/.github/workflows/metal-build-check.yml
+++ b/.github/workflows/metal-build-check.yml
@@ -6,10 +6,10 @@
 # targets still upload — a partial release, which is worse than a clean
 # failure. This job moves that discovery to review time.
 #
-# It also guards against bitrot: the accelerated backends are compiled nowhere
-# else in CI, so a dependency bump can break them silently. The `pull_request`
-# trigger is filtered to the files that can plausibly do it, because macOS
-# runner minutes bill at a multiple of Linux.
+# It also guards against bitrot: the only other place CI compiles an accelerated
+# backend is that release job, which is far too late to learn a dependency bump
+# broke it. The `pull_request` trigger is filtered to the files that can
+# plausibly do it, because macOS runner minutes bill at a multiple of Linux.
 #
 # Debug, not release: the failures this is built to catch are the compile and
 # link steps (`objc2` is Apple-only, and the Metal frameworks have to resolve),

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Rust
 /target/
 **/target/
-# Separate target dir for the `local-inference` engine build (see AGENTS.md).
+# Separate target dirs for the engine builds, which resolve a different feature
+# graph and would otherwise recompile the tree in the routine one (see AGENTS.md).
 /target-local-inference/
+/target-cuda/
 **/*.rs.bk
 Cargo.lock.bak
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Linux), so a change there wants the backend compiled too. `cuda` needs `nvcc`
 kernels are compiled for one capability and there is no GPU here to ask:
 
 ```bash
-CARGO_TARGET_DIR=target-cuda CUDA_COMPUTE_CAP=75 \
+CARGO_TARGET_DIR=target-cuda CUDA_COMPUTE_CAP=80 \
   cargo check -p yolop --locked --features cuda
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,16 @@ CARGO_TARGET_DIR=target-local-inference \
   cargo clippy --workspace --all-targets --features local-inference -- -D warnings
 ```
 
+The release ships an accelerated build per target (`metal` on macOS, `cuda` on
+Linux), so a change there wants the backend compiled too. `cuda` needs `nvcc`
+(`apt-get install nvidia-cuda-toolkit`) and `CUDA_COMPUTE_CAP` set, since the
+kernels are compiled for one capability and there is no GPU here to ask:
+
+```bash
+CARGO_TARGET_DIR=target-cuda CUDA_COMPUTE_CAP=75 \
+  cargo check -p yolop --locked --features cuda
+```
+
 ## Where things live
 
 - [`knowledge/`](knowledge/index.md), the OKF bundle and durable development

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ GPU-accelerated binary per target that does:
 |----------------------------------------------|------------------------------|
 | `yolop-aarch64-apple-darwin-metal.tar.gz`    | Apple Silicon                |
 | `yolop-x86_64-apple-darwin-metal.tar.gz`     | Intel Mac                    |
-| `yolop-x86_64-unknown-linux-gnu-cuda.tar.gz` | NVIDIA GPU and driver        |
+| `yolop-x86_64-unknown-linux-gnu-cuda.tar.gz` | NVIDIA GPU, Ampere or newer  |
 
 Grab one from the [latest release](https://github.com/everruns/yolop/releases/latest),
 or build it yourself. The backend is a feature that implies `local-inference`

--- a/README.md
+++ b/README.md
@@ -248,19 +248,32 @@ better-aimed model: its chat template emits tool calls as
 `<tool_call><function=…>` XML, and the engine only parses JSON inside
 `<tool_call>`, so none of its tool calls would be understood.
 
-Weights live under `<data_dir>/yolop/models/`. The engine is compiled into the
-Homebrew and GitHub release binaries; a build from source needs
-`cargo install yolop --locked --features local-inference`, which is much slower
-to compile. How well a local model actually drives the agent loop is the open
-question this is here to answer.
+Weights live under `<data_dir>/yolop/models/`. How well a local model actually
+drives the agent loop is the open question this is here to answer.
 
-Those builds run on the CPU. GPU acceleration needs a vendor toolchain, so it is
-a separate feature that implies `local-inference`:
+The engine is **not** in the default build, so `brew install` and
+`cargo install yolop --locked` do not carry it. Each release ships a second,
+GPU-accelerated binary per target that does:
+
+| Download                                     | Needs                        |
+|----------------------------------------------|------------------------------|
+| `yolop-aarch64-apple-darwin-metal.tar.gz`    | Apple Silicon                |
+| `yolop-x86_64-apple-darwin-metal.tar.gz`     | Intel Mac                    |
+| `yolop-x86_64-unknown-linux-gnu-cuda.tar.gz` | NVIDIA GPU and driver        |
+
+Grab one from the [latest release](https://github.com/everruns/yolop/releases/latest),
+or build it yourself. The backend is a feature that implies `local-inference`
+and needs its vendor toolchain:
 
 ```bash
 cargo install yolop --locked --features metal   # macOS
 cargo install yolop --locked --features cuda    # NVIDIA, needs the CUDA toolkit
 ```
+
+There is no CPU-only engine build to download. An 8B model on the CPU is slow
+enough to read as "local models are useless" when the real finding is "this was
+never accelerated", so `cargo install yolop --locked --features local-inference`
+is there if you want it, but it is not something to ship.
 
 ### Git attribution
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -17,8 +17,12 @@
 - [Release](specs/release.md): the accelerated builds are their own job, kept
   out of the Homebrew job's `needs`. `cuda` is the least proven build in the
   release, and a failure there must not hold back the tap. It now at least
-  compiles in CI, with its compute capability pinned to 7.5 because no runner
-  has a GPU to interrogate; evidence that it *runs* still needs a CUDA host.
+  compiles in CI, against Ubuntu's own `nvidia-cuda-toolkit` (nvcc 12.0) with
+  its compute capability pinned to 8.0, because no runner has a GPU to
+  interrogate. 8.0 is candle's floor, not a preference: its kernels call
+  `__hmax_nan`/`__hmin_nan`, which nvcc defines only for `__CUDA_ARCH__ >= 800`,
+  so pre-Ampere cards are out of reach of the shipped build. Evidence that it
+  *runs* still needs a CUDA host.
 
 ## 2026-08-21, A green release workflow can still ship half the binaries
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,25 @@
 # Knowledge Log
 
+## 2026-08-21, The default binary stops carrying the inference engine
+
+- [Local inference](specs/local-inference.md): every release target now ships
+  twice. `yolop-<target>.tar.gz` is built with default features and is what the
+  Homebrew formula points at; `yolop-<target>-metal.tar.gz` and
+  `yolop-<target>-cuda.tar.gz` carry the engine with the backend that target can
+  use.
+- The default asset is the portable one because it is the only build that runs
+  wherever the target does: a `cuda` binary needs an NVIDIA driver present, and
+  that is not a thing to hand someone who typed `brew install`. Through v0.17.0
+  the single shipped binary carried the engine, CPU-only, at +41.3 MiB.
+- No CPU-only engine build is offered for download. An unaccelerated engine
+  measures the wrong thing, so shipping one would only spread that mistake; the
+  feature stays available to anyone building from source.
+- [Release](specs/release.md): the accelerated builds are their own job, kept
+  out of the Homebrew job's `needs`. `cuda` is the least proven build in the
+  release, and a failure there must not hold back the tap. It now at least
+  compiles in CI, with its compute capability pinned to 7.5 because no runner
+  has a GPU to interrogate; evidence that it *runs* still needs a CUDA host.
+
 ## 2026-08-21, A green release workflow can still ship half the binaries
 
 - [Release](specs/release.md): `cli-binaries.yml` built the extension servers

--- a/knowledge/specs/local-inference.md
+++ b/knowledge/specs/local-inference.md
@@ -101,28 +101,37 @@ the gate earns its keep:
 - **Compile time justifies the gate for people who build from source.**
   `cargo install yolop` roughly doubles, and a contributor's cold build pays the
   same. That is worth avoiding for the majority who will never select `local`.
-- **Binary size is not something the gate fixes.** The release binaries are
-  built with the feature on, so a Homebrew install carries the engine whether or
-  not the user ever runs a local model. Two different costs hide behind that,
-  and they should not be quoted interchangeably: **+41.3 MiB of disk** after
-  install, and a *download* that grows by the compressed delta. The formula
-  fetches a `.tar.gz`, and the baseline binary compresses 3.46× (96.3 → 27.8
-  MiB), so the download delta is much smaller than the disk delta — but it has
-  not been measured, so do not quote a figure for it. If the trade stops being
-  worth it — and for an experiment with no eval numbers behind it, that is a
-  fair question — the lever is
-  [`cli-binaries.yml`](../../.github/workflows/cli-binaries.yml), not the
-  feature default.
+- **Binary size is what the distribution split fixes, not the gate.** Through
+  v0.17.0 the release binaries were built with the feature on, so a Homebrew
+  install carried the engine whether or not the user ever ran a local model:
+  **+41.3 MiB of disk** after install, plus a download that grew by the
+  compressed delta (the baseline binary compresses 3.46×, 96.3 → 27.8 MiB; the
+  delta itself was never measured, so do not quote a figure for it). That is
+  what the lever in [`cli-binaries.yml`](../../.github/workflows/cli-binaries.yml)
+  was for, and it has since been pulled: the default artifact no longer carries
+  the engine, and the people who want it download a build that does. See
+  [Distribution](#distribution).
 
-Because compile cost lands on builders rather than users, the gate and the
-distribution point in opposite directions:
+## Distribution
 
-- `local-inference` is **off** in the crate's default features, so
-  `cargo install yolop` and the contributor `cargo check` loop stay fast.
-- The **release binaries are built with it on**
-  (`.github/workflows/cli-binaries.yml`), and the Homebrew formula is generated
-  from those tarballs, so the install path most users take
-  ([Release](release.md)) ships the engine without anyone compiling it.
+`local-inference` is **off** in the crate's default features, so
+`cargo install yolop` and the contributor `cargo check` loop stay fast. A
+release ([Release](release.md)) resolves the same trade by shipping two builds
+per target rather than picking one:
+
+| Asset                              | Features                    | For                              |
+|------------------------------------|-----------------------------|----------------------------------|
+| `yolop-<target>.tar.gz`            | default, no engine          | everyone; what Homebrew installs |
+| `yolop-<target>-metal.tar.gz`      | `metal` (macOS)             | local models on an Apple GPU     |
+| `yolop-<target>-cuda.tar.gz`       | `cuda` (Linux x86_64)       | local models on an NVIDIA GPU    |
+
+The default asset is the portable one because it is the only build that runs
+wherever the target does. An accelerated build carries a runtime requirement
+the plain one does not: a `cuda` binary needs an NVIDIA driver present, and
+that is not a thing to hand someone who typed `brew install`. There is
+deliberately no CPU-only engine build in the list: the [Acceleration](#acceleration)
+finding is that an unaccelerated engine measures the wrong thing, so shipping
+one as a *download* would only spread that mistake.
 
 A build without the feature still resolves `--provider local` — only the driver
 is compiled out. Such a build reports the provider unusable so it stays out of
@@ -158,11 +167,15 @@ would be compiled nowhere in CI, so a dependency bump could break them and only
 a release would find out. `cuda` has no equivalent: no CI runner has the toolkit,
 so it stays unbuilt and its first real evidence has to come from a CUDA host.
 
-**The release binaries are built with `local-inference` alone, so they are
-CPU-only** ([`cli-binaries.yml`](../../.github/workflows/cli-binaries.yml)).
-A Homebrew install therefore runs local models on the CPU; accelerating the
-shipped macOS binaries is a separate decision, not something the feature flag
-settles.
+`cuda` is now also compiled in CI, by the release itself rather than a check:
+[`cli-binaries.yml`](../../.github/workflows/cli-binaries.yml) installs Ubuntu's
+`nvidia-cuda-toolkit` for the accelerated Linux build. That proves it compiles,
+which is all a GPU-less runner can prove. **Its first evidence that it runs
+still has to come from a CUDA host.** Two things about that build are worth
+knowing before quoting it as support: the kernels are compiled for one compute
+capability, pinned to 7.5 (Turing) via `CUDA_COMPUTE_CAP` because there is no
+GPU to interrogate, and anything newer reaches it through PTX rather than a
+native cubin.
 
 ## The model store
 

--- a/knowledge/specs/local-inference.md
+++ b/knowledge/specs/local-inference.md
@@ -173,9 +173,13 @@ the slower build and the one no `pull_request` path can justify on runner cost.
 which is all a GPU-less runner can prove. **Its first evidence that it runs
 still has to come from a CUDA host.** Two things about that build are worth
 knowing before quoting it as support: the kernels are compiled for one compute
-capability, pinned to 7.5 (Turing) via `CUDA_COMPUTE_CAP` because there is no
-GPU to interrogate, and anything newer reaches it through PTX rather than a
-native cubin.
+capability, pinned to 8.0 via `CUDA_COMPUTE_CAP` because there is no GPU to
+interrogate, and anything newer reaches it through PTX rather than a native
+cubin. 8.0 is a floor candle imposes, not a choice: its kernels call
+`__hmax_nan` and `__hmin_nan`, which nvcc defines only for
+`__CUDA_ARCH__ >= 800`, so a lower capability fails in `compatibility.cuh`
+rather than producing a wider-reaching binary. **Pre-Ampere cards are therefore
+out of reach of the shipped `cuda` build.**
 
 ## The model store
 

--- a/knowledge/specs/local-inference.md
+++ b/knowledge/specs/local-inference.md
@@ -163,9 +163,9 @@ features it wants.
 `metal` is compiled for both macOS release targets by
 [`metal-build-check.yml`](../../.github/workflows/metal-build-check.yml), on
 pull requests that touch the manifests. Without it the accelerated backends
-would be compiled nowhere in CI, so a dependency bump could break them and only
-a release would find out. `cuda` has no equivalent: no CI runner has the toolkit,
-so it stays unbuilt and its first real evidence has to come from a CUDA host.
+would be compiled nowhere at review time, so a dependency bump could break them
+and only a release would find out. `cuda` has no review-time equivalent: it is
+the slower build and the one no `pull_request` path can justify on runner cost.
 
 `cuda` is now also compiled in CI, by the release itself rather than a check:
 [`cli-binaries.yml`](../../.github/workflows/cli-binaries.yml) installs Ubuntu's

--- a/knowledge/specs/release.md
+++ b/knowledge/specs/release.md
@@ -61,11 +61,17 @@ first; see [`tuika.md`](./tuika.md).
 
 Prebuilt CLI binaries are produced for:
 
-| OS    | Target                       | Runner          |
-|-------|------------------------------|-----------------|
-| macOS | `aarch64-apple-darwin`       | `macos-latest`  |
-| macOS | `x86_64-apple-darwin`        | `macos-latest`  |
-| Linux | `x86_64-unknown-linux-gnu`   | `ubuntu-latest` |
+| OS    | Target                       | Runner          | Accelerated build |
+|-------|------------------------------|-----------------|-------------------|
+| macOS | `aarch64-apple-darwin`       | `macos-latest`  | `metal`           |
+| macOS | `x86_64-apple-darwin`        | `macos-latest`  | `metal`           |
+| Linux | `x86_64-unknown-linux-gnu`   | `ubuntu-latest` | `cuda`            |
+
+Every target ships twice: `yolop-<target>.tar.gz` built with default features,
+and `yolop-<target>-<backend>.tar.gz` carrying the local-inference engine and
+that backend. The plain one is what the Homebrew formula points at, because it
+is the only build that runs wherever the target does; see
+[Local inference](local-inference.md#distribution) for why the split exists.
 
 ## Release Flow
 
@@ -166,7 +172,10 @@ after it goes live.
   release binaries for the three CLI targets, packages them as
   `yolop-<target>.tar.gz`, uploads tarballs and `.sha256` files to the GitHub
   Release, and regenerates the Homebrew formula and pushes it to
-  `everruns/homebrew-tap`.
+  `everruns/homebrew-tap`. A separate `build-accelerated` job uploads the
+  engine builds (`yolop-<target>-<backend>.tar.gz`) beside them. It is
+  deliberately not in the formula job's `needs`: `cuda` is the least proven
+  build in the release, and a failure there must not hold back the tap.
 - **Secret**: `DOPPLER_TOKEN`. The Doppler config holds
   `HOMEBREW_TAP_GITHUB_TOKEN`, a fine-grained PAT scoped to
   `everruns/homebrew-tap` only.

--- a/scripts/check_release_matrix.py
+++ b/scripts/check_release_matrix.py
@@ -63,10 +63,31 @@ def targets(jobs: Mapping[str, Any], job: str) -> set[str]:
     return found
 
 
+def check_accelerated(jobs: Mapping[str, Any], cli: set[str]) -> None:
+    """The accelerated builds ship alongside the CLI, so they must line up.
+
+    Two ways this matrix goes wrong quietly: a backend build for a target the
+    release does not otherwise ship, which produces an asset nothing else
+    corroborates, and two combinations naming the same archive, which makes the
+    second `gh release upload --clobber` overwrite the first.
+    """
+    combinations = expand(jobs["build-accelerated"]["strategy"]["matrix"])
+    stray = {c["target"] for c in combinations} - cli
+    if stray:
+        raise SystemExit(
+            "build-accelerated builds targets the CLI does not ship: "
+            + ", ".join(sorted(stray))
+        )
+    archives = [c["archive"] for c in combinations]
+    if len(set(archives)) != len(archives):
+        raise SystemExit("build-accelerated: two combinations upload the same archive")
+
+
 def main() -> None:
     jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
     cli = targets(jobs, "build")
     extensions = targets(jobs, "extensions")
+    check_accelerated(jobs, cli)
     if cli != extensions:
         missing = ", ".join(sorted(cli - extensions)) or "none"
         extra = ", ".join(sorted(extensions - cli)) or "none"

--- a/scripts/test_check_release_matrix.py
+++ b/scripts/test_check_release_matrix.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from check_release_matrix import expand
+from check_release_matrix import check_accelerated, expand
 
 CLI_STYLE = {
     "include": [
@@ -45,6 +45,32 @@ class ExpandTests(unittest.TestCase):
         self.assertEqual(
             {job["runner"] for job in jobs}, {"macos-latest", "ubuntu-latest"}
         )
+
+
+
+MAC = {"target": "aarch64-apple-darwin", "backend": "metal", "archive": "a.tar.gz"}
+LINUX = {"target": "x86_64-unknown-linux-gnu", "backend": "cuda", "archive": "b.tar.gz"}
+CLI = {"aarch64-apple-darwin", "x86_64-unknown-linux-gnu"}
+
+
+def jobs(*entries: dict) -> dict:
+    return {"build-accelerated": {"strategy": {"matrix": {"include": list(entries)}}}}
+
+
+class AcceleratedTests(unittest.TestCase):
+    def test_matching_targets_pass(self) -> None:
+        check_accelerated(jobs(MAC, LINUX), CLI)
+
+    def test_a_target_the_cli_does_not_ship_is_rejected(self) -> None:
+        stray = {**MAC, "target": "aarch64-unknown-linux-gnu"}
+        with self.assertRaises(SystemExit):
+            check_accelerated(jobs(stray), CLI)
+
+    def test_two_backends_sharing_an_archive_are_rejected(self) -> None:
+        """The second upload would clobber the first, silently."""
+        clash = {**LINUX, "archive": MAC["archive"]}
+        with self.assertRaises(SystemExit):
+            check_accelerated(jobs(MAC, clash), CLI)
 
 
 if __name__ == "__main__":

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,8 +441,9 @@ enum ProviderArg {
     Google,
     Openrouter,
     Ollama,
-    /// In-process inference — no external server. Requires a build with the
-    /// `local-inference` feature (the release binaries and Homebrew formula).
+    /// In-process inference, no external server. Requires a build with the
+    /// `local-inference` feature: the accelerated release binaries
+    /// (`yolop-<target>-metal` / `-cuda`), not the default one or Homebrew.
     Local,
     /// Generic OpenAI-compatible endpoint (CUSTOM_BASE_URL / saved base URL).
     Custom,
@@ -479,8 +480,9 @@ fn ensure_provider_is_built_in(provider: &ProviderChoice) -> Result<()> {
     if matches!(provider, ProviderChoice::Local { .. }) && !cfg!(feature = "local-inference") {
         anyhow::bail!(
             "this build has no local inference engine, so `--provider local` cannot run. \
-             Install a release build (`brew install everruns/tap/yolop`) or build with \
-             `--features local-inference`."
+             Download an accelerated build (`yolop-<target>-metal` or `-cuda`) from \
+             https://github.com/everruns/yolop/releases/latest, or build with \
+             `--features metal` / `--features cuda`."
         );
     }
     Ok(())
@@ -1089,7 +1091,9 @@ async fn run_models_pull(spec: &str) -> Result<()> {
 async fn run_models_pull(_spec: &str) -> Result<()> {
     Err(anyhow::anyhow!(
         "this build has no local inference engine, so downloaded weights could not be run. \
-         Install a release build (Homebrew) or build with `--features local-inference`."
+         Download an accelerated build (`yolop-<target>-metal` or `-cuda`) from \
+         https://github.com/everruns/yolop/releases/latest, or build with \
+         `--features metal` / `--features cuda`."
     ))
 }
 
@@ -2596,8 +2600,12 @@ mod tests {
             // internal driver id and offers the user no way forward.
             let err = result.expect_err("a build without the engine must reject `local`");
             let message = err.to_string();
-            assert!(message.contains("--features local-inference"), "{message}");
-            assert!(message.contains("brew install"), "{message}");
+            // The default release binary and Homebrew both ship without the
+            // engine, so pointing there would send the user in a circle. The
+            // accelerated download is the only prebuilt answer.
+            assert!(message.contains("releases/latest"), "{message}");
+            assert!(message.contains("--features metal"), "{message}");
+            assert!(!message.contains("brew install"), "{message}");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1021,6 +1021,23 @@ fn resolve_workspace_root(
     std::env::current_dir().context("resolve current workspace directory")
 }
 
+/// What to tell someone whose weights store is empty.
+///
+/// `list` and `rm` compile into every build, so one that dropped the engine can
+/// still clean up after one that had it. Pulling does not, and the default
+/// release binary is now the engine-less one, so the obvious hint would
+/// dead-end most of the people who read it.
+fn empty_weights_store_hint() -> String {
+    if cfg!(feature = "local-inference") {
+        format!("Pull one with `yolop weights pull {DEFAULT_LOCAL_MODEL}`.")
+    } else {
+        "This build has no local inference engine, so there is nothing here to run weights. \
+         Download an accelerated build (`yolop-<target>-metal` or `-cuda`) from \
+         https://github.com/everruns/yolop/releases/latest to pull them."
+            .to_string()
+    }
+}
+
 async fn run_weights_command(command: WeightsCommand) -> Result<()> {
     match command {
         WeightsCommand::List => {
@@ -1030,7 +1047,7 @@ async fn run_weights_command(command: WeightsCommand) -> Result<()> {
                     .map(|root| root.display().to_string())
                     .unwrap_or_else(|| "<no data directory>".to_string());
                 println!("No models downloaded. Store: {location}");
-                println!("Pull one with `yolop weights pull {DEFAULT_LOCAL_MODEL}`.");
+                println!("{}", empty_weights_store_hint());
                 return Ok(());
             }
             let total: u64 = models.iter().map(|model| model.bytes).sum();
@@ -2606,6 +2623,20 @@ mod tests {
             assert!(message.contains("releases/latest"), "{message}");
             assert!(message.contains("--features metal"), "{message}");
             assert!(!message.contains("brew install"), "{message}");
+        }
+    }
+
+    #[test]
+    fn an_empty_weights_store_only_suggests_pulling_when_something_could_run_it() {
+        let hint = empty_weights_store_hint();
+
+        if cfg!(feature = "local-inference") {
+            assert!(hint.contains("yolop weights pull"), "{hint}");
+        } else {
+            // `weights pull` is compiled out here, so suggesting it would send
+            // the reader to a command that only errors.
+            assert!(!hint.contains("yolop weights pull"), "{hint}");
+            assert!(hint.contains("releases/latest"), "{hint}");
         }
     }
 


### PR DESCRIPTION
## What changed

Every release target now ships **two** CLI binaries instead of one.

| Asset | Features | Linux tarball |
|---|---|---|
| `yolop-<target>.tar.gz` | default, no engine | **18.2 MB** (was 29.9 MB) |
| `yolop-<target>-metal.tar.gz` | `metal`, both macOS targets | ~28 MB |
| `yolop-x86_64-unknown-linux-gnu-cuda.tar.gz` | `cuda` | ~28 MB |

The plain name keeps the plain build, so `brew install` and every existing
download URL now get the portable binary. It is the only build that runs
wherever the target does: an accelerated one carries a runtime requirement the
plain one does not, and a `cuda` binary needs an NVIDIA driver present. That is
not a thing to hand someone who typed `brew install`.

Two user-facing messages were fixed as a direct consequence. `--provider local`
and `yolop weights pull` on an engine-less build both told the reader to install
a release build or Homebrew, which is now exactly the build that just refused
them. `yolop weights list` on an empty store likewise suggested a `pull` this
build cannot perform. All three now name the accelerated download.

The accelerated builds are their own job, deliberately outside the Homebrew
job's `needs`: `cuda` is the least proven build in the release and must not be
able to hold back the tap.

## Why

Through v0.17.0 the single shipped binary carried the inference engine, CPU-only,
at +41.3 MiB. Every user paid that download whether or not they ever selected
`--provider local`, and the ones who did select it got the unaccelerated build
that `local-inference.md` § Acceleration says measures the wrong thing. Splitting
the artifact serves both groups instead of neither.

## Before / After

Default Linux build, this branch, measured locally (13m06s cold, release profile):

```
$ ls -l target/release/yolop        # 70,456,208 bytes  (v0.17.0: 96.3 MB)
$ tar czf plain.tar.gz yolop        # 18,158,493 bytes  (v0.17.0: 29,923,751)
$ ./target/release/yolop --version
yolop 0.17.0 (commit 086f15275398, everruns-runtime unknown)
$ ./target/release/yolop --provider llmsim -p "say hi in three words"
I'm running in offline mode (llmsim - no API key set). ...
```

A 39% smaller download for everyone who does not use local inference.

The no-engine paths, before and after:

```
# before
Error: ... Install a release build (`brew install everruns/tap/yolop`) or build
with `--features local-inference`.        # <- the build that just refused you

# after
$ ./target/release/yolop --provider local -p "hi"
Error: this build has no local inference engine, so `--provider local` cannot
run. Download an accelerated build (`yolop-<target>-metal` or `-cuda`) from
https://github.com/everruns/yolop/releases/latest, or build with
`--features metal` / `--features cuda`.
```

`yolop weights list` / `rm` still work without the engine, as designed.

## Risk

- **Medium.** The artifact set changes shape, and the Homebrew formula's binary
  changes contents at unchanged URLs.
- Anyone who installed via Homebrew for local inference loses it on upgrade and
  must take the `-metal` download. This is the intended trade; it is called out
  in the README and the spec.
- `cuda` is new in CI. Compiled locally here against Ubuntu's own
  `nvidia-cuda-toolkit` (nvcc 12.0.140), but **no GPU has run the result**,
  a GPU-less runner can only prove it compiles.
- The `cuda` job cannot block the release: `fail-fast: false` plus its own job
  means a failure costs one asset, not the tap or the other five.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Validation

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --features
  yolop-yep/schema -- -D warnings`: clean.
- `cargo test --workspace --features yolop-yep/schema`: **1356 passed, 0 failed**,
  including the two tests changed/added here.
- `cargo check -p yolop --locked --features cuda --all-targets` with
  `CUDA_COMPUTE_CAP=80`: clean, so both `cfg!(feature = "local-inference")`
  branches compile.
- `scripts/check_release_matrix.py` and its unit tests, `validate_okf.py
  --check-links`, and the public-docs boundary grep: all clean.
- Release build + tarball + `--version` + `llmsim` smoke, as above.

## Knowledge

Updated `knowledge/specs/local-inference.md` (new **Distribution** section; the
"binary size is not something the gate fixes" bullet described a lever that this
PR pulls) and `knowledge/specs/release.md` (the second build job, and why it is
outside the Homebrew job's `needs`). Logged in `knowledge/log.md`. `AGENTS.md`
gains the local `cuda` check command.

## Security

Reviewed. **TM-DEP** is the only category this touches, and no Rust dependency
changes: `Cargo.lock` is untouched. The one new dependency is CI-only,
`nvidia-cuda-toolkit` from Ubuntu's own archive on an ephemeral runner, used
only to compile. Distro packaging was chosen over a third-party CUDA GitHub
Action specifically to avoid adding an unvetted action to the release path.

No change to the write blocklist or capability registration (**TM-FS**,
**TM-TOOL**), none to `tools.rs` or the bounded execution model (**TM-BASH**),
and none to prompt construction or key handling (**TM-LLM**). The `sudo rm -rf`
in the disk-cleanup step names four fixed runner SDK paths, no interpolation
from any external value. `build-accelerated` uses the workflow's existing
`GITHUB_TOKEN` and `contents: write` to upload assets; it never touches the
Doppler PAT, which stays confined to `update-homebrew`.

## Follow-ups

- **A CUDA host must run the `cuda` binary before it is advertised as working.**
  CI proves compilation only. Until then the asset is best-effort.
- `CUDA_COMPUTE_CAP` is pinned to 8.0, so pre-Ampere cards are out of reach.
  8.0 is candle's floor, not a preference: its kernels call `__hmax_nan` and
  `__hmin_nan`, which nvcc defines only for `__CUDA_ARCH__ >= 800`. Widening
  coverage would mean a multi-capability build, which is a separate change.
- There is no review-time compile check for `cuda` (`metal-build-check.yml`
  covers `metal` only). Runner cost on every relevant PR is the reason; the
  release job is currently the only place it compiles.
- Nothing asserts the generated Homebrew formula's URLs against the build
  matrix's `archive` names. `update-homebrew` fails loudly on a missing
  checksum file, so a rename cannot ship silently, but the two lists are still
  written separately.
- **Flaky test observed on this PR, unrelated to the diff and not fixed here:**
  `runtime::session_log::tests::simultaneous_fresh_opens_fail_without_creating_a_session_shell`
  failed once on attempt 1 at `session_log.rs:1533`, with
  `lock released after close: ... another yolop process is already writing
  /tmp/.tmpDc7jVn/.locks/session_...bc61`. So the `flock` was still held after
  the owning `JsonlEventEmitter` was dropped, in the test's own tempdir. It did
  not reproduce on the re-run, nor in 35 local attempts (15 isolated, 12
  module-parallel at `--test-threads=16`, 8 full-suite), and `main` is green
  across 30 consecutive runs.
  Leading hypothesis, **unverified**: fd inheritance. `open_private_append`
  opens the lock file with `O_CLOEXEC`, but between another thread's
  `Command::spawn` fork and its `exec` the child briefly inherits that fd. The
  `flock` lives on the shared open file description, so the parent's drop closes
  only its own copy and the lock survives until the child execs, which is exactly
  the window the test reopens into. The suite has 87 `Command::new` sites, many
  exercised in parallel with this test. If that is right it is a latent product
  issue too, not only a test one: yolop could spuriously refuse to open a session
  log when something else on the box forks at the wrong instant. Worth its own
  investigation.