### PR TITLE
fix(runtime): make checkpoints a tool transition

### DIFF
--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -47,7 +47,7 @@ search/refactor, and read-only code navigation.
 | `capability-disclosure-exact-reply` [`capability-disclosure`] | empty workdir | Return one exact token without tools | exact response and one model call | trivial first-request baseline |
 | `capability-disclosure-release-control` [`capability-disclosure`] | repository-local release skill | Activate release instructions without mutation | exact response, `activate_skill` called, no mutation tool called | deferred release/control discovery |
 | `progress-guard-sequential-read` [`progress-guard`] | 24 numbered notes; answer in `notes/24.txt` | Read notes sequentially and answer the final code | final response contains `KITE-7429` | long exploration streak that should trigger `progress_guard` |
-| `progress-guard-checkpoint-read` [`progress-guard`] | 50 numbered notes; answer in `checkpoint/50.txt` | Read notes sequentially and answer the final code | final response contains `WREN-5081` | escalation from first warning to checkpoint warnings |
+| `progress-guard-checkpoint-read` [`progress-guard`, `progress-efficiency`] | 50 numbered notes; answer in `checkpoint/50.txt` | Read notes sequentially and answer the final code | one checkpoint-required warning, one accepted checkpoint, no failed tool calls, and at most two later non-bookkeeping calls | low-churn checkpoint transition after legitimate long diagnosis |
 | `background-callback-bridge` [`progress-guard`] | Rust crate where `spawn_background` completions land in `SessionTaskRegistry`, but app wake only drains legacy background state | Fix the callback bridge while keeping the legacy wake test passing | source drains session-task completions and keeps focused regression tests | realistic investigation based on the background-callback failure mode |
 | `owner-selection-runtime-guard` [`owner-selection`] | Rust client adapter with a tempting workaround two layers above the shared mount resolver | Fix prefix normalization starting from the adapter | first applied mutation is in the shared owner; adapters stay workaround-free | existing runtime-guard comparison, first-mutation correctness, and investigation cost |
 | `owner-selection-prompt-policy` [`owner-selection`] | Same fixture plus an `AGENTS.md` owner-first instruction | Fix prefix normalization starting from the adapter | same owner/cost checks | prompt-only comparison arm |
@@ -286,7 +286,7 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `search-efficiency` | baseline/candidate session/search proof, 3 trials | 5 focused cases | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `search-controls` | ordinary regression controls, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `capability-disclosure` | first-request token and reveal-path proof, 5 trials | exact reply, read-only search, simple edit, complex coding, release/control, deferred history | gpt-5.5 + claude-sonnet-4-5 | baseline + candidate, harness=default, effort=default |
-| `progress-efficiency` | baseline/candidate state-progress proof, 3 trials | dependency oscillation + redundant validation | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `progress-efficiency` | baseline/candidate state-progress proof, 3 trials | checkpoint transition + dependency oscillation + redundant validation | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `progress-controls` | ordinary regression controls, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `owner-selection` | first-mutation owner selection plus local-edit controls, 3 trials | two owner fixtures + `add-fn` + `implement-todo` | gpt-5.5 | candidate, default vs no-progress-guard |
 | `orchestration-efficiency` | batching interventions and dependency control, 3 trials | three orchestration cases | gpt-5.5 | baseline + parallel-only + policy-only + candidate |
@@ -353,7 +353,10 @@ that do run in pull-request CI.
 
 For progress-efficiency, the distribution gate additionally requires fewer
 workspace-state revisits in the dependency case and fewer redundant validation
