### PR TITLE
refactor(tui): route every input event through one ownership table

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,20 @@
 # Knowledge Log
 
+## 2026-08-22, One route for every input event
+
+- [Tuika](specs/tuika.md): input ownership is now one ordered table of surfaces,
+  and every event kind is delivered against it through tuika 0.11's `Router`.
+  `handle_key` and `handle_paste` each used to re-derive precedence with their
+  own `if` chain.
+- The paste chain had never grown the sandbox-approval branch the key chain had,
+  so text pasted while the approval prompt owned the screen was inserted into
+  the composer behind it and went out with the next prompt. Deriving precedence
+  twice is what made that reachable, so the fix is the shared table rather than
+  a seventh branch in the second chain.
+- A running turn's Esc-to-cancel is a partial claim, not a modal, so ownership
+  is resolved against the event rather than once per frame. Reverse search is
+  the one surface that outranks the global chord layer.
+
 ## 2026-08-21, The default binary stops carrying the inference engine
 
 - [Local inference](specs/local-inference.md): every release target now ships

--- a/knowledge/specs/tuika.md
+++ b/knowledge/specs/tuika.md
@@ -67,6 +67,7 @@ tuika owns *presentation*; yolop owns *acquisition and meaning*. Concretely:
 | Markdown images | block reservation and protocol emission | an `ImageResolver` that decodes bytes to RGBA |
 | Mermaid fences | the `FencedBlockRenderer` boundary | the renderer (`tuika-mermaid`), the transcript's width guard, and telling the model the TUI paints them ([system prompt](./system-prompt.md)) |
 | Key bindings | the keymap engine (chords, sequences, gated layers, dispatch) | the binding table and what each command *means* |
+| Input routing | `Router` stages, and the `FocusRegistry` ownership they read | which modal state owns input, and in what order |
 | Links | OSC 8 encoding and the `LinkPolicy` sanitizer | which schemes are allowed, and the transcript's link runs |
 | Progress | the OSC 9;4 encoder | when a turn is running |
 | Live data | reading shared state at render time | producing it and requesting redraws |
@@ -74,11 +75,30 @@ tuika owns *presentation*; yolop owns *acquisition and meaning*. Concretely:
 Yolop's keymap adoption is the clearest case of the split: tuika resolves a
 translated key to a named command, and yolop decides that the resulting command
 interrupts a turn, opens the activity rail, or starts a reverse search. The
