### PR TITLE
chore(deps): bump tuika to 0.11.0 and its companion crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1838,7 +1838,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2130,7 +2130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5020,7 +5020,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5418,7 +5418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6071,7 +6071,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6833,7 +6833,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6892,7 +6892,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7546,7 +7546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8029,7 +8029,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8062,7 +8062,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8904,24 +8904,22 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuika"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81aa791c7f5cee95e83344cd30aef2ccf904539cc853a5ab79dfc828f1f8939"
+checksum = "0801704b836dfdfad58935f24378fd62872776902cb4321f0659c0a91b6c0557"
 dependencies = [
  "crossterm 0.29.0",
  "pulldown-cmark",
  "ratatui-core",
- "ratatui-crossterm",
- "textwrap",
  "unicode-segmentation",
  "unicode-width",
 ]
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ad0d716af6749bdb1561ba7a76f4002cd0d294fdd53e6fe7a8bd2660525363"
+checksum = "d2e84785f6fd1d449f34ad4cd20e3fac379e332b64e761f37b2940fc5fbb2c8a"
 dependencies = [
  "ratatui",
  "tree-sitter",
@@ -8944,9 +8942,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-html"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888e15d6463a5c221592d056437e0cef293602635fc6acc1a04f8f89a8305da2"
+checksum = "50db8de977839eca099a898f3dba6f81750a311952553bdc1158fd451cc0ba9d"
 dependencies = [
  "html5ever 0.39.0",
  "markup5ever_rcdom 0.39.0+unofficial",
@@ -8956,9 +8954,9 @@ dependencies = [
 
 [[package]]
 name = "tuika-mermaid"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918ddf1653af88991177df96d0be505c3ec0fbddd3859377cee8727dcacd0312"
+checksum = "d28462e679499773278a971c862542116edd34ffb2dcbbbf5cf25ff9658bbf6f"
 dependencies = [
  "mmdflux",
  "ratatui-core",
@@ -9732,7 +9730,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,14 @@ textwrap = "0.16"
 # The TUI toolkit behind both renderers. It lives in its own repository
 # (everruns/tuika) and is consumed from crates.io like any other dependency;
 # yolop gets no special treatment there.
-tuika = "0.10.0"
+tuika = "0.11.0"
 # Optional structured-markdown renderers stay outside tuika core. Mermaid
 # fences become terminal diagrams; safe block HTML becomes styled text.
-tuika-mermaid = "0.3.1"
-tuika-html = "0.1.3"
+tuika-mermaid = "0.3.2"
+tuika-html = "0.1.4"
 # Tree-sitter Highlighter impl for tuika's CodeBlock/Markdown; owns the grammar
 # deps so tuika core stays dependency-light. Published from the tuika repo.
-tuika-codeformatters = "0.4.3"
+tuika-codeformatters = "0.5.0"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tree-sitter = "0.26"


### PR DESCRIPTION
## What changed

Both renderers pick up tuika 0.11.0, with `tuika-codeformatters` 0.5.0, `tuika-html` 0.1.4, and `tuika-mermaid` 0.3.2 moving in lockstep (the companions pin a compatible tuika range).

What users get from upstream:

- Streamed markdown now renders identically to a one-shot render. Two cache boundaries misfired at particular chunk splits: an info-string fence line inside an open block was read as a closer, and a blank line between list items settled the prefix and restarted numbering, so a streaming `1. … 2. … 3. …` could render `1. … 1. … 1. …`.
- A link's underline and hit area stop at the URL instead of running one cell into the following text.
- A component no longer stamps OSC 8 markers outside its own rect, so a markdown block with links running past its rows can't leave a stray link or an orphaned escape on a neighbour.
- The split footer (`--inline`) is pinned and published at the terminal's current size; a resize before the first frame no longer pins the old geometry.
- Smaller graph: 66 crates to 55 (`textwrap`, `ratatui-crossterm`, `tokio-stream` dropped upstream), and graphics-protocol encoders are now pay-for-use.

No yolop source changes are needed. Neither upstream breaking change reaches here: `tuika-codeformatters` put each tree-sitter grammar behind its own cargo feature but left all fourteen on by default, and yolop takes the crate with default features; `Paragraph`'s switch from `textwrap` to tuika's own wrap solver changes no yolop assertion. yolop's direct `textwrap` use in `src/tui/render.rs` is its own dependency and unaffected.

## Why

Keep the toolkit current so yolop carries upstream's rendering fixes, several of which land directly on the transcript path (streaming markdown, link underlines, footer geometry).

## Before / After

No observable behavior change originates in this diff: it is a version bump with no yolop source changes. The visible differences come from tuika itself, listed above.

Evidence on this branch:

```
cargo fmt --check                                                       # clean
cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings   # clean
cargo test --workspace --features yolop-yep/schema                      # 1356 passed, 0 failed
cargo run -- --provider llmsim -p "hi"                                  # binary starts, turn completes
```

The 69-test `tuika_pty.rs` suite and the 5 gallery PTY tests, which drive the real binary through a pty in both screen modes, pass unchanged against 0.11.

Live-provider smoke was not run: no `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` and no Doppler in this environment. The change is offline-safe (dependency versions only), so the llmsim run is the applicable smoke test; CI's live-smoke job covers the rest.

## Risk

- Low
- The realistic failure mode is a rendering regression from upstream's `Paragraph` wrap change (greedy first-fit instead of textwrap's optimal-fit, whitespace runs collapsed to one break opportunity, breaks only at whitespace). yolop's terminal-buffer tests would catch a layout shift in the surfaces they cover, and they pass; a paragraph in an uncovered surface could still wrap at different words than in 0.10. Purely cosmetic if so.

## Checklist

- [ ] Tests added or updated — none; a version bump with no source change is covered by the existing suite, including the PTY tests that render through tuika.
- [x] Backward compatibility considered — no yolop public surface changes. Upstream's two breaking changes do not reach yolop (see **What changed**).
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — `knowledge/specs/tuika.md` describes the dependency relationship and the bump procedure without pinning a version, and this change alters no intent, architecture, policy, or constraint. Routine version bumps are not `knowledge/log.md` material.

## Security

No security-relevant code changes: the diff is `Cargo.toml` version requirements and the matching `Cargo.lock` entries, with no yolop source touched.

TM-DEP is the one applicable category. No new crate is introduced; the four bumped crates are the same already-vendored tuika family from the same upstream repository, and the direction of travel reduces the graph (66 crates to 55, with `textwrap`, `ratatui-crossterm`, and `tokio-stream` dropped from tuika's tree). `everruns-*` versions are untouched, so they stay in lockstep. TM-FS, TM-BASH, TM-LLM, and TM-TOOL are unreached: no change to the write blocklist, `tools.rs`, prompt construction or key handling, or capability registration.

## Follow-ups

- `tuika-codeformatters` 0.5.0 lets a host select grammars by cargo feature; a probe binary measured ~24.0 MiB with all fourteen versus ~4.8 MiB for `rust` + `python`. Trimming yolop's set would cut release binary size meaningfully, but it changes which languages highlight and belongs in its own change with a deliberate language list.
- tuika 0.11 adds a `routing` module that gives every event kind one path to the surface owning input. yolop's current input dispatch works; adopting `Router` is a refactor to evaluate separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YX1yBrkxXfyCtpxLajY5XY)_