-calls in both focused cases. Ordinary-task token and cost regressions are gated
+calls in both focused cases. The checkpoint case measures calls after the
+required warning separately from earlier advisory warnings, requires exactly
+one transition warning and one accepted checkpoint, and rejects a failed tool
+round before the transition. Ordinary-task token and cost regressions are gated
 over a separate five-trial control run; correctness, tool shape, and unexpected
 warnings remain per-control checks. The fixtures are bounded, so an ineffective
 guard finishes with measurable waste instead of running until the study timeout.

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -86,13 +86,13 @@ tag = "capability-disclosure"
 targets = ["openai/gpt-5.5", "anthropic/claude-sonnet-4-5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 
-# PROGRESS-EFFICIENCY — regressions from the costly dependency bump: recurring
-# workspace states and repeated validation on unchanged state. The fixtures are
-# bounded; ordinary controls run separately with five trials.
+# PROGRESS-EFFICIENCY: recurring workspace states, repeated validation, and
+# the required checkpoint transition after long read-only investigation. The
+# fixtures are bounded; ordinary controls run separately with five trials.
 # Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
 #   doppler run -- mira run --preset progress-efficiency --trials 3 --group-by binary
 [presets.progress-efficiency]
-samples = ["dependency-release-oscillation", "redundant-validation"]
+samples = ["progress-guard-checkpoint-read", "dependency-release-oscillation", "redundant-validation"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -173,9 +173,24 @@ fn progress_guard_checkpoint_sample() -> Sample {
          Reply with only the FINAL_CODE value from checkpoint/50.txt.",
     )
     .tag("progress-guard")
+    .tag("progress-efficiency")
     .meta("kind", "guardrail")
     .meta("max_turns", 64)
-    .meta("checks", json!([{"response_contains": ["WREN-5081"]}]));
+    .meta(
+        "checks",
+        json!([
+            {"response_contains": ["WREN-5081"]},
+            {
+                "when_binary": "candidate",
+                "metric_equals": {
+                    "checkpoint_required_warnings": 1.0,
+                    "successful_progress_checkpoints": 1.0,
+                    "tool_calls_failed": 0.0
+                },
+                "metric_at_most": {"calls_after_checkpoint_required": 2.0}
+            }
+        ]),
+    );
 
     for i in 1..50 {
         sample = sample.file(
@@ -1790,6 +1805,8 @@ struct Mined {
     exploration_tools_before_first_mutation: u64,
     max_exploration_tools_without_progress: u64,
     progress_guard_warnings: u64,
+    checkpoint_required_warnings: u64,
+    successful_progress_checkpoints: u64,
     ast_edit_tool_calls: u64,
     ast_edit_tool_calls_failed: u64,
     max_tool_result_bytes: u64,
@@ -1801,6 +1818,7 @@ struct Mined {
     search_sessions_first_exploration: u64,
     duplicate_exploration_calls: u64,
     calls_after_progress_warning: u64,
+    calls_after_checkpoint_required: u64,
     bash_tool_calls: u64,
     read_file_tool_calls: u64,
     grep_files_tool_calls: u64,
@@ -1957,16 +1975,20 @@ fn validation_command(data: &Value) -> Option<String> {
         .then_some(command)
 }
 
-fn has_progress_guard_warning(data: &Value) -> bool {
+fn progress_guard_warning(data: &Value) -> Option<String> {
     match tool_result_value(data) {
         Some(Value::Object(obj)) => obj
             .get("progress_guard_warning")
             .and_then(Value::as_str)
-            .is_some_and(|s| !s.is_empty()),
-        Some(Value::String(text)) => {
-            text.contains("progress_guard_warning") || text.starts_with("progress_guard:")
+            .filter(|warning| !warning.is_empty())
+            .map(str::to_string),
+        Some(Value::String(text))
+            if text.contains("progress_guard_warning")
+                || text.starts_with("progress_guard:") =>
+        {
+            Some(text)
         }
-        _ => false,
+        _ => None,
     }
 }
 
@@ -2152,6 +2174,7 @@ fn parse_events(jsonl: &str) -> Mined {
     let mut saw_mutation = false;
     let mut saw_exploration = false;
     let mut saw_progress_warning = false;
+    let mut saw_checkpoint_required = false;
     let mut saw_truncated_repo_map = false;
     let mut repo_map_recovery_pending = false;
     let mut exploration_fingerprints = BTreeSet::new();
@@ -2258,6 +2281,9 @@ fn parse_events(jsonl: &str) -> Mined {
                 if saw_progress_warning && !is_bookkeeping_tool(name) {
                     m.calls_after_progress_warning += 1;
                 }
+                if saw_checkpoint_required && !is_bookkeeping_tool(name) {
+                    m.calls_after_checkpoint_required += 1;
+                }
                 let result_bytes = data
                     .get("result")
                     .map(Value::to_string)
@@ -2336,6 +2362,14 @@ fn parse_events(jsonl: &str) -> Mined {
                         m.contextual_grep_files_tool_calls += 1;
                     }
                 }
+                if name == "progress_checkpoint"
+                    && data.get("success") == Some(&Value::Bool(true))
+                    && tool_result_value(&data).is_some_and(|result| {
+                        result.get("accepted") == Some(&Value::Bool(true))
+                    })
+                {
+                    m.successful_progress_checkpoints += 1;
+                }
                 if workspace.observe_mutation(&data) {
                     m.workspace_state_revisits += 1;
                 }
@@ -2360,10 +2394,13 @@ fn parse_events(jsonl: &str) -> Mined {
                 if outer_failed || inner_failed {
                     m.tool_calls_failed += 1;
                 }
-                let progress_warning = has_progress_guard_warning(&data);
-                if progress_warning {
+                if let Some(progress_warning) = progress_guard_warning(&data) {
                     m.progress_guard_warnings += 1;
                     saw_progress_warning = true;
+                    if progress_warning.contains("checkpoint required") {
+                        m.checkpoint_required_warnings += 1;
+                        saw_checkpoint_required = true;
+                    }
                 }
                 if name == "ast_edit" {
                     m.ast_edit_tool_calls += 1;
@@ -2736,6 +2773,14 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         mined.progress_guard_warnings as f64,
     );
     t.metrics.insert(
+        "checkpoint_required_warnings".into(),
+        mined.checkpoint_required_warnings as f64,
+    );
+    t.metrics.insert(
+        "successful_progress_checkpoints".into(),
+        mined.successful_progress_checkpoints as f64,
+    );
+    t.metrics.insert(
         "ast_edit_tool_calls".into(),
         mined.ast_edit_tool_calls as f64,
     );
@@ -2778,6 +2823,10 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
     t.metrics.insert(
         "calls_after_progress_warning".into(),
         mined.calls_after_progress_warning as f64,
+    );
+    t.metrics.insert(
+        "calls_after_checkpoint_required".into(),
+        mined.calls_after_checkpoint_required as f64,
     );
     t.metrics
         .insert("bash_tool_calls".into(), mined.bash_tool_calls as f64);
@@ -3055,6 +3104,9 @@ mod tests {
         assert_eq!(m.exploration_tools_before_first_mutation, 3);
         assert_eq!(m.max_exploration_tools_without_progress, 3);
         assert_eq!(m.progress_guard_warnings, 2);
+        assert_eq!(m.checkpoint_required_warnings, 1);
+        assert_eq!(m.calls_after_checkpoint_required, 2);
+        assert_eq!(m.successful_progress_checkpoints, 0);
         assert_eq!(m.tool_emitting_model_calls, 2);
         assert_eq!(m.single_tool_model_calls, 1);
         assert_eq!(m.batched_tool_model_calls, 1);
@@ -3103,6 +3155,22 @@ mod tests {
         assert_eq!(m.read_file_tool_calls, 1);
         assert_eq!(m.leading_marker_in_bash_result, 1);
         assert!(m.total_tool_result_bytes >= m.max_tool_result_bytes);
+    }
+
+    #[test]
+    fn parse_events_measures_the_required_checkpoint_transition() {
+        let jsonl = r#"
+{"type":"tool.completed","data":{"tool_name":"read_file","success":true,"result":[{"type":"text","text":"{\"progress_guard_warning\":\"progress_guard: checkpoint required\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"progress_checkpoint","success":true,"result":[{"type":"text","text":"{\"accepted\":true,\"exploration_resumed\":true}"}]}}
+{"type":"tool.completed","data":{"tool_name":"read_file","success":true}}
+{"type":"tool.completed","data":{"tool_name":"read_file","success":true}}
+"#;
+
+        let mined = parse_events(jsonl);
+
+        assert_eq!(mined.checkpoint_required_warnings, 1);
+        assert_eq!(mined.successful_progress_checkpoints, 1);
+        assert_eq!(mined.calls_after_checkpoint_required, 2);
     }
 
     #[test]
@@ -3556,6 +3624,7 @@ mod tests {
             .next()
             .unwrap();
         assert!(section.contains("binary = [\"baseline\", \"candidate\"]"));
+        assert!(section.contains("\"progress-guard-checkpoint-read\""));
         assert!(section.contains("\"dependency-release-oscillation\""));
         assert!(section.contains("\"redundant-validation\""));
         assert!(!section.contains("\"add-fn\""));

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,19 @@
 # Knowledge Log
 
+## 2026-08-24, A required checkpoint changes the next tool surface
+
+- [Progress guard](specs/progress-guard.md): the checkpoint-required warning is
+  now a real provider-visible transition. The next reasoning step omits the
+  statically classified read, search, and waiting tools that the pre-tool gate
+  would reject, while the eager checkpoint schema and decisive mutation or
+  validation paths stay available.
+- `tool_search` is part of the blocked exploration set during that transition.
+  The warning no longer suggests revealing `progress_checkpoint`, because that
+  tool has always been in Yolop's eager schema profile.
+- Everruns already reapplies capability tool-definition transforms on every
+  reasoning step. Yolop owns the policy and shared guard state, so no upstream
+  runtime fork or dependency release is required.
+
 ## 2026-08-22, One route for every input event
 
 - [Tuika](specs/tuika.md): input ownership is now one ordered table of surfaces,

--- a/knowledge/specs/progress-guard.md
+++ b/knowledge/specs/progress-guard.md
@@ -44,9 +44,14 @@ defined by [tool-call shape enforcement](tool-calling.md).
 An accepted checkpoint resets the exploration tranche and re-enables exploration.
 Submitting the same checkpoint again on unchanged state is rejected. Mutation
 or validation clears the gate directly, so the guard cannot trap a decisive
-action behind its own checkpoint. Other tools remain available, allowing the
-agent to report a complete read-only diagnosis instead of manufacturing a
-change.
+action behind its own checkpoint. On the next reasoning step, the host removes
+the statically blocked exploration and waiting tools from the provider-visible
+list, including `tool_search`. `progress_checkpoint` remains fully visible,
+while mutation tools and argument-dependent `bash` remain available for a
+decisive mutation or validation. The pre-tool hook remains the enforcement
+backstop for a stale or provider-invented call. A final answer needs no tool, so
+the agent can still report a complete read-only diagnosis instead of
+manufacturing a change.
 
 ## State and reset boundaries
 
@@ -67,13 +72,16 @@ state instead of applying it to an earlier trajectory.
 ## Ownership
 
 This is Yolop host behavior: the capability composes Everruns' existing
-pre-tool and post-tool hooks and does not require a competing runtime loop or an
-`everruns-*` dependency change.
+per-reason tool-definition transform with its pre-tool and post-tool hooks. The
+runtime already rebuilds that provider-visible list on every reasoning step, so
+the transition needs no competing runtime loop or `everruns-*` dependency
+change.
 
 ## Evidence
 
-The feature test drives the registered hooks through a real llmsim turn,
-including unchanged payload compaction, a blocked post-budget read, checkpoint
+The feature tests drive the registered hooks through a real llmsim turn and the
+provider-visible tool transform, including unchanged payload compaction,
+warning-once behavior, checkpoint-only gating of blocked paths, checkpoint
 acceptance, and resumed exploration. A deterministic advisory-only
 baseline/candidate study requires at least 50% fewer calls and result bytes with
 the same completed diagnosis. Mutation, validation, long read-only diagnosis,

--- a/knowledge/specs/tool-search.md
+++ b/knowledge/specs/tool-search.md
@@ -60,6 +60,11 @@ vendor was deleted and yolop now consumes upstream directly:
    explicitly marked `never_defer` retain their manifest contract. Yolop does not own the built-in definitions, so it sets this policy
    by name rather than changing each tool's `DeferrablePolicy`.
 
+   When `progress_guard` requires its checkpoint, the guard removes
+   `tool_search` and other statically blocked exploration paths from the next
+   provider-visible tool list. No reveal round is needed or advertised because
+   `progress_checkpoint` is already in this eager profile.
+
    **MCP server tools defer on the same footing**: with many configured servers
    their schemas are the largest, least-used part of the surface, so only names
    and descriptions ride each turn until `tool_search` loads a schema (execution

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -9,7 +9,7 @@ use everruns_core::ToolContext;
 use everruns_core::tool_hooks::{
     PostToolExecHook, PostToolExecHookPriority, PreToolUseDecision, PreToolUseHook,
 };
-use everruns_core::{Capability, CapabilityStatus};
+use everruns_core::{Capability, CapabilityStatus, SystemPromptContext, ToolDefinitionHook};
 use everruns_core::{Tool, ToolExecutionResult};
 use everruns_provider::typed_id::SessionId;
 use everruns_provider::{DeferrablePolicy, ToolCall, ToolDefinition, ToolResult};
@@ -114,6 +114,17 @@ impl Capability for ProgressGuardCapability {
     fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn PreToolUseHook>> {
         vec![Arc::new(ProgressGuardGate {
             state: self.state.clone(),
+        })]
+    }
+
+    fn tool_definition_hooks_with_context(
+        &self,
+        context: &SystemPromptContext,
+        _config: &Value,
+    ) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        vec![Arc::new(ProgressGuardToolGate {
+            state: self.state.clone(),
+            session_id: context.session_id.to_string(),
         })]
     }
 
@@ -592,7 +603,7 @@ impl SessionProgress {
             self.checkpoint_required = true;
             self.warning_count += 1;
             return Some(format!(
-                "progress_guard: checkpoint required after {count} investigation tools without an edit or validation. Further exploration is host-blocked until you call progress_checkpoint with bounded facts, hypothesis, missing evidence, and one next decisive action (mutation, validation, or no-change diagnosis). If its schema is deferred, load it with tool_search first.",
+                "progress_guard: checkpoint required after {count} investigation tools without an edit or validation. Further exploration is host-blocked until you call progress_checkpoint with bounded facts, hypothesis, missing evidence, and one next decisive action (mutation, validation, or no-change diagnosis).",
                 count = self.exploration_since_progress
             ));
         }
@@ -661,6 +672,35 @@ impl PostToolExecHook for ProgressGuardHook {
 
 struct ProgressGuardGate {
     state: Arc<Mutex<ProgressGuardState>>,
+}
+
+struct ProgressGuardToolGate {
+    state: Arc<Mutex<ProgressGuardState>>,
+    session_id: String,
+}
+
+impl ToolDefinitionHook for ProgressGuardToolGate {
+    fn transform(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
+        let checkpoint_required = self
+            .state
+            .lock()
+            .expect("progress guard state poisoned")
+            .sessions
+            .get(&self.session_id)
+            .is_some_and(|progress| progress.checkpoint_required);
+        if !checkpoint_required {
+            return tools;
+        }
+        tools
+            .into_iter()
+            .filter(|tool| {
+                !matches!(
+                    static_tool_class(tool.name()),
+                    Some(ToolClass::Exploration | ToolClass::Waiting)
+                )
+            })
+            .collect()
+    }
 }
 
 #[async_trait]
@@ -980,11 +1020,10 @@ enum ToolClass {
 }
 
 fn classify_tool_call(tool_call: &ToolCall) -> ToolClass {
+    if let Some(class) = static_tool_class(&tool_call.name) {
+        return class;
+    }
     match tool_call.name.as_str() {
-        "read_file" | "grep_files" | "repo_map" | "search_sessions" | "ast_grep"
-        | "list_directory" | "stat_file" => ToolClass::Exploration,
-        "write_file" | "edit_file" | "delete_file" | "ast_edit" => ToolClass::Mutation,
-        "get_task" | "list_tasks" => ToolClass::Waiting,
         "bash" => classify_bash_command(
             tool_call
                 .arguments
@@ -993,6 +1032,16 @@ fn classify_tool_call(tool_call: &ToolCall) -> ToolClass {
                 .unwrap_or_default(),
         ),
         _ => ToolClass::Other,
+    }
+}
+
+fn static_tool_class(name: &str) -> Option<ToolClass> {
+    match name {
+        "read_file" | "grep_files" | "repo_map" | "search_sessions" | "ast_grep"
+        | "list_directory" | "stat_file" | "tool_search" => Some(ToolClass::Exploration),
+        "write_file" | "edit_file" | "delete_file" | "ast_edit" => Some(ToolClass::Mutation),
+        "get_task" | "list_tasks" => Some(ToolClass::Waiting),
+        _ => None,
     }
 }
 
@@ -1396,10 +1445,15 @@ mod tests {
     #[tokio::test]
     async fn checkpoint_gate_blocks_exploration_then_accepts_a_bounded_transition() {
         let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let capability = ProgressGuardCapability {
+            state: state.clone(),
+        };
         let hook = ProgressGuardHook {
             state: state.clone(),
         };
-        let gate = ProgressGuardGate { state };
+        let gate = ProgressGuardGate {
+            state: state.clone(),
+        };
         let context = ToolContext::new(SessionId::new());
 
         for i in 0..CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD {
@@ -1442,6 +1496,103 @@ mod tests {
             )
             .await;
         assert!(matches!(resumed, PreToolUseDecision::Continue(_)));
+
+        let prompt_context = SystemPromptContext::without_file_store(context.session_id);
+        let visible = capability.tool_definition_hooks_with_context(&prompt_context, &json!({}))[0]
+            .transform(vec![
+                tool_def("read_file"),
+                tool_def(PROGRESS_CHECKPOINT_TOOL),
+            ]);
+        assert_eq!(
+            visible.iter().map(|tool| tool.name()).collect::<Vec<_>>(),
+            vec!["read_file", PROGRESS_CHECKPOINT_TOOL],
+            "an accepted checkpoint should restore ordinary exploration"
+        );
+    }
+
+    #[test]
+    fn checkpoint_gate_leaves_ordinary_tool_surface_unchanged() {
+        let capability = ProgressGuardCapability {
+            state: Arc::new(Mutex::new(ProgressGuardState::default())),
+        };
+        let session_id = SessionId::new();
+        let prompt_context = SystemPromptContext::without_file_store(session_id);
+        let tools = vec![
+            tool_def("read_file"),
+            tool_def("tool_search"),
+            tool_def("edit_file"),
+            tool_def(PROGRESS_CHECKPOINT_TOOL),
+        ];
+
+        let visible = capability.tool_definition_hooks_with_context(&prompt_context, &json!({}))[0]
+            .transform(tools.clone());
+
+        assert_eq!(
+            visible.iter().map(|tool| tool.name()).collect::<Vec<_>>(),
+            tools.iter().map(|tool| tool.name()).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_gate_removes_blocked_paths_from_the_next_model_round() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let capability = ProgressGuardCapability {
+            state: state.clone(),
+        };
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+
+        for i in 0..CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD {
+            hook.after_exec(
+                &call("read_file", json!({ "path": format!("/src/{i}.rs") })),
+                &tool_def("read_file"),
+                &mut result(),
+                &context,
+            )
+            .await;
+        }
+
+        let tools = [
+            "read_file",
+            "grep_files",
+            "tool_search",
+            "get_task",
+            "bash",
+            "edit_file",
+            PROGRESS_CHECKPOINT_TOOL,
+            "write_todos",
+        ]
+        .into_iter()
+        .map(tool_def)
+        .collect::<Vec<_>>();
+        let prompt_context = SystemPromptContext::without_file_store(context.session_id);
+        let visible = capability
+            .tool_definition_hooks_with_context(&prompt_context, &json!({}))
+            .into_iter()
+            .fold(tools, |tools, hook| hook.transform(tools))
+            .into_iter()
+            .map(|tool| tool.name().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            visible,
+            vec!["bash", "edit_file", PROGRESS_CHECKPOINT_TOOL, "write_todos"],
+            "the gated model round should not advertise paths the pre-tool hook will reject"
+        );
+
+        let other_session = SystemPromptContext::without_file_store(SessionId::new());
+        let other_visible =
+            capability.tool_definition_hooks_with_context(&other_session, &json!({}))[0].transform(
+                vec![tool_def("read_file"), tool_def(PROGRESS_CHECKPOINT_TOOL)],
+            );
+        assert_eq!(
+            other_visible
+                .iter()
+                .map(|tool| tool.name())
+                .collect::<Vec<_>>(),
+            vec!["read_file", PROGRESS_CHECKPOINT_TOOL],
+            "one session's checkpoint gate must not alter another session's tools"
+        );
     }
 
     #[tokio::test]
@@ -1773,6 +1924,7 @@ mod tests {
         };
         let context = ToolContext::new(SessionId::new());
         let mut warning_count = 0;
+        let mut checkpoint_warning = String::new();
 
         for i in 0..(CHECKPOINT_WITHOUT_PROGRESS_THRESHOLD + 12) {
             let mut out = result();
@@ -1783,16 +1935,23 @@ mod tests {
                 &context,
             )
             .await;
-            warning_count += usize::from(
-                out.result
-                    .as_ref()
-                    .and_then(|value| value.get("progress_guard_warning"))
-                    .and_then(Value::as_str)
-                    .is_some_and(|warning| warning.contains("checkpoint required")),
-            );
+            if let Some(warning) = out
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .and_then(Value::as_str)
+                .filter(|warning| warning.contains("checkpoint required"))
+            {
+                warning_count += 1;
+                checkpoint_warning = warning.to_string();
+            }
         }
 
         assert_eq!(warning_count, 1);
+        assert!(
+            !checkpoint_warning.contains("tool_search"),
+            "progress_checkpoint is always eager, so the warning must not prescribe a reveal round"
+        );
         assert!(
             state
                 .lock()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5563,7 +5563,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn real_tool_hooks_compact_runaway_reads_and_enforce_one_checkpoint() {
+    async fn real_tool_hooks_compact_runaway_reads_and_transition_through_one_checkpoint() {
         use everruns_core::EventData;
         use everruns_llmsim::{SimToolCall, SimTurn};
 
@@ -5601,11 +5601,6 @@ mod tests {
         let options = BuildOptions {
             llmsim_override: Some(LlmSimConfig::scripted(vec![
                 SimTurn::ToolCalls(runaway),
-                SimTurn::ToolCalls(vec![SimToolCall {
-                    name: "read_file".to_string(),
-                    arguments: serde_json::json!({ "path": "decisive.txt" }),
-                    id: None,
-                }]),
                 SimTurn::ToolCalls(vec![SimToolCall {
                     name: "progress_checkpoint".to_string(),
                     arguments: serde_json::json!({
@@ -5733,14 +5728,12 @@ mod tests {
                 .count(),
             1
         );
-        assert!(completed.iter().any(|data| {
-            data.tool_name == "read_file"
-                && !data.success
-                && data
-                    .error
-                    .as_deref()
-                    .is_some_and(|error| error.contains("progress checkpoint required"))
-        }));
+        assert!(
+            !completed
+                .iter()
+                .any(|data| data.tool_name == "read_file" && !data.success),
+            "the checkpoint transition must not produce a blocked-read error round"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What changed

Make `progress_checkpoint` a real low-churn trajectory transition. Once a session requires a checkpoint, the next provider call no longer advertises statically blocked read, search, or waiting tools. The eager checkpoint, mutation, validation-capable `bash`, bookkeeping, and final-answer paths remain available. The pre-tool hook remains as a backstop for stale or invented calls.

The focused harness now measures the required warning, accepted transition, failed calls, and calls after the gate. Ordinary long read-only diagnosis remains supported.

## Why

The guard previously waited until after the model selected another blocked exploration tool. That spent another model round, returned an avoidable tool failure, and could lead to repeated transition friction. Its warning also suggested revealing `progress_checkpoint` through `tool_search`, although the checkpoint schema is never deferred.

Everruns already rebuilds capability-transformed tool definitions on every reasoning step. Yolop owns the gating policy and session state, so this uses the existing upstream seam and requires no Everruns fork, release, or dependency bump.

## Before / After

Three-trial live A/B with `openai/gpt-5.5`, using the `progress-efficiency` preset:

| Checkpoint case | Before (`origin/main`) | After |
| --- | ---: | ---: |
| Exact one checkpoint warning and accepted checkpoint | 3/3 | 3/3 |
| Failed tool call after the gate | 1/3 | 0/3 |
| Low-churn path: 53 model calls / 52 tool calls | 2/3 | 3/3 |
| Calls after checkpoint-required | 2 in all trials | 2 in all trials |

The full focused preset produced 8/9 candidate passes versus 3/9 baseline passes. The one candidate miss was an unrelated stochastic redundant-validation bound in the dependency-oscillation case. The separate five-trial ordinary control preset passed 20/20 across baseline and candidate.

A live OpenAI tool-wiring smoke through Doppler read a synthetic file and returned exactly `LIVE_CHECKPOINT_SMOKE_OK`.

## Risk

- Low
- A misclassified static tool could be hidden during the gated step. Classification is shared with execution enforcement, argument-dependent `bash` remains visible, the gate is session-scoped, and tests cover ordinary, gated, cross-session, accepted-transition, and warning-once behavior.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered, Yolop is pre-1.0 and the change only narrows an already-blocked gated state
- [x] Knowledge concepts updated

Validation:

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema progress_guard -- --nocapture`
- `cargo test --workspace --features yolop-yep/schema real_tool_hooks_compact_runaway_reads_and_transition_through_one_checkpoint -- --nocapture`
- `cargo test --manifest-path evals/harness_basic/Cargo.toml`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Full workspace run reached 1267 passing tests. Five local-only failures were isolated: four nested macOS sandbox tests pass when the candidate test binary runs outside the enclosing Codex sandbox, and the cold-start prompt-size assertion fails identically on untouched `origin/main` in this machine's configuration.

## Knowledge

Updated `progress-guard`, `tool-search`, and the knowledge log with the provider-visible transition, eager checkpoint contract, enforcement backstop, and existing Everruns ownership seam.

## Security

- TM-TOOL: reviewed capability registration and session isolation. The change removes blocked tools from model visibility and retains pre-execution enforcement. It does not expand write authority.
- TM-LLM: reviewed prompt/tool-boundary injection, data exposure, validation, and resource bounds. Tool names come from registered definitions, checkpoint arguments retain strict bounds, and no keys or tool results are newly logged.
- TM-FS and TM-BASH: unchanged. The write blocklist, workspace boundaries, timeouts, output caps, and argument-dependent shell classification remain intact.
- TM-DEP: no dependency changes.

## Follow-ups

No follow-ups.