-engine's precedence is yolop's choice too, the global layer is ungated and
-dispatched ahead of every modal guard, which reproduces the precedence the
-former inline `match` had: global chords fire in any mode, mid-turn, during
-setup, or with an overlay open. A key that no binding matches falls through to
-the composer and modal handlers unchanged.
+engine's precedence is yolop's choice too, the global layer is ungated and runs
+at the router's `Pre` stage, ahead of every surface, which reproduces the
+precedence the former inline `match` had: global chords fire in any mode,
+mid-turn, during setup, or with an overlay open. A key that no binding matches
+falls through to whichever surface owns input.
+
+Routing is the same split one layer down. tuika owns *how* an event reaches a
+surface, and yolop owns *who* the surfaces are: one ordered table names them
+(reverse search, sandbox approval, background panel, extension ask, a running
+turn's Esc claim, setup, composer) and every event kind is delivered against it.
+Two properties are load-bearing and neither is tuika's to enforce:
+
+- **Ownership is derived once, not per event kind.** A key and a paste consult
+  the same table. When they did not, only the key chain knew about the sandbox
+  approval prompt, so pasted text landed in the composer behind an open dialog.
+  A new surface is added in one place or it is wrong everywhere.
+- **Reverse search outranks the global chords.** It owns the keyboard outright,
+  Ctrl+C included, which cancels the search rather than arming exit. `Pre` is
+  the router's first stage and no surface can outrank it, so this exception is
+  written into the `Pre` handler rather than declared.
+
+A running turn is a *partial* claim rather than a modal: it takes Esc and
+nothing else, so every other key reaches the surface underneath. That is why
+ownership is resolved against the event rather than once per frame.
 
 Link activation is the other case worth stating, because it is a *negative*
 requirement: OSC 8 targets are activated by the terminal emulator, using its

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -16,7 +16,7 @@
 use tuika::keymap::{Keymap, Layer};
 
 /// A global action a chord shortcut can trigger. Each maps to a method on
-/// [`App`](super::App) in [`App::handle_key`](super::App::handle_key).
+/// [`App`](super::App) in [`App::run_global_action`](super::App::run_global_action).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum GlobalAction {
     /// Open Ctrl+R reverse-history search over past prompts.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -38,6 +38,7 @@ use tuika::InputOutcome;
 use tuika::components::{ScrollState, SingleLineInputState, TextInputState};
 use tuika::keymap::Dispatch;
 use tuika::mouse::{SelectionRange, selected_text, word_at};
+use tuika::routing::Router;
 use tuika::term::hyperlink::BufferLink;
 use tuika::term::pointer::{self, PointerShape};
 use tuika::term::progress::TerminalProgress;
@@ -46,6 +47,7 @@ pub(crate) mod fullscreen;
 mod keymap;
 mod render;
 mod repo_pulse;
+pub(crate) mod routing;
 mod setup;
 
 pub mod host_ui;
@@ -514,6 +516,21 @@ pub(crate) struct PendingAsk {
 
 struct PendingSandboxApproval {
     reply: oneshot::Sender<crate::sandbox_approval::ApprovalDecision>,
+}
+
+/// Work a route stage asked for but could not run itself.
+///
+/// tuika's route stages are synchronous, while a few of yolop's surfaces handle
+/// a key by awaiting (the setup wizard advances a step, the background panel
+/// reads the task registry, a submitted prompt starts a turn). Those stages
+/// name the work instead of doing it and the caller runs it once the route is
+/// finished, which keeps every surface on the one route rather than splitting
+/// the async ones back out into a chain of their own.
+enum Deferred {
+    SetupKey(KeyEvent),
+    BackgroundPanelKey(KeyEvent),
+    SubmitInput,
+    ClipboardPaste,
 }
 
 enum CodexLoginEvent {
@@ -2072,13 +2089,9 @@ impl App {
                         return Ok(());
                     }
                 }
-                CrosstermEvent::Paste(pasted) => {
-                    if self.setup.is_some() {
-                        self.handle_setup_paste(pasted).await;
-                    } else {
-                        self.handle_paste(pasted);
-                    }
-                }
+                // Every paste takes the same route; the setup wizard is one
+                // more surface on it, not a case checked before routing.
+                CrosstermEvent::Paste(pasted) => self.handle_paste(pasted).await,
                 _ => {}
             }
             if self.should_quit {
@@ -2257,99 +2270,172 @@ impl App {
         }
     }
 
+    /// Deliver one key to whichever surface owns input this event.
+    ///
+    /// Ownership comes from [`routing::InputSurfaces`] and delivery from
+    /// tuika's [`Router`], the same pair [`handle_paste`](Self::handle_paste)
+    /// uses, so a surface added here cannot be missed by another event kind.
+    /// That is how a paste used to reach the composer behind the sandbox
+    /// approval prompt: two chains, and only one of them knew about it.
     async fn handle_key(&mut self, key: KeyEvent) {
-        // Reverse-history search owns the keyboard while active (even Ctrl+C,
-        // which cancels the search rather than arming exit).
-        if self.history_search.is_some() {
-            self.handle_search_key(key);
+        let Some(event) = tuika::translate_event(CrosstermEvent::Key(key)) else {
+            // A key tuika does not model: a release, or a code no yolop surface
+            // binds (function, media, Insert). Nothing to route.
             return;
-        }
-        if self.busy && key.code != KeyCode::Esc {
+        };
+
+        let surfaces = self.input_surfaces();
+        // Reverse-history search owns the keyboard outright, Ctrl+C included,
+        // which cancels the search rather than arming exit. So it runs ahead of
+        // the global chord layer, and a keystroke inside it is not activity in
+        // a running turn: it leaves that turn's Esc and Ctrl+C arming alone.
+        // `Pre` is the router's first stage and no surface can outrank it, so
+        // this one exception is spelled out here instead of declared.
+        let search_owns_keyboard = surfaces.owner(&event) == routing::HISTORY_SEARCH;
+
+        if !search_owns_keyboard && self.busy && key.code != KeyCode::Esc {
             self.esc_pending_cancel = false;
         }
+
+        let focus = surfaces.focus(&event);
+        let mut deferred = None;
+        let mut router = Router::new(&focus, &event);
+
         // App-global chord shortcuts resolve through the keymap (see
         // `crate::tui::keymap`), so yolop's bindings live in one declarative
-        // place instead of a hand-rolled match. They fire regardless of mode
-        // (mid-turn, during setup, or with an overlay open) — the same ordering
-        // they had before, since this sits ahead of every modal guard below.
-        if let Some(action) = self.dispatch_global_key(key) {
-            match action {
-                GlobalAction::ReverseSearch => self.history_search_start(),
-                GlobalAction::Interrupt => self.handle_ctrl_c(),
-                GlobalAction::Quit => {
-                    self.abort_codex_login();
-                    self.abort_openrouter_login();
-                    self.abort_mcp_login();
-                    self.should_quit = true;
-                }
-                GlobalAction::ToggleBackground => {
-                    // This branch returns before the shared grace reset below, so
-                    // clear the armed single-Ctrl+C exit ourselves.
-                    self.disarm_ctrl_c_pending_exit();
-                    self.toggle_background_panel();
-                }
-                GlobalAction::PasteImage => self.try_paste_clipboard(),
-                GlobalAction::ToggleWorkDetails => self.toggle_compact_work_details(),
+        // place instead of a hand-rolled match. They fire regardless of mode:
+        // mid-turn, during setup, or with an overlay open.
+        router.pre_fn(|_| {
+            if search_owns_keyboard {
+                return InputOutcome::Ignored;
             }
-            return;
-        }
-
-        self.disarm_ctrl_c_pending_exit_if_grace_elapsed();
-
-        if self.pending_sandbox_approval.is_some() {
-            match key.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    if let Some(pending) = self.pending_sandbox_approval.take() {
-                        let _ = pending
-                            .reply
-                            .send(crate::sandbox_approval::ApprovalDecision::ApproveOnce);
-                        self.push_system("approved".into());
-                    }
+            match self.dispatch_global_key(key) {
+                Some(action) => {
+                    deferred = self.run_global_action(action);
+                    InputOutcome::Consumed
                 }
-                KeyCode::Char('a') | KeyCode::Char('A') => {
-                    if let Some(pending) = self.pending_sandbox_approval.take() {
-                        let _ = pending
-                            .reply
-                            .send(crate::sandbox_approval::ApprovalDecision::ApproveForSession);
-                        self.push_system("approved for this session".into());
-                    }
-                }
-                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                    self.deny_pending_sandbox_approval();
-                }
-                _ => {}
+                None => InputOutcome::Ignored,
             }
-            return;
+        });
+        // A fired chord returned early before input was routed, so it still
+        // skips the shared grace reset.
+        if !search_owns_keyboard && !router.delivery().consumed() {
+            self.disarm_ctrl_c_pending_exit_if_grace_elapsed();
         }
 
-        // A manually opened/focused sidebar captures task navigation keys. An
-        // automatically opened sidebar is passive and leaves the composer live.
-        if self.background_panel_focused {
-            self.handle_background_panel_key(key).await;
-            return;
-        }
-
-        // An extension `ui/ask` prompt owns the keyboard even mid-turn, since
-        // the server typically asks while a tool is running.
-        if self.pending_ask.is_some() {
+        router.target_fn(routing::HISTORY_SEARCH, |_| {
+            self.handle_search_key(key);
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::SANDBOX_APPROVAL, |_| {
+            self.handle_sandbox_approval_key(key);
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::BACKGROUND_PANEL, |_| {
+            deferred = Some(Deferred::BackgroundPanelKey(key));
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::ASK, |_| {
             self.handle_ask_key(key);
-            return;
-        }
-
-        if self.busy && key.code == KeyCode::Esc {
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::TURN_CANCEL, |_| {
             self.handle_busy_key(key);
-            return;
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::SETUP, |_| {
+            deferred = Some(Deferred::SetupKey(key));
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::COMPOSER, |_| {
+            deferred = self.composer_key(key);
+            InputOutcome::Consumed
+        });
+        router.finish();
+
+        match deferred {
+            Some(Deferred::SetupKey(key)) => self.handle_setup_key(key).await,
+            Some(Deferred::BackgroundPanelKey(key)) => self.handle_background_panel_key(key).await,
+            Some(Deferred::SubmitInput) => self.submit_input().await,
+            Some(Deferred::ClipboardPaste) => self.try_paste_clipboard().await,
+            None => {}
         }
-        if self.setup.is_some() {
-            self.handle_setup_key(key).await;
-            return;
+    }
+
+    /// The modal state that decides input ownership, sampled for one event.
+    fn input_surfaces(&self) -> routing::InputSurfaces {
+        routing::InputSurfaces {
+            searching: self.history_search.is_some(),
+            awaiting_sandbox_approval: self.pending_sandbox_approval.is_some(),
+            // A manually opened/focused sidebar captures task navigation keys.
+            // An automatically opened sidebar is passive and leaves the
+            // composer live.
+            background_panel_focused: self.background_panel_focused,
+            // An extension `ui/ask` prompt owns the keyboard even mid-turn,
+            // since the server typically asks while a tool is running.
+            asking: self.pending_ask.is_some(),
+            busy: self.busy,
+            in_setup: self.setup.is_some(),
         }
+    }
+
+    /// Run one global chord action, naming any follow-up work that must await.
+    fn run_global_action(&mut self, action: GlobalAction) -> Option<Deferred> {
+        match action {
+            GlobalAction::ReverseSearch => self.history_search_start(),
+            GlobalAction::Interrupt => self.handle_ctrl_c(),
+            GlobalAction::Quit => {
+                self.abort_codex_login();
+                self.abort_openrouter_login();
+                self.abort_mcp_login();
+                self.should_quit = true;
+            }
+            GlobalAction::ToggleBackground => {
+                // This action returned before the shared grace reset in
+                // `handle_key`, so it clears the armed single-Ctrl+C exit itself.
+                self.disarm_ctrl_c_pending_exit();
+                self.toggle_background_panel();
+            }
+            GlobalAction::PasteImage => return Some(Deferred::ClipboardPaste),
+            GlobalAction::ToggleWorkDetails => self.toggle_compact_work_details(),
+        }
+        None
+    }
+
+    /// Keyboard handling for the y/a/n sandbox approval prompt.
+    fn handle_sandbox_approval_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                if let Some(pending) = self.pending_sandbox_approval.take() {
+                    let _ = pending
+                        .reply
+                        .send(crate::sandbox_approval::ApprovalDecision::ApproveOnce);
+                    self.push_system("approved".into());
+                }
+            }
+            KeyCode::Char('a') | KeyCode::Char('A') => {
+                if let Some(pending) = self.pending_sandbox_approval.take() {
+                    let _ = pending
+                        .reply
+                        .send(crate::sandbox_approval::ApprovalDecision::ApproveForSession);
+                    self.push_system("approved for this session".into());
+                }
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                self.deny_pending_sandbox_approval();
+            }
+            _ => {}
+        }
+    }
+
+    /// Keyboard handling for the composer, the surface under everything else.
+    fn composer_key(&mut self, key: KeyEvent) -> Option<Deferred> {
         match key.code {
             KeyCode::Enter => match self
                 .composer
                 .handle_enter(key.modifiers == KeyModifiers::SHIFT)
             {
-                InputOutcome::Submitted => self.submit_input().await,
+                InputOutcome::Submitted => return Some(Deferred::SubmitInput),
                 InputOutcome::Ignored
                 | InputOutcome::Consumed
                 | InputOutcome::Changed
@@ -2370,6 +2456,7 @@ impl App {
                 self.composer_edit_key(normalize_printable_key(key));
             }
         }
+        None
     }
 
     /// Resolve one crossterm key against the app-global [`keymap`](crate::tui::keymap),
@@ -2657,14 +2744,17 @@ impl App {
             .clamp(1, MAX_INPUT_HEIGHT)
     }
 
-    /// Route pasted text, from a bracketed paste or from Ctrl+V.
+    /// Deliver pasted text, from a bracketed paste or from Ctrl+V, to whichever
+    /// surface owns input.
     ///
-    /// The precedence mirrors [`handle_key`](Self::handle_key) deliberately:
-    /// whichever surface owns the keyboard owns pasted text too. Without that,
-    /// a paste aimed at an overlay lands in the composer behind it — which is
-    /// how a pasted credential ended up sitting in the input once an extension
-    /// prompt closed.
-    fn handle_paste(&mut self, pasted: String) {
+    /// Whoever owns the keyboard owns pasted text too. This chain used to
+    /// mirror [`handle_key`](Self::handle_key) by hand and drifted anyway,
+    /// twice: an overlay-bound paste landing in the composer behind it is how a
+    /// pasted credential ended up sitting in the input once an extension prompt
+    /// closed, and the chain never grew the sandbox-approval branch its
+    /// counterpart had. Both surfaces now come from one shared
+    /// [`routing::InputSurfaces`] table, so there is no second copy to drift.
+    async fn handle_paste(&mut self, pasted: String) {
         // Normalization and the size cap apply to every target: a single-line
         // overlay field has no placeholder machinery to fall back on, so an
         // oversized paste is refused before any surface stores or renders it.
@@ -2680,29 +2770,55 @@ impl App {
             return;
         }
 
-        if self.history_search.is_some() {
+        let event = tuika::Event::Paste(pasted.clone());
+        let focus = self.input_surfaces().focus(&event);
+        // The setup wizard's handler awaits, so its stage names the text and
+        // the paste is applied once the route is finished.
+        let mut deferred_setup = None;
+        let mut router = Router::new(&focus, &event);
+
+        router.target_fn(routing::HISTORY_SEARCH, |_| {
             self.handle_search_paste(&pasted);
-            return;
-        }
-        if self.pending_ask.is_some() {
+            InputOutcome::Consumed
+        });
+        // A prompt that reads single keystrokes has nowhere to put pasted text.
+        // It still owns the event, so the surface underneath never sees it.
+        router.target_fn(routing::SANDBOX_APPROVAL, |_| InputOutcome::Consumed);
+        router.target_fn(routing::BACKGROUND_PANEL, |_| InputOutcome::Consumed);
+        router.target_fn(routing::ASK, |_| {
             self.handle_ask_paste(&pasted);
-            return;
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::SETUP, |_| {
+            deferred_setup = Some(pasted.clone());
+            InputOutcome::Consumed
+        });
+        router.target_fn(routing::COMPOSER, |_| {
+            self.composer_paste(&pasted);
+            InputOutcome::Consumed
+        });
+        router.finish();
+
+        if let Some(pasted) = deferred_setup {
+            self.handle_setup_paste(pasted).await;
         }
-        if self.setup.is_some() || self.background_panel_focused {
-            return;
-        }
+    }
+
+    /// Insert a paste into the composer, attaching it as a placeholder when it
+    /// is large enough that inlining it would bury the prompt.
+    fn composer_paste(&mut self, pasted: &str) {
         self.esc_pending_cancel = false;
 
-        if crate::tui::input::paste_attachment::is_large_paste(&pasted) {
+        if crate::tui::input::paste_attachment::is_large_paste(pasted) {
             let char_count = pasted.chars().count();
             let placeholder = crate::tui::input::paste_attachment::next_large_paste_placeholder(
                 char_count,
                 &self.pending_pastes,
             );
             self.composer_insert_str(&placeholder);
-            self.pending_pastes.push((placeholder, pasted));
+            self.pending_pastes.push((placeholder, pasted.to_string()));
         } else {
-            self.composer_insert_str(&pasted);
+            self.composer_insert_str(pasted);
         }
     }
 
@@ -2711,20 +2827,23 @@ impl App {
         self.composer.insert_str(s);
     }
 
-    fn try_paste_clipboard(&mut self) {
-        // The ask overlay is a plain text field: Ctrl+V fills it from the
-        // clipboard's *text*, an image attachment has nowhere to go there.
-        if self.pending_ask.is_some() {
+    /// Fill the focused surface from the system clipboard (Ctrl+V).
+    ///
+    /// Resolves the target through the same ownership table as a terminal
+    /// paste, so this entry point cannot drift from it the way it did when
+    /// each one kept its own chain of modal guards.
+    async fn try_paste_clipboard(&mut self) {
+        // Only the composer can hold an image attachment. Every other surface
+        // is a text field, so Ctrl+V fills it from the clipboard's *text* and
+        // the result routes like any other paste.
+        if self.input_surfaces().paste_owner() != routing::COMPOSER {
             match crate::tui::input::clipboard_paste::paste_clipboard_text() {
-                Ok(text) => self.handle_ask_paste(&text),
+                Ok(text) => self.handle_paste(text).await,
                 Err(err) => {
                     tracing::debug!("clipboard text paste failed: {err}");
                     self.push_system(format!("clipboard paste failed: {err}"));
                 }
             }
-            return;
-        }
-        if self.setup.is_some() || self.background_panel_focused {
             return;
         }
         match crate::tui::input::clipboard_paste::paste_image_content_part() {
@@ -2738,7 +2857,7 @@ impl App {
             }
             Err(crate::tui::input::clipboard_paste::PasteImageError::NoImage(_)) => {
                 if let Ok(text) = crate::tui::input::clipboard_paste::paste_clipboard_text() {
-                    self.handle_paste(text);
+                    self.handle_paste(text).await;
                 }
             }
             Err(err) => {
@@ -8306,6 +8425,69 @@ mod tests {
         );
     }
 
+    /// The divergence that motivated routing every event kind through one
+    /// ownership table: the approval prompt captured keys but not pastes, so
+    /// pasted text landed in the composer behind an open dialog and went out
+    /// with the next prompt the user submitted.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn paste_does_not_reach_the_composer_behind_a_sandbox_approval() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = None;
+
+        app.handle_paste("harmless".to_string()).await;
+        assert_eq!(
+            app.input_text(),
+            "harmless",
+            "with nothing modal the composer owns the paste"
+        );
+        app.set_input_text(String::new());
+
+        let (reply, _answer_rx) = oneshot::channel();
+        app.pending_sandbox_approval = Some(PendingSandboxApproval { reply });
+
+        app.handle_paste("rm -rf /".to_string()).await;
+
+        assert!(
+            app.input_text().is_empty(),
+            "the approval prompt owns input, so the composer must stay empty: {:?}",
+            app.input_text()
+        );
+        assert!(
+            app.pending_sandbox_approval.is_some(),
+            "a paste must not answer the prompt either"
+        );
+    }
+
+    /// The setup wizard used to be checked for before routing, in the terminal
+    /// read loop, so it was the one surface a paste reached without passing the
+    /// shared normalization and size cap. It is a surface on the route now.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn paste_reaches_the_setup_wizard_through_the_route() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.setup = Some(SetupStep::TokenInput {
+            provider: "openai".to_string(),
+            token: String::new(),
+            error: None,
+        });
+
+        app.handle_paste("sk-TOKEN\r\n".to_string()).await;
+
+        match app.setup.as_ref().expect("wizard still open") {
+            SetupStep::TokenInput { token, .. } => assert_eq!(
+                token, "sk-TOKEN\n",
+                "the wizard receives the paste, normalized like every other surface"
+            ),
+            other => panic!("unexpected setup step: {other:?}"),
+        }
+        assert!(
+            app.input_text().is_empty(),
+            "the composer behind the wizard must stay untouched: {:?}",
+            app.input_text()
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn paste_fills_the_open_ask_prompt_not_the_composer() {
         let mut fixture = app_with_llmsim().await;
@@ -8322,7 +8504,7 @@ mod tests {
             reply: Some(reply),
         });
 
-        app.handle_paste("pylf_v1_us_TOKEN\n".to_string());
+        app.handle_paste("pylf_v1_us_TOKEN\n".to_string()).await;
 
         assert_eq!(
             app.pending_ask.as_ref().expect("prompt open").value.text(),
@@ -8435,7 +8617,8 @@ mod tests {
             reply: Some(reply),
         });
 
-        app.handle_paste("x".repeat(MAX_PASTE_ATTACHMENT_BYTES + 1));
+        app.handle_paste("x".repeat(MAX_PASTE_ATTACHMENT_BYTES + 1))
+            .await;
 
         assert!(
             app.pending_ask
@@ -8462,7 +8645,7 @@ mod tests {
         app.history.record("an earlier prompt");
         app.history_search_start();
 
-        app.handle_paste("needle".to_string());
+        app.handle_paste("needle".to_string()).await;
 
         assert_eq!(
             app.history_search.as_ref().expect("search open").query,
@@ -8491,7 +8674,7 @@ mod tests {
             reply: Some(reply),
         });
 
-        app.handle_paste("pasted".to_string());
+        app.handle_paste("pasted".to_string()).await;
 
         assert!(
             app.pending_ask
@@ -8513,7 +8696,7 @@ mod tests {
         app.lines.clear();
 
         let payload = format!("paste-marker-{}", "x".repeat(LARGE_PASTE_CHAR_THRESHOLD));
-        app.handle_paste(payload.clone());
+        app.handle_paste(payload.clone()).await;
         let placeholder = app.input_text();
         assert!(
             placeholder.contains("[Pasted Content"),

--- a/src/tui/routing.rs
+++ b/src/tui/routing.rs
@@ -1,0 +1,193 @@
+// Which input surface owns an event.
+//
+// Decision: ownership is resolved in exactly one place, and every event kind
+// routes through it. Before this, `handle_key` and `handle_paste` each
+// re-derived precedence with their own `if` chain, and the paste chain had
+// simply never grown the sandbox-approval branch the key chain had — so text
+// pasted while an approval dialog owned the screen landed in the composer
+// behind it. Deriving precedence twice is what made that possible, so the fix
+// is one table, not a seventh branch.
+//
+// The surfaces below are yolop's, but the route is tuika's `Router`
+// (see `knowledge/specs/tuika.md`): the toolkit owns the routing model, this
+// module owns which of yolop's modal states claims input.
+
+use tuika::Event;
+use tuika::focus::FocusRegistry;
+
+/// Reverse-history search. Owns the keyboard outright while open.
+pub(crate) const HISTORY_SEARCH: &str = "history-search";
+/// The y/a/n sandbox approval prompt.
+pub(crate) const SANDBOX_APPROVAL: &str = "sandbox-approval";
+/// The background-task sidebar, when the user focused it deliberately.
+pub(crate) const BACKGROUND_PANEL: &str = "background-panel";
+/// An extension `ui/ask` prompt.
+pub(crate) const ASK: &str = "extension-ask";
+/// The Esc-to-cancel claim a running turn has on the keyboard.
+pub(crate) const TURN_CANCEL: &str = "turn-cancel";
+/// The first-run setup wizard.
+pub(crate) const SETUP: &str = "setup";
+/// The prompt composer: the base ring, and the only surface always present.
+pub(crate) const COMPOSER: &str = "composer";
+
+/// The modal state that decides who owns input, sampled once per event.
+///
+/// A plain snapshot rather than a borrow of `App`, so resolving ownership never
+/// conflicts with the `&mut self` a route stage then takes.
+pub(crate) struct InputSurfaces {
+    pub(crate) searching: bool,
+    pub(crate) awaiting_sandbox_approval: bool,
+    pub(crate) background_panel_focused: bool,
+    pub(crate) asking: bool,
+    pub(crate) busy: bool,
+    pub(crate) in_setup: bool,
+}
+
+impl InputSurfaces {
+    /// The surface that owns `event`, in yolop's precedence order.
+    ///
+    /// `event` is a parameter because [`TURN_CANCEL`] is a partial claim: a
+    /// running turn takes Esc (arm, then cancel) and nothing else, so every
+    /// other key still reaches the setup wizard or the composer under it. The
+    /// remaining surfaces are true modals and ignore the event entirely.
+    pub(crate) fn owner(&self, event: &Event) -> &'static str {
+        if self.searching {
+            return HISTORY_SEARCH;
+        }
+        if self.awaiting_sandbox_approval {
+            return SANDBOX_APPROVAL;
+        }
+        if self.background_panel_focused {
+            return BACKGROUND_PANEL;
+        }
+        if self.asking {
+            return ASK;
+        }
+        if self.busy && is_escape(event) {
+            return TURN_CANCEL;
+        }
+        if self.in_setup {
+            return SETUP;
+        }
+        COMPOSER
+    }
+
+    /// The surface a clipboard paste (Ctrl+V) should fill, for a caller that
+    /// has no terminal event to resolve against.
+    pub(crate) fn paste_owner(&self) -> &'static str {
+        self.owner(&Event::Paste(String::new()))
+    }
+
+    /// The frame's focus state: the composer is the base ring, and whichever
+    /// modal claims `event` owns input over it.
+    pub(crate) fn focus(&self, event: &Event) -> FocusRegistry {
+        let mut focus = FocusRegistry::new();
+        focus.begin_frame();
+        focus.register(COMPOSER);
+        let owner = self.owner(event);
+        if owner != COMPOSER {
+            focus.set_owner(owner);
+        }
+        focus
+    }
+}
+
+fn is_escape(event: &Event) -> bool {
+    matches!(event, Event::Key(key) if key.code == tuika::event::KeyCode::Esc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tuika::event::{Key, KeyCode};
+
+    fn surfaces() -> InputSurfaces {
+        InputSurfaces {
+            searching: false,
+            awaiting_sandbox_approval: false,
+            background_panel_focused: false,
+            asking: false,
+            busy: false,
+            in_setup: false,
+        }
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(Key {
+            code,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        })
+    }
+
+    fn paste() -> Event {
+        Event::Paste("payload".to_string())
+    }
+
+    #[test]
+    fn the_composer_owns_input_when_nothing_is_modal() {
+        assert_eq!(surfaces().owner(&key(KeyCode::Char('a'))), COMPOSER);
+        assert_eq!(surfaces().owner(&paste()), COMPOSER);
+    }
+
+    #[test]
+    fn a_modal_owns_every_event_kind_not_just_keys() {
+        // The divergence this module exists to prevent: ownership must not
+        // depend on which kind of event arrived.
+        let modal = InputSurfaces {
+            awaiting_sandbox_approval: true,
+            ..surfaces()
+        };
+        assert_eq!(modal.owner(&key(KeyCode::Char('y'))), SANDBOX_APPROVAL);
+        assert_eq!(modal.owner(&paste()), SANDBOX_APPROVAL);
+    }
+
+    #[test]
+    fn search_outranks_every_other_surface() {
+        let all = InputSurfaces {
+            searching: true,
+            awaiting_sandbox_approval: true,
+            background_panel_focused: true,
+            asking: true,
+            busy: true,
+            in_setup: true,
+        };
+        assert_eq!(all.owner(&key(KeyCode::Esc)), HISTORY_SEARCH);
+    }
+
+    #[test]
+    fn a_running_turn_claims_escape_only() {
+        let busy = InputSurfaces {
+            busy: true,
+            in_setup: true,
+            ..surfaces()
+        };
+        assert_eq!(busy.owner(&key(KeyCode::Esc)), TURN_CANCEL);
+        // Anything else falls through to the surface under the running turn.
+        assert_eq!(busy.owner(&key(KeyCode::Char('a'))), SETUP);
+        assert_eq!(busy.owner(&paste()), SETUP);
+    }
+
+    #[test]
+    fn an_open_ask_outranks_a_running_turns_escape() {
+        let asking = InputSurfaces {
+            asking: true,
+            busy: true,
+            ..surfaces()
+        };
+        assert_eq!(asking.owner(&key(KeyCode::Esc)), ASK);
+    }
+
+    #[test]
+    fn focus_makes_the_owner_active_over_the_composer_ring() {
+        let focus = surfaces().focus(&paste());
+        assert_eq!(focus.active(), Some(COMPOSER));
+
+        let modal = InputSurfaces {
+            asking: true,
+            ..surfaces()
+        };
+        assert_eq!(modal.focus(&paste()).active(), Some(ASK));
+    }
+}


### PR DESCRIPTION
## What changed

Input ownership is now one ordered table of surfaces, and every event kind is delivered against it through tuika 0.11's `Router`.

`handle_key` and `handle_paste` each re-derived precedence with their own `if` chain, and Ctrl+V was a third. The paste chain had never grown the sandbox-approval branch the key chain had, so **text pasted while the approval prompt owned the screen was inserted into the composer behind it** and went out with the next prompt the user submitted. A surface is now added in one place or it is wrong everywhere.

The table (`src/tui/routing.rs`) names yolop's surfaces — reverse search, sandbox approval, background panel, extension ask, a running turn's Esc claim, setup, composer — and tuika owns the delivery. Two properties are preserved deliberately rather than inherited:

- **Reverse-history search outranks the global chord layer**, Ctrl+C included, which cancels the search rather than arming exit, and a keystroke inside it leaves a running turn's Esc/Ctrl+C arming alone. `Pre` is the router's first stage and no surface can outrank it, so this exception is spelled out in the `Pre` handler.
- **A running turn is a partial claim, not a modal**: it takes Esc and nothing else, so every other key still reaches the surface underneath. That is why ownership resolves against the event rather than once per frame.

Route stages are synchronous, so the four surfaces whose handlers await (setup key, background panel key, submit, clipboard) name the work through a `Deferred` value and the caller runs it once the route is finished — rather than splitting the async surfaces back out into a chain of their own.

Three deliberate behavior changes fall out of the unification, each a case where an entry point had drifted:

1. A paste while the sandbox approval prompt is open is swallowed by the prompt instead of reaching the composer. **This is the bug.**
2. The setup wizard was checked for in the terminal read loop, ahead of routing, so it was the one surface a paste reached without the shared normalization and 512 KiB cap. It is on the route now, and Ctrl+V reaches it (it previously did nothing there).
3. Ctrl+V with the background panel focused now resolves through the same table instead of its own guard; an image still only ever attaches to the composer.

## Why

Deriving precedence twice is what made the paste bug reachable, so the fix is the shared table, not a seventh branch in the second chain. This is the follow-up flagged in #624.

## Before / After

The regression test fails on the old precedence and passes on the new. Simulating the old paste chain (ownership not consulting the approval prompt):

```
test tui::tests::paste_does_not_reach_the_composer_behind_a_sandbox_approval ... FAILED
the approval prompt owns input, so the composer must stay empty: "rm -rf /"
```

After:

```
test tui::tests::paste_does_not_reach_the_composer_behind_a_sandbox_approval ... ok
test tui::tests::paste_reaches_the_setup_wizard_through_the_route ... ok
```

Evidence on this branch:

```
cargo fmt --check                                                                   # clean
cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings   # clean
cargo test --workspace --features yolop-yep/schema                                  # 1365 passed, 0 failed
cargo run -- --provider llmsim -p "hi"                                              # binary starts, turn completes
python3 scripts/validate_okf.py knowledge --check-links                             # 42 concepts, 0 errors
```

The 69-test `tuika_pty.rs` suite and the 5 gallery PTY tests drive the real binary through a pty in both screen modes and pass unchanged.

Live-provider smoke was not run: no `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` and no Doppler in this environment. CI's live-smoke job covers it.

## Risk

- Medium
- This is the TUI's central input path. The realistic failure mode is a precedence difference no test covers — a key or paste reaching a different surface than before in a modal combination the suite does not construct. The two ordering deltas I found while re-reading the diff (reverse search vs. the busy-turn `esc_pending_cancel` reset, and vs. the Ctrl+C grace disarm) are preserved explicitly rather than left to fall out; anything comparable that I missed would be a behavior change, not a crash.
- Second-order: routing now happens on tuika's translated `Event`, so a key `translate_event` does not model (function, media, Insert) is dropped before the chain instead of reaching handlers that ignored it. No yolop surface binds one — `grep` for `KeyCode::F(`/`Insert` is empty — so this is equivalent, not a loss.

## Checklist

- [x] Tests added or updated — a regression test for the paste bug (verified failing on the old precedence), a routed setup-paste test, and 6 unit tests for the ownership table.
- [x] Backward compatibility considered — no public surface changes; the three intended behavior changes are listed under **What changed**.
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

[`knowledge/specs/tuika.md`](knowledge/specs/tuika.md): the boundary table gains an **Input routing** row (tuika provides `Router` stages and the `FocusRegistry` ownership they read; yolop supplies which modal state owns input and in what order), and the keymap paragraph is corrected — the global layer now runs at the router's `Pre` stage rather than "ahead of every modal guard" — plus the two load-bearing properties above. [`knowledge/log.md`](knowledge/log.md): one entry, *One route for every input event*.

## Security

Security-relevant, and the change is a net improvement in two of the categories.

- **TM-BASH** — the sandbox approval prompt is a trust boundary: it gates whether a command runs inside the sandbox or with full access. A paste can now neither answer it nor slip past it into the composer; the stage is an explicit no-op that consumes the event, and the regression test asserts `pending_sandbox_approval` is still set afterwards. Bounded execution in `tools.rs` is untouched.
- **TM-LLM** — pasted credentials. The `handle_paste` doc records that an overlay-bound paste landing in the composer is how a pasted credential once ended up sitting in the input after an extension prompt closed. One table removes the second copy that let that class recur. Key handling and prompt construction are untouched.
- No injection surface is added: the router dispatches on an enum-typed `Event` and a fixed set of `&'static str` surface ids, never on user text. The 512 KiB paste cap and normalization now apply to strictly more targets than before (setup included), never fewer.
- **TM-FS**, **TM-TOOL**, **TM-DEP** — unreached. No change to the write blocklist, capability registration, or any dependency; `Router` ships in the tuika 0.11 already on `main`.

## Follow-ups

- Mouse events still resolve by geometry through tuika's `HitMap` rather than by ownership, which is what upstream prescribes (keys route by ownership, the pointer routes by position). Feeding the hit-resolved id into `FocusRegistry::focus` would put pointer focus on the same table; it is a separate change and needs the fullscreen selection paths looked at with it.
- `handle_escape_prefixed_enter` and the fullscreen selection handlers still run in the terminal read loop ahead of routing. They are terminal-quirk handling rather than surface dispatch, so they are arguably in the right place, but they are the last input code that decides anything before the table is consulted.
- Trimming `tuika-codeformatters` grammars by feature, listed as a follow-up on #624, is **dropped rather than deferred**: it would silently stop highlighting languages users write in, which is not a trade worth a smaller binary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YX1yBrkxXfyCtpxLajY5XY)_