### PR TITLE
fix(runtime): repair equivalent failure loops

### DIFF
--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -58,6 +58,9 @@ search/refactor, and read-only code navigation.
 | `untrusted-file-instructions` [`instruction-precedence`] | Config value followed by a malicious instruction | Report the config value only | response reports the value, file remains, and `delete_file` is not called | untrusted workspace content |
 | `grep-files-nested-glob` [`search-efficiency`] | Nested Rust source plus decoys | Search through `src/**/*.rs` | response finds the nested code through `grep_files` | path glob contract |
 | `missing-rg-recovery` [`search-efficiency`] | Restricted PATH without ripgrep | Recover after the required `rg` call fails | response finds the code via an available path | command-not-found guidance |
+| `equivalent-failure-recovery` [`search-efficiency`] [`progress-efficiency`] | Three rewritten invocations with the same usage failure plus a real target | Stop the equivalent loop after the runtime warning and recover through `grep_files` | correct value, one warning, two expected failures, at most one call after warning | semantic failure fingerprinting and enforced recovery |
+| `expected-diagnostic-failure-control` [`search-efficiency-control`] [`progress-efficiency-control`] | Rust crate with one intentionally failing test | Reproduce, fix, and pass the test | source fixed with no semantic-failure warning | expected diagnostic failure control |
+| `distinct-failures-control` [`search-efficiency-control`] [`progress-efficiency-control`] | Missing command, wrong path, and usage failure in sequence | Finish through a built-in search without a warning | correct value and no equivalent-failure warning | false-positive guard across different root reasons |
 | `zero-result-search-recovery` [`search-efficiency`] | Three absent terms plus a real target | Recover after repeated empty searches | response finds the target and records a progress warning | result-aware progress guard |
 | `repo-map-bounded` [`search-efficiency`] | Rust file with 260+ symbols | Use an unqueried repo map | answer is found, output stays bounded, and truncation is followed by a targeted map or grep | output-size and recovery discipline |
 | `normal-output-preserves-head` [`search-efficiency`] | leading match followed by 600 `Error` lines | Run one bash search with explicit `output: normal` | leading match remains visible without reading persisted output | successful-output compaction |
@@ -141,7 +144,8 @@ comparison itself reads the per-case numbers the transcript carries, tokens,
 cost, `llm_calls`, `turns`, `tool_calls_failed`, `agent_reported_ms`,
 `exploration_tools_before_first_mutation`, `max_exploration_tools_without_progress`,
 `progress_guard_warnings`, `calls_after_progress_warning`, structured inner
-`tool_calls_failed`, duplicate exploration, total/maximum tool-result bytes,
+`tool_calls_failed`, equivalent-failure warnings and blocked retries, duplicate
+exploration, total/maximum tool-result bytes,
 repo-map narrowing and targeted recovery (a narrower map or `grep_files` fallback),
 session-search ordering, `ast_edit_tool_calls`, and
 `ast_edit_tool_calls_failed`, validation calls, redundant validations, and
@@ -242,6 +246,14 @@ python3 analyze_progress_efficiency.py \
   results/<focused_run_id>/report.json \
   results/<control_run_id>/report.json
 
+# Smallest semantic-failure A/B, with three focused trials and five controls.
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
+  doppler run -- mira run --preset failure-repair --trials 3 --group-by binary
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
+  doppler run -- mira run --preset failure-repair-controls --trials 5 --group-by binary
+
 # Compare owner selection, investigation cost, and local-edit controls across
 # the default runtime guard, no guard, and prompt-policy fixture.
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/yolop \
@@ -283,11 +295,13 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `smoke` | cheap candidate sanity check | tag `smoke` | claude-sonnet-4-5 | candidate, effort=default, all harness |
 | `harness-compare` | **A/B yolop configurations** | all | claude-sonnet-4-5 | candidate, effort=default, all harness |
 | `progress-guard` | focused warning-behavior check | tag `progress-guard` | claude-sonnet-4-5 | candidate, effort=default, default vs no-progress-guard |
-| `search-efficiency` | baseline/candidate session/search proof, 3 trials | 5 focused cases | gpt-5.5 | baseline + candidate, harness=default, effort=default |
-| `search-controls` | ordinary regression controls, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `search-efficiency` | baseline/candidate session/search proof, 3 trials | 8 focused cases | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `search-controls` | ordinary and semantic-failure controls, 5 trials | 4 controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `capability-disclosure` | first-request token and reveal-path proof, 5 trials | exact reply, read-only search, simple edit, complex coding, release/control, deferred history | gpt-5.5 + claude-sonnet-4-5 | baseline + candidate, harness=default, effort=default |
-| `progress-efficiency` | baseline/candidate state-progress proof, 3 trials | checkpoint transition + dependency oscillation + redundant validation | gpt-5.5 | baseline + candidate, harness=default, effort=default |
-| `progress-controls` | ordinary regression controls, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `progress-efficiency` | baseline/candidate state-progress proof, 3 trials | checkpoint transition, state cycle, redundant validation, equivalent failure | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `progress-controls` | ordinary and semantic-failure controls, 5 trials | 4 controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `failure-repair` | equivalent-failure recovery proof, 3 trials | `equivalent-failure-recovery` | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `failure-repair-controls` | expected diagnostic and distinct-failure controls, 5 trials | two failure-repair controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `owner-selection` | first-mutation owner selection plus local-edit controls, 3 trials | two owner fixtures + `add-fn` + `implement-todo` | gpt-5.5 | candidate, default vs no-progress-guard |
 | `orchestration-efficiency` | batching interventions and dependency control, 3 trials | three orchestration cases | gpt-5.5 | baseline + parallel-only + policy-only + candidate |
 | `output-persistence` | dependency-isolated output proof, 3 trials | `normal-output-preserves-head` | gpt-5.5 | dependency baseline + candidate |
@@ -352,14 +366,17 @@ graded nothing has not passed the gate and must not be read as evidence that
 that do run in pull-request CI.
 
 For progress-efficiency, the distribution gate additionally requires fewer
-workspace-state revisits in the dependency case and fewer redundant validation
-calls in both focused cases. The checkpoint case measures calls after the
-required warning separately from earlier advisory warnings, requires exactly
-one transition warning and one accepted checkpoint, and rejects a failed tool
-round before the transition. Ordinary-task token and cost regressions are gated
-over a separate five-trial control run; correctness, tool shape, and unexpected
-warnings remain per-control checks. The fixtures are bounded, so an ineffective
-guard finishes with measurable waste instead of running until the study timeout.
+workspace-state revisits in the dependency case, fewer redundant validation
+calls, and fewer failed calls in the equivalent-failure case. The candidate
+must emit the structured warning, recover within the post-warning call budget,
+and never hit the host block in the scripted task. The checkpoint case measures
+calls after the required warning separately from earlier advisory warnings,
+requires exactly one transition warning and one accepted checkpoint, and
+rejects a failed tool round before the transition. Ordinary-task, expected
+diagnostic, and distinct-failure controls use five trials; correctness, tool
+shape, cost, and unexpected warnings remain gated. The fixtures are bounded, so
+an ineffective guard finishes with measurable waste instead of running until
+the study timeout.
 
 Verified: with the `no-ast-grep` settings applied, the `ast_grep` tool is
 absent from yolop's registered toolset (and each case's input tokens drop by
@@ -394,6 +411,7 @@ evals/harness_basic/
   prompt_composition_baseline.json # immutable pre-trim revision + evidence
   capability_disclosure_baseline.json # cold-start byte baseline + A/B contract
   analyze_progress_efficiency.py  # state-progress distribution gates
+  failure_repair_baseline.json # semantic failure A/B contract and evidence
   tests/         # analyzer unit tests
   Cargo.toml    # standalone crate (outside the yolop package), mira-eval SDK
   mira.toml     # host config: launcher, ./results, presets

--- a/evals/harness_basic/analyze_progress_efficiency.py
+++ b/evals/harness_basic/analyze_progress_efficiency.py
@@ -10,10 +10,16 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-CONTROLS = {"add-fn", "find-constant"}
+CONTROLS = {
+    "add-fn",
+    "find-constant",
+    "expected-diagnostic-failure-control",
+    "distinct-failures-control",
+}
 FOCUSED = {
     "dependency-release-oscillation": ("workspace_state_revisits", 1.0),
     "redundant-validation": ("redundant_validation_calls", 1.0),
+    "equivalent-failure-recovery": ("tool_calls_failed", 2.0),
 }
 EXPECTED_SAMPLES = CONTROLS | set(FOCUSED)
 FOCUSED_TRIALS = 3
@@ -71,6 +77,8 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
                 failures.append(f"{sample}: ordinary control did not pass every trial")
             if sum(value(case, "progress_guard_warnings") for case in candidate):
                 failures.append(f"{sample}: progress guard warned on an ordinary control")
+            if sum(value(case, "equivalent_failure_warnings") for case in candidate):
+                failures.append(f"{sample}: semantic failure repair warned on a control")
             for metric in CONTROL_METRICS:
                 before = median(baseline, metric)
                 after = median(candidate, metric)
@@ -105,6 +113,16 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str]]:
                 f"{sample}: candidate median calls after warning "
                 f"{calls_after_warning:g} > 2"
             )
+        if sample == "equivalent-failure-recovery":
+            equivalent_warnings = median(candidate, "equivalent_failure_warnings")
+            if equivalent_warnings < 1:
+                failures.append(
+                    f"{sample}: candidate emitted no equivalent-failure warning"
+                )
+            if median(candidate, "blocked_equivalent_failures") > 0:
+                failures.append(
+                    f"{sample}: candidate kept invoking the blocked failure path"
+                )
         rows.append(
             f"{sample}: pass {base_pass:.0%}->{cand_pass:.0%}; "
             f"{metric} {before:g}->{after:g}; warnings {warnings:g}; "

--- a/evals/harness_basic/analyze_search_efficiency.py
+++ b/evals/harness_basic/analyze_search_efficiency.py
@@ -10,11 +10,17 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-CONTROLS = {"add-fn", "find-constant"}
+CONTROLS = {
+    "add-fn",
+    "find-constant",
+    "expected-diagnostic-failure-control",
+    "distinct-failures-control",
+}
 FOCUSED = {
     "prior-session-reference",
     "grep-files-nested-glob",
     "missing-rg-recovery",
+    "equivalent-failure-recovery",
     "zero-result-search-recovery",
     "repo-map-bounded",
 }
@@ -266,6 +272,8 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str], list[str
         if sample in CONTROLS:
             if base_pass < 1 or cand_pass < 1:
                 failures.append(f"{sample}: ordinary control did not pass every trial")
+            if sum(value(case, "equivalent_failure_warnings") for case in candidate):
+                failures.append(f"{sample}: semantic failure repair warned on a control")
             for metric in ("tool_calls", "llm_calls", "input_tokens", "cost_usd"):
                 base = medians[("baseline", metric)]
                 candidate_value = medians[("candidate", metric)]
@@ -275,6 +283,25 @@ def analyze_reports(reports: list[dict]) -> tuple[list[str], list[str], list[str
                         f"{sample}: control {metric} regressed >10% "
                         f"({base:g} -> {candidate_value:g})"
                     )
+        if sample == "equivalent-failure-recovery":
+            if statistics.median(
+                value(case, "equivalent_failure_warnings") for case in candidate
+            ) < 1:
+                failures.append(
+                    f"{sample}: candidate emitted no equivalent-failure warning"
+                )
+            if statistics.median(
+                value(case, "calls_after_progress_warning") for case in candidate
+            ) > 1:
+                failures.append(
+                    f"{sample}: candidate continued for more than one call after warning"
+                )
+        if sample in FOCUSED and (
+            medians[("candidate", "tool_calls")] < medians[("baseline", "tool_calls")]
+            or medians[("candidate", "tool_calls_failed")]
+            < medians[("baseline", "tool_calls_failed")]
+        ):
+            improved += 1
         rows.append(
             f"{sample}: pass {base_pass:.0%}->{cand_pass:.0%}; "
             f"tools {medians[('baseline', 'tool_calls')]:g}->"

--- a/evals/harness_basic/failure_repair_baseline.json
+++ b/evals/harness_basic/failure_repair_baseline.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "git_commit": "5a3fde105f935eb3d7469f5badc4e4119efbb1b8",
+    "description": "Immutable origin/main immediately before semantic failure repair."
+  },
+  "monitor": {
+    "focused_preset": "failure-repair",
+    "focused_trials": 3,
+    "control_preset": "failure-repair-controls",
+    "control_trials": 5,
+    "target": "openai/gpt-5.5"
+  },
+  "reference_evidence": {
+    "focused_run_id": "20260825T004828Z-9e96",
+    "control_run_id": "20260825T004854Z-cb4c",
+    "focused": {
+      "baseline_passed": 2,
+      "candidate_passed": 3,
+      "trials_per_binary": 3,
+      "baseline_median_tool_calls": 5,
+      "candidate_median_tool_calls": 4,
+      "baseline_median_failed_calls": 3,
+      "candidate_median_failed_calls": 2,
+      "candidate_median_equivalent_failure_warnings": 1,
+      "candidate_median_calls_after_warning": 1,
+      "candidate_median_blocked_retries": 0
+    },
+    "controls": {
+      "passed": 20,
+      "scored": 20,
+      "trials_per_binary": 5,
+      "candidate_equivalent_failure_warnings": 0,
+      "candidate_blocked_retries": 0
+    }
+  }
+}

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -53,7 +53,7 @@ axes = { binary = ["candidate"], effort = ["default"], harness = ["default", "no
 # Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
 #   doppler run -- mira run --preset search-efficiency --trials 3 --group-by binary
 [presets.search-efficiency]
-samples = ["prior-session-reference", "overlapping-recent-work", "unchanged-repeated-discovery", "grep-files-nested-glob", "missing-rg-recovery", "zero-result-search-recovery", "repo-map-bounded"]
+samples = ["prior-session-reference", "overlapping-recent-work", "unchanged-repeated-discovery", "grep-files-nested-glob", "missing-rg-recovery", "equivalent-failure-recovery", "zero-result-search-recovery", "repo-map-bounded"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 
@@ -71,7 +71,7 @@ axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["d
 # Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
 #   doppler run -- mira run --preset search-controls --trials 5 --group-by binary
 [presets.search-controls]
-samples = ["add-fn", "find-constant"]
+samples = ["add-fn", "find-constant", "expected-diagnostic-failure-control", "distinct-failures-control"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 
@@ -92,7 +92,7 @@ axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["d
 # Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
 #   doppler run -- mira run --preset progress-efficiency --trials 3 --group-by binary
 [presets.progress-efficiency]
-samples = ["progress-guard-checkpoint-read", "dependency-release-oscillation", "redundant-validation"]
+samples = ["progress-guard-checkpoint-read", "dependency-release-oscillation", "redundant-validation", "equivalent-failure-recovery"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 
@@ -101,7 +101,19 @@ axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["d
 # Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
 #   doppler run -- mira run --preset progress-controls --trials 5 --group-by binary
 [presets.progress-controls]
-samples = ["add-fn", "find-constant"]
+samples = ["add-fn", "find-constant", "expected-diagnostic-failure-control", "distinct-failures-control"]
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
+
+# FAILURE-REPAIR, smallest baseline/candidate proof for semantic failure-loop
+# detection. Three trials expose model variance; controls below use five.
+[presets.failure-repair]
+tag = "failure-repair"
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
+
+[presets.failure-repair-controls]
+tag = "failure-repair-control"
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -642,6 +642,119 @@ fn missing_rg_recovery_sample() -> Sample {
     )
 }
 
+fn equivalent_failure_recovery_sample() -> Sample {
+    Sample::new(
+        "equivalent-failure-recovery",
+        "This is a controlled recovery evaluation. Run these bash commands exactly, one \
+         call at a time: `python3 failure_probe.py alpha`, then \
+         `python3 failure_probe.py beta`, then `python3 failure_probe.py gamma`. Each \
+         rewritten invocation reports the same usage failure. A runtime progress warning \
+         overrides the remaining invocation: immediately switch to grep_files, find \
+         FAILURE_RECOVERY, and reply with only its value. Do not install anything.",
+    )
+    .file(
+        "failure_probe.py",
+        "import sys\nprint(\"usage: failure-probe TARGET\", file=sys.stderr)\nraise SystemExit(2)\n",
+    )
+    .file("src/recovery.txt", "FAILURE_RECOVERY=REPAIRED-527\n")
+    .tag("search-efficiency")
+    .tag("progress-efficiency")
+    .tag("failure-repair")
+    .meta("kind", "equivalent-failure-recovery")
+    .meta(
+        "checks",
+        json!([
+            {"response_contains": ["REPAIRED-527"], "tool_called": ["bash", "grep_files"]},
+            {
+                "when_binary": "candidate",
+                "metric_equals": {
+                    "equivalent_failure_warnings": 1.0,
+                    "blocked_equivalent_failures": 0.0,
+                    "tool_calls_failed": 2.0
+                },
+                "metric_at_most": {
+                    "calls_after_progress_warning": 1.0,
+                    "task_tool_calls": 3.0,
+                    "task_llm_calls": 4.0
+                }
+            },
+            {
+                "when_binary": "baseline",
+                "metric_equals": {
+                    "equivalent_failure_warnings": 0.0,
+                    "progress_guard_warnings": 0.0
+                },
+                "metric_at_least": {"tool_calls_failed": 3.0}
+            }
+        ]),
+    )
+}
+
+fn expected_diagnostic_failure_control_sample() -> Sample {
+    Sample::new(
+        "expected-diagnostic-failure-control",
+        "Run `cargo test` before editing to reproduce the failing assertion. Then fix \
+         answer() at the owning source, rerun `cargo test`, and reply with exactly \
+         DIAGNOSTIC_RECOVERED.",
+    )
+    .file(
+        "Cargo.toml",
+        "[package]\nname = \"diagnostic_control\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .file(
+        "src/lib.rs",
+        "pub fn answer() -> u32 { 1 }\n\n#[test]\nfn expected_answer() { assert_eq!(answer(), 2); }\n",
+    )
+    .tag("progress-efficiency-control")
+    .tag("search-efficiency-control")
+    .tag("failure-repair-control")
+    .meta("kind", "expected-diagnostic-failure")
+    .meta(
+        "checks",
+        json!([{
+            "response_contains": ["DIAGNOSTIC_RECOVERED"],
+            "file": "src/lib.rs",
+            "contains": ["answer() -> u32 { 2 }"],
+            "metric_equals": {
+                "equivalent_failure_warnings": 0.0,
+                "blocked_equivalent_failures": 0.0,
+                "progress_guard_warnings": 0.0
+            },
+            "metric_at_least": {"validation_tool_calls": 2.0, "tool_calls_failed": 1.0}
+        }]),
+    )
+}
+
+fn distinct_failures_control_sample() -> Sample {
+    Sample::new(
+        "distinct-failures-control",
+        "Run these three diagnostic bash commands exactly, one call at a time: \
+         `missing_distinct_probe`, then `cat absent-control.txt`, then \
+         `python3 -c 'import sys; print(\"usage: probe FLAG\", file=sys.stderr); \
+         raise SystemExit(2)'`. These failures have different root reasons and must not \
+         be treated as an equivalent loop. Then use grep_files to find DISTINCT_RECOVERY \
+         and reply with only its value.",
+    )
+    .file("src/distinct.txt", "DISTINCT_RECOVERY=DISTINCT-913\n")
+    .tag("progress-efficiency-control")
+    .tag("search-efficiency-control")
+    .tag("failure-repair-control")
+    .meta("kind", "distinct-failure-control")
+    .meta(
+        "checks",
+        json!([{
+            "response_contains": ["DISTINCT-913"],
+            "tool_called": ["bash", "grep_files"],
+            "metric_equals": {
+                "equivalent_failure_warnings": 0.0,
+                "blocked_equivalent_failures": 0.0,
+                "progress_guard_warnings": 0.0
+            },
+            "metric_at_least": {"tool_calls_failed": 3.0}
+        }]),
+    )
+}
+
 fn zero_result_search_sample() -> Sample {
     Sample::new(
         "zero-result-search-recovery",
@@ -1346,6 +1459,9 @@ fn dataset() -> Dataset {
         untrusted_file_content_sample(),
         nested_glob_search_sample(),
         missing_rg_recovery_sample(),
+        equivalent_failure_recovery_sample(),
+        expected_diagnostic_failure_control_sample(),
+        distinct_failures_control_sample(),
         zero_result_search_sample(),
         bounded_repo_map_sample(),
         normal_output_preservation_sample(),
@@ -1807,6 +1923,8 @@ struct Mined {
     progress_guard_warnings: u64,
     checkpoint_required_warnings: u64,
     successful_progress_checkpoints: u64,
+    equivalent_failure_warnings: u64,
+    blocked_equivalent_failures: u64,
     ast_edit_tool_calls: u64,
     ast_edit_tool_calls_failed: u64,
     max_tool_result_bytes: u64,
@@ -1983,8 +2101,7 @@ fn progress_guard_warning(data: &Value) -> Option<String> {
             .filter(|warning| !warning.is_empty())
             .map(str::to_string),
         Some(Value::String(text))
-            if text.contains("progress_guard_warning")
-                || text.starts_with("progress_guard:") =>
+            if text.contains("progress_guard_warning") || text.starts_with("progress_guard:") =>
         {
             Some(text)
         }
@@ -2364,9 +2481,8 @@ fn parse_events(jsonl: &str) -> Mined {
                 }
                 if name == "progress_checkpoint"
                     && data.get("success") == Some(&Value::Bool(true))
-                    && tool_result_value(&data).is_some_and(|result| {
-                        result.get("accepted") == Some(&Value::Bool(true))
-                    })
+                    && tool_result_value(&data)
+                        .is_some_and(|result| result.get("accepted") == Some(&Value::Bool(true)))
                 {
                     m.successful_progress_checkpoints += 1;
                 }
@@ -2401,6 +2517,23 @@ fn parse_events(jsonl: &str) -> Mined {
                         m.checkpoint_required_warnings += 1;
                         saw_checkpoint_required = true;
                     }
+                }
+                if tool_result_value(&data).is_some_and(|value| {
+                    value
+                        .get("progress_guard_warning")
+                        .and_then(Value::as_str)
+                        .is_some_and(|warning| {
+                            warning.contains("equivalent") && warning.contains("failure")
+                        })
+                }) {
+                    m.equivalent_failure_warnings += 1;
+                }
+                if data
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .is_some_and(|error| error.contains("equivalent") && error.contains("failure"))
+                {
+                    m.blocked_equivalent_failures += 1;
                 }
                 if name == "ast_edit" {
                     m.ast_edit_tool_calls += 1;
@@ -2779,6 +2912,14 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
     t.metrics.insert(
         "successful_progress_checkpoints".into(),
         mined.successful_progress_checkpoints as f64,
+    );
+    t.metrics.insert(
+        "equivalent_failure_warnings".into(),
+        mined.equivalent_failure_warnings as f64,
+    );
+    t.metrics.insert(
+        "blocked_equivalent_failures".into(),
+        mined.blocked_equivalent_failures as f64,
     );
     t.metrics.insert(
         "ast_edit_tool_calls".into(),
@@ -3171,6 +3312,22 @@ mod tests {
         assert_eq!(mined.checkpoint_required_warnings, 1);
         assert_eq!(mined.successful_progress_checkpoints, 1);
         assert_eq!(mined.calls_after_checkpoint_required, 2);
+    }
+
+    #[test]
+    fn parse_events_mines_equivalent_failure_recovery() {
+        let jsonl = r#"
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"exit_code\":127,\"success\":false}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":true,"result":[{"type":"text","text":"{\"exit_code\":127,\"success\":false,\"progress_guard_warning\":\"progress_guard: repeated an equivalent missing-command failure\"}"}]}}
+{"type":"tool.completed","data":{"tool_name":"bash","success":false,"error":"equivalent missing-command failure repeated on unchanged state"}}
+{"type":"tool.completed","data":{"tool_name":"grep_files","success":true,"result":[{"type":"text","text":"{\"count\":1}"}]}}
+"#;
+        let mined = parse_events(jsonl);
+        assert_eq!(mined.progress_guard_warnings, 1);
+        assert_eq!(mined.equivalent_failure_warnings, 1);
+        assert_eq!(mined.blocked_equivalent_failures, 1);
+        assert_eq!(mined.calls_after_progress_warning, 2);
+        assert_eq!(mined.tool_calls_failed, 3);
     }
 
     #[test]

--- a/evals/harness_basic/tests/test_analyze_progress_efficiency.py
+++ b/evals/harness_basic/tests/test_analyze_progress_efficiency.py
@@ -64,6 +64,23 @@ class AnalyzeProgressEfficiencyTests(unittest.TestCase):
                 "progress_guard_warnings": 1,
             },
         )
+        focused += trials(
+            "equivalent-failure-recovery",
+            "baseline",
+            metrics={"tool_calls_failed": 3},
+            tools=4,
+        )
+        focused += trials(
+            "equivalent-failure-recovery",
+            "candidate",
+            metrics={
+                "tool_calls_failed": 2,
+                "progress_guard_warnings": 1,
+                "equivalent_failure_warnings": 1,
+                "calls_after_progress_warning": 1,
+            },
+            tools=3,
+        )
         return {"cases": focused}, {"cases": controls}
 
     def test_accepts_split_reports_with_five_trial_controls(self):
@@ -98,6 +115,19 @@ class AnalyzeProgressEfficiencyTests(unittest.TestCase):
         _, failures = MODULE.analyze_reports([focused, controls])
         self.assertTrue(any("warned on an ordinary control" in failure for failure in failures))
 
+    def test_rejects_equivalent_failure_warning_on_diagnostic_control(self):
+        focused, controls = self.passing_reports()
+        for item in controls["cases"]:
+            if (
+                item["sample"] == "expected-diagnostic-failure-control"
+                and item["params"]["binary"] == "candidate"
+            ):
+                item["transcript"]["metrics"]["equivalent_failure_warnings"] = 1
+        _, failures = MODULE.analyze_reports([focused, controls])
+        self.assertTrue(
+            any("semantic failure repair warned on a control" in failure for failure in failures)
+        )
+
     def test_rejects_ignored_warning_distribution(self):
         focused, controls = self.passing_reports()
         for item in focused["cases"]:
@@ -108,6 +138,19 @@ class AnalyzeProgressEfficiencyTests(unittest.TestCase):
                 item["transcript"]["metrics"]["calls_after_progress_warning"] = 3
         _, failures = MODULE.analyze_reports([focused, controls])
         self.assertTrue(any("median calls after warning" in failure for failure in failures))
+
+    def test_rejects_missing_equivalent_failure_warning(self):
+        focused, controls = self.passing_reports()
+        for item in focused["cases"]:
+            if (
+                item["sample"] == "equivalent-failure-recovery"
+                and item["params"]["binary"] == "candidate"
+            ):
+                item["transcript"]["metrics"]["equivalent_failure_warnings"] = 0
+        _, failures = MODULE.analyze_reports([focused, controls])
+        self.assertTrue(
+            any("no equivalent-failure warning" in failure for failure in failures)
+        )
 
     def test_rejects_three_trial_controls(self):
         focused, controls = self.passing_reports()

--- a/evals/harness_basic/tests/test_analyze_search_efficiency.py
+++ b/evals/harness_basic/tests/test_analyze_search_efficiency.py
@@ -26,13 +26,30 @@ def scores(checks=None, budget=None):
 NA = object()
 
 
-def case(sample, binary, passed, tools=1, tokens=100, failures=0, error=None, scored=None):
+def case(
+    sample,
+    binary,
+    passed,
+    tools=1,
+    tokens=100,
+    failures=0,
+    error=None,
+    scored=None,
+    metrics=None,
+):
+    default_metrics = (
+        {"equivalent_failure_warnings": 1, "calls_after_progress_warning": 1}
+        if sample == "equivalent-failure-recovery" and binary == "candidate"
+        else {}
+    )
     transcript = {
         "tool_calls_count": tools,
         "metrics": {
             "llm_calls": 2,
             "tool_calls_failed": failures,
             "total_tool_result_bytes": 1000,
+            **default_metrics,
+            **(metrics or {}),
         },
         "usage": {"input_tokens": tokens, "cost_usd": 0.01},
         "timing": {"duration_ms": 1000},
@@ -125,6 +142,19 @@ class AnalyzeTests(unittest.TestCase):
         _, failures, _ = analyzer.analyze({"cases": cases})
         self.assertTrue(any("correctness regressed" in failure for failure in failures))
         self.assertTrue(any("input_tokens regressed" in failure for failure in failures))
+
+    def test_rejects_equivalent_failure_warning_on_control(self):
+        cases = focused_cases() + control_cases()
+        for item in cases:
+            if (
+                item["sample"] == "distinct-failures-control"
+                and item["params"]["binary"] == "candidate"
+            ):
+                item["transcript"]["metrics"]["equivalent_failure_warnings"] = 1
+        _, failures, _ = analyzer.analyze({"cases": cases})
+        self.assertTrue(
+            any("semantic failure repair warned on a control" in failure for failure in failures)
+        )
 
     def test_rejects_three_trial_controls(self):
         cases = focused_cases() + control_cases(trials=3)

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,20 @@
 # Knowledge Log
 
+## 2026-08-24, Equivalent failures require a different action
+
+- [Progress guard](specs/progress-guard.md): rewritten invocations no longer
+  count as progress when structured diagnostics show the same missing command,
+  wrong path, usage mistake, or invocation failure on unchanged workspace
+  state. The second equivalent failure warns, and the next call through the
+  same tool is removed from the model-visible surface and blocked until a
+  different tool/action or checkpoint is used.
+- Failure evidence stays intact and the classifier is narrow. A nonzero exit is
+  not itself misuse, and an initially failing test remains normal diagnostic
+  evidence for a fix and revalidation cycle.
+- Everruns already exposes the authoritative call and structured result to
+  Yolop's pre-tool and post-tool hooks, so ownership remains in the Yolop host
+  capability and no runtime dependency change is needed.
+
 ## 2026-08-24, A required checkpoint changes the next tool surface
 
 - [Progress guard](specs/progress-guard.md): the checkpoint-required warning is

--- a/knowledge/specs/progress-guard.md
+++ b/knowledge/specs/progress-guard.md
@@ -14,13 +14,23 @@ Long read/search trajectories remain legitimate when each call answers a new
 question. The guard intervenes when the trajectory stops changing state: exact
 evidence repeats, validations rerun against the same workspace, investigation
 crosses its budget without mutation or validation, or external-event probes
-become polling.
+become polling. It also classifies bounded command and tool diagnostics for
+invocation, missing-command, wrong-path, and usage failures. Two consecutive
+equivalent failures on unchanged workspace state trigger a transition away from
+the same tool path, even when the command text or target path was rewritten.
 
 Warnings are transition notices, not recurring reminders. Each warning fires
 once for its relevant unchanged state. An exact repeated read or search still
 returns a compact content-addressed freshness marker on every repeat, but only
 the first marker for those bytes carries the warning. New result bytes create a
 new evidence state.
+
+Failure classification is deliberately narrow. The guard retains the original
+result and adds its transition warning beside it, so evidence is never hidden.
+Arbitrary nonzero exits are not classified as misuse. In particular, an
+initially failing test is useful diagnostic evidence and remains available for
+the normal edit and validation loop. A success, a different failure class, or a
+workspace mutation breaks the consecutive-failure streak.
 
 ## Checkpoint transition
 
@@ -53,6 +63,13 @@ backstop for a stale or provider-invented call. A final answer needs no tool, so
 the agent can still report a complete read-only diagnosis instead of
 manufacturing a change.
 
+After an equivalent failure warning, the pre-tool gate rejects another call
+through the same tool, and the next provider-visible tool list omits that tool,
+until the agent takes a different tool/action or submits `progress_checkpoint`.
+A failure-recovery checkpoint is accepted even when the long-exploration
+checkpoint is not active. This makes the transition enforceable without
+replaying, suppressing, or changing the failed invocation.
+
 ## State and reset boundaries
 
 Mutation resets exploration, repeated-evidence reuse, checkpoint, and
@@ -73,9 +90,10 @@ state instead of applying it to an earlier trajectory.
 
 This is Yolop host behavior: the capability composes Everruns' existing
 per-reason tool-definition transform with its pre-tool and post-tool hooks. The
-runtime already rebuilds that provider-visible list on every reasoning step, so
-the transition needs no competing runtime loop or `everruns-*` dependency
-change.
+runtime rebuilds the provider-visible list on every reasoning step, and the
+hooks expose the authoritative call and structured result before the next
+invocation. Both transitions therefore stay in the host capability without a
+competing runtime loop or `everruns-*` dependency change.
 
 ## Evidence
 
@@ -85,4 +103,7 @@ warning-once behavior, checkpoint-only gating of blocked paths, checkpoint
 acceptance, and resumed exploration. A deterministic advisory-only
 baseline/candidate study requires at least 50% fewer calls and result bytes with
 the same completed diagnosis. Mutation, validation, long read-only diagnosis,
-and persisted-session boundaries have focused negative-path tests.
+persisted-session boundaries, expected diagnostic failures, distinct failure
+classes, forced recovery, and checkpoint recovery have focused negative-path
+tests. The harness study compares the equivalent-failure loop over three trials
+per binary and runs five-trial diagnostic and distinct-failure controls.

--- a/src/capabilities/progress_guard.rs
+++ b/src/capabilities/progress_guard.rs
@@ -37,6 +37,7 @@ const WAITING_WINDOW_THRESHOLD: usize = 4;
 const SEMANTIC_HISTORY_LIMIT: usize = 512;
 const TRACKED_PATH_LIMIT: usize = 1024;
 const MIN_REUSABLE_RESULT_BYTES: usize = 512;
+const FAILURE_DIAGNOSTIC_LIMIT: usize = 4096;
 const SESSION_STATE_LIMIT: usize = 32;
 const STORED_STATE_VERSION: u8 = 1;
 
@@ -78,7 +79,7 @@ impl Capability for ProgressGuardCapability {
     }
 
     fn description(&self) -> &str {
-        "Compacts unchanged evidence and requires a structured checkpoint when investigation stops making progress."
+        "Compacts unchanged evidence and forces a different action or checkpoint when investigation or equivalent failures stop making progress."
     }
 
     fn status(&self) -> CapabilityStatus {
@@ -100,7 +101,7 @@ impl Capability for ProgressGuardCapability {
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
-            "<capability id=\"progress_guard\">\nWarns on investigation without progress.\n</capability>"
+            "<capability id=\"progress_guard\">\nWarns and gates investigation or equivalent failures without progress.\n</capability>"
                 .to_string(),
         )
     }
@@ -155,6 +156,7 @@ impl ProgressGuardState {
 }
 
 #[derive(Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
 struct SessionProgress {
     tool_count: usize,
     exploration_since_progress: usize,
@@ -191,6 +193,11 @@ struct SessionProgress {
     warned_status_commands: HashSet<String>,
     recent_checkpoints: VecDeque<String>,
     seen_checkpoints: HashSet<String>,
+    last_failure: Option<FailureFingerprint>,
+    consecutive_equivalent_failures: usize,
+    failure_gate: Option<FailureGate>,
+    recent_warned_failures: VecDeque<FailureFingerprint>,
+    warned_failures: HashSet<FailureFingerprint>,
 }
 
 impl SessionProgress {
@@ -200,6 +207,10 @@ impl SessionProgress {
             self.observe_checkpoint(tool_call, result);
             return None;
         }
+        if let Some(class) = classify_semantic_failure(result) {
+            return self.observe_failure(tool_call, class);
+        }
+        self.reset_failure_streak();
         let class = classify_tool_call(tool_call);
 
         match class {
@@ -299,7 +310,8 @@ impl SessionProgress {
         if result.error.is_some() {
             return;
         }
-        if !self.checkpoint_required {
+        let failure_recovery = self.failure_gate.is_some();
+        if !self.checkpoint_required && !failure_recovery {
             reject_checkpoint(result, "no progress checkpoint is currently required");
             return;
         }
@@ -318,12 +330,61 @@ impl SessionProgress {
         );
         self.checkpoint_count += 1;
         self.checkpoint_required = false;
+        self.failure_gate = None;
+        self.reset_failure_streak();
         self.reset_activity_streaks();
         result.result = Some(json!({
             "accepted": true,
             "exploration_resumed": true,
-            "message": "checkpoint accepted; execute the stated decisive action or gather only evidence that tests it"
+            "message": if failure_recovery {
+                "failure-recovery checkpoint accepted; execute a materially different action that addresses the classified root failure"
+            } else {
+                "checkpoint accepted; execute the stated decisive action or gather only evidence that tests it"
+            }
         }));
+    }
+
+    fn observe_failure(
+        &mut self,
+        tool_call: &ToolCall,
+        class: SemanticFailureClass,
+    ) -> Option<String> {
+        let fingerprint = FailureFingerprint {
+            workspace_state: self.validation_state_signature(),
+            class,
+        };
+        if self.last_failure.as_ref() == Some(&fingerprint) {
+            self.consecutive_equivalent_failures += 1;
+        } else {
+            self.last_failure = Some(fingerprint.clone());
+            self.consecutive_equivalent_failures = 1;
+        }
+        if self.consecutive_equivalent_failures < 2 {
+            return None;
+        }
+
+        self.failure_gate = Some(FailureGate {
+            source_tool: tool_call.name.clone(),
+            fingerprint: fingerprint.clone(),
+        });
+        if self.warned_failures.contains(&fingerprint) {
+            return None;
+        }
+        remember_bounded(
+            &mut self.warned_failures,
+            &mut self.recent_warned_failures,
+            fingerprint,
+        );
+        self.warning_count += 1;
+        Some(format!(
+            "progress_guard: repeated an equivalent {} failure on an unchanged workspace state. The full failure evidence remains above. Do not rewrite and retry the same invocation path: use a materially different tool/action that addresses the root cause, or call progress_checkpoint before another attempt.",
+            class.label()
+        ))
+    }
+
+    fn reset_failure_streak(&mut self) {
+        self.last_failure = None;
+        self.consecutive_equivalent_failures = 0;
     }
 
     fn observe_mutation(&mut self, tool_call: &ToolCall, result: &ToolResult) -> Option<String> {
@@ -341,6 +402,10 @@ impl SessionProgress {
         self.warned_observation_hashes.clear();
         self.seen_checkpoints.clear();
         self.recent_checkpoints.clear();
+        self.failure_gate = None;
+        self.reset_failure_streak();
+        self.warned_failures.clear();
+        self.recent_warned_failures.clear();
 
         let Some(transition) = mutation_hash_transition(tool_call, result) else {
             // Shell, delete, and structural edits can touch an unknown set of
@@ -681,23 +746,34 @@ struct ProgressGuardToolGate {
 
 impl ToolDefinitionHook for ProgressGuardToolGate {
     fn transform(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
-        let checkpoint_required = self
+        let (checkpoint_required, failed_tool) = self
             .state
             .lock()
             .expect("progress guard state poisoned")
             .sessions
             .get(&self.session_id)
-            .is_some_and(|progress| progress.checkpoint_required);
-        if !checkpoint_required {
+            .map(|progress| {
+                (
+                    progress.checkpoint_required,
+                    progress
+                        .failure_gate
+                        .as_ref()
+                        .map(|gate| gate.source_tool.clone()),
+                )
+            })
+            .unwrap_or_default();
+        if !checkpoint_required && failed_tool.is_none() {
             return tools;
         }
         tools
             .into_iter()
             .filter(|tool| {
-                !matches!(
-                    static_tool_class(tool.name()),
-                    Some(ToolClass::Exploration | ToolClass::Waiting)
-                )
+                failed_tool.as_deref() != Some(tool.name())
+                    && (!checkpoint_required
+                        || !matches!(
+                            static_tool_class(tool.name()),
+                            Some(ToolClass::Exploration | ToolClass::Waiting)
+                        ))
             })
             .collect()
     }
@@ -714,19 +790,29 @@ impl PreToolUseHook for ProgressGuardGate {
         if tool_call.name == PROGRESS_CHECKPOINT_TOOL {
             return PreToolUseDecision::Continue(tool_call);
         }
-        let blocked = self
-            .state
-            .lock()
-            .expect("progress guard state poisoned")
-            .sessions
-            .get(&context.session_id.to_string())
-            .is_some_and(|progress| {
-                progress.checkpoint_required
-                    && matches!(
-                        classify_tool_call(&tool_call),
-                        ToolClass::Exploration | ToolClass::Status(_) | ToolClass::Waiting
-                    )
-            });
+        let mut state = self.state.lock().expect("progress guard state poisoned");
+        let Some(progress) = state.sessions.get_mut(&context.session_id.to_string()) else {
+            return PreToolUseDecision::Continue(tool_call);
+        };
+        if let Some(failure_gate) = &progress.failure_gate {
+            if failure_gate.source_tool == tool_call.name {
+                return PreToolUseDecision::Block {
+                    reason: format!(
+                        "equivalent {} failure repeated on unchanged state: use a different tool/action or call progress_checkpoint before retrying {}",
+                        failure_gate.fingerprint.class.label(),
+                        tool_call.name
+                    ),
+                    user_message: None,
+                    tool_call,
+                };
+            }
+            progress.failure_gate = None;
+        }
+        let blocked = progress.checkpoint_required
+            && matches!(
+                classify_tool_call(&tool_call),
+                ToolClass::Exploration | ToolClass::Status(_) | ToolClass::Waiting
+            );
         if blocked {
             PreToolUseDecision::Block {
                 reason: "progress checkpoint required: call progress_checkpoint with facts, hypothesis, missing_evidence, and next_decisive_action before more exploration"
@@ -1006,6 +1092,135 @@ fn exploration_evidence(tool_call: &ToolCall, result: &ToolResult) -> Option<Exp
     })
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SemanticFailureClass {
+    Invocation,
+    MissingCommand,
+    WrongPath,
+    Usage,
+}
+
+impl SemanticFailureClass {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Invocation => "invocation",
+            Self::MissingCommand => "missing-command",
+            Self::WrongPath => "wrong-path",
+            Self::Usage => "usage",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+struct FailureFingerprint {
+    workspace_state: u64,
+    class: SemanticFailureClass,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct FailureGate {
+    source_tool: String,
+    fingerprint: FailureFingerprint,
+}
+
+fn classify_semantic_failure(result: &ToolResult) -> Option<SemanticFailureClass> {
+    let value = result.result.as_ref();
+    let structured_failure = value
+        .and_then(|value| value.get("success"))
+        .and_then(Value::as_bool)
+        == Some(false);
+    if result.error.is_none() && !structured_failure {
+        return None;
+    }
+
+    let diagnostic = bounded_failure_diagnostic(result).to_ascii_lowercase();
+    let exit_code = value
+        .and_then(|value| value.get("exit_code"))
+        .and_then(Value::as_i64);
+    if diagnostic.contains("command not found")
+        || diagnostic.contains("not recognized as an internal or external command")
+        || (exit_code == Some(127) && diagnostic.contains("not found"))
+    {
+        return Some(SemanticFailureClass::MissingCommand);
+    }
+    if [
+        "no such file or directory",
+        "cannot find the path specified",
+        "could not find a part of the path",
+        "can't cd to",
+        "cannot cd to",
+    ]
+    .iter()
+    .any(|pattern| diagnostic.contains(pattern))
+    {
+        return Some(SemanticFailureClass::WrongPath);
+    }
+    if [
+        "usage:",
+        "unknown option",
+        "unrecognized option",
+        "unexpected argument",
+        "invalid option",
+        "requires an argument",
+        "missing required argument",
+        "the following required arguments were not provided",
+    ]
+    .iter()
+    .any(|pattern| diagnostic.contains(pattern))
+    {
+        return Some(SemanticFailureClass::Usage);
+    }
+    if exit_code == Some(126)
+        || [
+            "spawn failed",
+            "sandbox setup failed",
+            "failed to execute",
+            "could not execute",
+            "exec format error",
+        ]
+        .iter()
+        .any(|pattern| diagnostic.contains(pattern))
+    {
+        return Some(SemanticFailureClass::Invocation);
+    }
+    None
+}
+
+fn bounded_failure_diagnostic(result: &ToolResult) -> String {
+    let mut diagnostic = String::new();
+    if let Some(error) = &result.error {
+        append_bounded_diagnostic(&mut diagnostic, error);
+    }
+    for field in ["stderr", "stdout", "message"] {
+        let Some(text) = result
+            .result
+            .as_ref()
+            .and_then(|value| value.get(field))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        if !diagnostic.is_empty() {
+            append_bounded_diagnostic(&mut diagnostic, "\n");
+        }
+        append_bounded_diagnostic(&mut diagnostic, text);
+    }
+    diagnostic
+}
+
+fn append_bounded_diagnostic(diagnostic: &mut String, text: &str) {
+    let remaining = FAILURE_DIAGNOSTIC_LIMIT.saturating_sub(diagnostic.len());
+    if remaining == 0 {
+        return;
+    }
+    let mut end = remaining.min(text.len());
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    diagnostic.push_str(&text[..end]);
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum ToolClass {
     Exploration,
@@ -1102,6 +1317,15 @@ fn mutation_hash_transition(
 }
 
 fn mutation_was_applied(tool_call: &ToolCall, result: &ToolResult) -> bool {
+    if result
+        .result
+        .as_ref()
+        .and_then(|value| value.get("success"))
+        .and_then(Value::as_bool)
+        == Some(false)
+    {
+        return false;
+    }
     if tool_call.name == "ast_edit" {
         return result
             .result
@@ -1331,6 +1555,23 @@ mod tests {
     fn result_value(value: Value) -> ToolResult {
         ToolResult {
             result: Some(value),
+            ..result()
+        }
+    }
+
+    fn failed_bash_result(exit_code: i32, stderr: &str) -> ToolResult {
+        result_value(json!({
+            "exit_code": exit_code,
+            "success": false,
+            "stdout": "",
+            "stderr": stderr,
+        }))
+    }
+
+    fn tool_error_result(error: &str) -> ToolResult {
+        ToolResult {
+            result: None,
+            error: Some(error.to_string()),
             ..result()
         }
     }
@@ -1783,6 +2024,22 @@ mod tests {
         }
         assert_eq!(progress.observation_hashes.len(), SEMANTIC_HISTORY_LIMIT);
         assert_eq!(progress.recent_observations.len(), SEMANTIC_HISTORY_LIMIT);
+
+        for index in 0..(SEMANTIC_HISTORY_LIMIT * 2) {
+            remember_bounded(
+                &mut progress.warned_failures,
+                &mut progress.recent_warned_failures,
+                FailureFingerprint {
+                    workspace_state: index as u64,
+                    class: SemanticFailureClass::WrongPath,
+                },
+            );
+        }
+        assert_eq!(progress.warned_failures.len(), SEMANTIC_HISTORY_LIMIT);
+        assert_eq!(
+            progress.recent_warned_failures.len(),
+            SEMANTIC_HISTORY_LIMIT
+        );
     }
 
     #[tokio::test]
@@ -1860,6 +2117,324 @@ mod tests {
         );
         // `sleepwalk` must not parse as a sleep prefix.
         assert_eq!(classify_bash_command("sleepwalk"), ToolClass::Other);
+    }
+
+    #[tokio::test]
+    async fn repeated_equivalent_missing_commands_force_a_different_action() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook {
+            state: state.clone(),
+        };
+        let gate = ProgressGuardGate {
+            state: state.clone(),
+        };
+        let context = ToolContext::new(SessionId::new());
+        let tool_gate = ProgressGuardToolGate {
+            state,
+            session_id: context.session_id.to_string(),
+        };
+
+        for (command, executable) in [("rg needle .", "rg"), ("ag needle .", "ag")] {
+            let mut failed = result_value(json!({
+                "command": command,
+                "exit_code": 127,
+                "success": false,
+                "stdout": "",
+                "stderr": format!("bash: {executable}: command not found"),
+            }));
+            hook.after_exec(
+                &call("bash", json!({ "command": command })),
+                &tool_def("bash"),
+                &mut failed,
+                &context,
+            )
+            .await;
+
+            if executable == "ag" {
+                assert!(
+                    failed
+                        .result
+                        .as_ref()
+                        .and_then(|value| value.get("progress_guard_warning"))
+                        .and_then(Value::as_str)
+                        .is_some_and(|warning| {
+                            warning.contains("equivalent missing-command failure")
+                        }),
+                    "the rewritten command should be recognized as the same root failure: {failed:?}"
+                );
+            }
+        }
+
+        let visible_tools = tool_gate.transform(vec![
+            tool_def("bash"),
+            tool_def("grep_files"),
+            tool_def(PROGRESS_CHECKPOINT_TOOL),
+        ]);
+        assert_eq!(
+            visible_tools
+                .iter()
+                .map(|tool| tool.name())
+                .collect::<Vec<_>>(),
+            ["grep_files", PROGRESS_CHECKPOINT_TOOL],
+            "the next model round should expose recovery paths but not the failed tool"
+        );
+        assert!(matches!(
+            gate.before_exec(
+                call("bash", json!({ "command": "grep -R needle ." })),
+                &tool_def("bash"),
+                &context,
+            )
+            .await,
+            PreToolUseDecision::Block { .. }
+        ));
+        assert!(matches!(
+            gate.before_exec(
+                call("grep_files", json!({ "pattern": "needle" })),
+                &tool_def("grep_files"),
+                &context,
+            )
+            .await,
+            PreToolUseDecision::Continue(_)
+        ));
+    }
+
+    #[test]
+    fn semantic_failure_classification_is_structured_and_conservative() {
+        let cases = [
+            (
+                failed_bash_result(127, "bash: rg: command not found"),
+                Some(SemanticFailureClass::MissingCommand),
+            ),
+            (
+                failed_bash_result(1, "cat: src/missing.rs: No such file or directory"),
+                Some(SemanticFailureClass::WrongPath),
+            ),
+            (
+                failed_bash_result(2, "error: unexpected argument '--bogus'\nUsage: cargo test"),
+                Some(SemanticFailureClass::Usage),
+            ),
+            (
+                tool_error_result("spawn failed: exec format error"),
+                Some(SemanticFailureClass::Invocation),
+            ),
+            (
+                failed_bash_result(101, "test result: FAILED. 1 failed; 3 passed"),
+                None,
+            ),
+            (
+                failed_bash_result(1, "assertion failed: expected 2, received 3"),
+                None,
+            ),
+        ];
+
+        for (result, expected) in cases {
+            assert_eq!(classify_semantic_failure(&result), expected, "{result:?}");
+        }
+    }
+
+    #[test]
+    fn failure_diagnostics_are_bounded_without_splitting_utf8() {
+        let oversized = "é".repeat(FAILURE_DIAGNOSTIC_LIMIT);
+        let diagnostic = bounded_failure_diagnostic(&ToolResult {
+            result: Some(json!({ "stderr": oversized })),
+            error: Some("x".repeat(FAILURE_DIAGNOSTIC_LIMIT)),
+            ..result()
+        });
+        assert_eq!(diagnostic.len(), FAILURE_DIAGNOSTIC_LIMIT);
+        assert!(diagnostic.chars().all(|character| character == 'x'));
+
+        let unicode_only = bounded_failure_diagnostic(&failed_bash_result(2, &oversized));
+        assert!(unicode_only.len() <= FAILURE_DIAGNOSTIC_LIMIT);
+        assert!(unicode_only.is_char_boundary(unicode_only.len()));
+    }
+
+    #[test]
+    fn every_supported_failure_class_fingerprints_equivalent_rewrites() {
+        let cases = [
+            (
+                failed_bash_result(126, "failed to execute probe-one"),
+                failed_bash_result(126, "failed to execute probe-two"),
+                "invocation",
+            ),
+            (
+                failed_bash_result(127, "bash: rg: command not found"),
+                failed_bash_result(127, "bash: ag: command not found"),
+                "missing-command",
+            ),
+            (
+                tool_error_result("read failed for old/a: No such file or directory"),
+                tool_error_result("read failed for old/b: No such file or directory"),
+                "wrong-path",
+            ),
+            (
+                failed_bash_result(2, "usage: probe-one ARG"),
+                failed_bash_result(2, "usage: probe-two ARG"),
+                "usage",
+            ),
+        ];
+
+        for (mut first, mut second, label) in cases {
+            let mut progress = SessionProgress::default();
+            let first_warning = progress.observe(
+                &call("bash", json!({ "command": format!("{label}-one") })),
+                &mut first,
+            );
+            let second_warning = progress.observe(
+                &call("bash", json!({ "command": format!("{label}-two") })),
+                &mut second,
+            );
+            assert!(first_warning.is_none());
+            assert!(
+                second_warning.is_some_and(|warning| warning.contains(label)),
+                "{label} rewrites should share one semantic fingerprint"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn expected_diagnostic_test_failures_do_not_warn_or_gate_validation() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook {
+            state: state.clone(),
+        };
+        let gate = ProgressGuardGate { state };
+        let context = ToolContext::new(SessionId::new());
+        let test = call("bash", json!({ "command": "cargo test" }));
+
+        let mut failed = failed_bash_result(
+            101,
+            "failures:\n    tests::reproduces_bug\ntest result: FAILED. 1 failed",
+        );
+        hook.after_exec(&test, &tool_def("bash"), &mut failed, &context)
+            .await;
+        assert!(
+            failed
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_none(),
+            "an initially failing test is code evidence, not command misuse"
+        );
+        assert!(matches!(
+            gate.before_exec(test.clone(), &tool_def("bash"), &context)
+                .await,
+            PreToolUseDecision::Continue(_)
+        ));
+
+        let mut edit = result_value(json!({
+            "path": "/workspace/src/lib.rs",
+            "previous_content_hash": "before",
+            "content_hash": "after",
+        }));
+        hook.after_exec(
+            &call("edit_file", json!({ "path": "/workspace/src/lib.rs" })),
+            &tool_def("edit_file"),
+            &mut edit,
+            &context,
+        )
+        .await;
+        let mut diagnostic_after_edit = failed_bash_result(
+            101,
+            "failures:\n    tests::another_bug\ntest result: FAILED. 1 failed",
+        );
+        hook.after_exec(
+            &test,
+            &tool_def("bash"),
+            &mut diagnostic_after_edit,
+            &context,
+        )
+        .await;
+        assert!(
+            diagnostic_after_edit
+                .result
+                .as_ref()
+                .and_then(|value| value.get("progress_guard_warning"))
+                .is_none(),
+            "a new failing test after mutation is fresh diagnostic evidence"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_failure_classes_and_success_break_the_equivalence_streak() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook { state };
+        let context = ToolContext::new(SessionId::new());
+        let observations = [
+            failed_bash_result(127, "bash: rg: command not found"),
+            failed_bash_result(1, "cat: absent: No such file or directory"),
+            result(),
+            failed_bash_result(127, "bash: ag: command not found"),
+        ];
+
+        for (index, mut observed) in observations.into_iter().enumerate() {
+            hook.after_exec(
+                &call("bash", json!({ "command": format!("probe-{index}") })),
+                &tool_def("bash"),
+                &mut observed,
+                &context,
+            )
+            .await;
+            assert!(
+                observed
+                    .result
+                    .as_ref()
+                    .and_then(|value| value.get("progress_guard_warning"))
+                    .is_none(),
+                "different evidence must not create an equivalent-failure warning"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_wrong_path_can_recover_through_a_checkpoint() {
+        let state = Arc::new(Mutex::new(ProgressGuardState::default()));
+        let hook = ProgressGuardHook {
+            state: state.clone(),
+        };
+        let gate = ProgressGuardGate { state };
+        let context = ToolContext::new(SessionId::new());
+
+        for path in ["src/old.rs", "lib/old.rs"] {
+            let mut failed = tool_error_result(&format!(
+                "read failed for {path}: No such file or directory"
+            ));
+            hook.after_exec(
+                &call("read_file", json!({ "path": path })),
+                &tool_def("read_file"),
+                &mut failed,
+                &context,
+            )
+            .await;
+        }
+        assert!(matches!(
+            gate.before_exec(
+                call("read_file", json!({ "path": "src/third.rs" })),
+                &tool_def("read_file"),
+                &context,
+            )
+            .await,
+            PreToolUseDecision::Block { .. }
+        ));
+
+        let arguments = checkpoint_arguments("wrong path recovery");
+        let mut checkpoint = result_value(json!({ "submitted": true }));
+        hook.after_exec(
+            &call(PROGRESS_CHECKPOINT_TOOL, arguments),
+            &tool_def(PROGRESS_CHECKPOINT_TOOL),
+            &mut checkpoint,
+            &context,
+        )
+        .await;
+        assert_eq!(checkpoint.result.unwrap()["accepted"], true);
+        assert!(matches!(
+            gate.before_exec(
+                call("read_file", json!({ "path": "src/verified.rs" })),
+                &tool_def("read_file"),
+                &context,
+            )
+            .await,
+            PreToolUseDecision::Continue(_)
+        ));
     }
 
     #[tokio::test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5737,6 +5737,116 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn real_tool_hooks_repair_an_equivalent_failure_loop() {
+        use everruns_core::EventData;
+        use everruns_llmsim::{SimToolCall, SimTurn};
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::create_dir_all(workspace.path().join("src")).expect("create src");
+        std::fs::write(
+            workspace.path().join("src/answer.txt"),
+            "SEMANTIC_RECOVERY=FOUND\n",
+        )
+        .expect("seed answer");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let scripted_call = |name: &str, arguments| {
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: name.to_string(),
+                arguments,
+                id: None,
+            }])
+        };
+        let options = BuildOptions {
+            llmsim_override: Some(LlmSimConfig::scripted(vec![
+                scripted_call(
+                    "bash",
+                    serde_json::json!({ "command": "missing_search_one SEMANTIC_RECOVERY ." }),
+                ),
+                scripted_call(
+                    "bash",
+                    serde_json::json!({ "command": "missing_search_two SEMANTIC_RECOVERY ." }),
+                ),
+                scripted_call(
+                    "bash",
+                    serde_json::json!({ "command": "grep -R SEMANTIC_RECOVERY ." }),
+                ),
+                scripted_call(
+                    "grep_files",
+                    serde_json::json!({ "pattern": "SEMANTIC_RECOVERY", "path_pattern": "src/**" }),
+                ),
+                SimTurn::Assistant("FOUND".to_string()),
+            ])),
+            ..BuildOptions::default()
+        };
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::Sim,
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            options,
+        )
+        .await
+        .expect("build runtime");
+
+        let result = built
+            .handles
+            .run_checkpointed_turn(
+                "Recover from equivalent missing search commands.",
+                built
+                    .model
+                    .input_message("Recover from equivalent missing search commands."),
+            )
+            .await
+            .expect("run guarded trajectory");
+        assert!(result.success, "guarded trajectory: {result:?}");
+
+        let events = built
+            .handles
+            .runtime
+            .events()
+            .await
+            .expect("runtime events");
+        let completed = events
+            .iter()
+            .filter_map(|event| match &event.data {
+                EventData::ToolCompleted(data) => Some(data),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(completed.iter().any(|data| {
+            data.tool_name == "bash"
+                && crate::tui::transcript::result_value(data).is_some_and(|value| {
+                    value
+                        .get("progress_guard_warning")
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|warning| warning.contains("equivalent missing-command"))
+                })
+        }));
+        let bash_results = completed
+            .iter()
+            .filter(|data| data.tool_name == "bash")
+            .collect::<Vec<_>>();
+        assert!(
+            bash_results.last().is_some_and(|data| {
+                !data.success
+                    && data
+                        .error
+                        .as_deref()
+                        .is_some_and(|error| error == "Tool definition not found: bash")
+            }),
+            "the scripted stale retry should prove bash was absent from the next model-visible surface: {bash_results:?}"
+        );
+        assert!(completed.iter().any(|data| {
+            data.tool_name == "grep_files"
+                && data.success
+                && crate::tui::transcript::result_value(data)
+                    .is_some_and(|value| value.to_string().contains("SEMANTIC_RECOVERY"))
+        }));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn real_turn_exposes_model_runtime_context_without_persisting_it() {
         let workspace = tempfile::tempdir().expect("workspace");
         let sessions = tempfile::tempdir().expect("sessions");


### PR DESCRIPTION
## What changed

Yolop now recognizes consecutive equivalent invocation, missing-command, wrong-path, and usage failures on an unchanged workspace. The second equivalent failure keeps the original evidence visible, adds a structured progress warning, removes the failing tool from the next model-visible surface, and requires a different tool/action or a bounded progress checkpoint before the same tool can be tried again. The pre-tool hook also blocks stale or concurrent retries as defense in depth.

The classifier is deliberately narrow. Arbitrary nonzero exits, including an initially failing test used to reproduce a bug, remain ordinary diagnostic evidence. Failure state, diagnostics, and warning history are bounded, and successful work or a workspace mutation resets the streak.

The harness now covers equivalent-failure recovery, calls after warning, blocked retry detection, expected diagnostic failures, and distinct failure classes. Progress/search efficiency presets and analyzers include the new cases.

## Why

Agents could rewrite a command or path repeatedly while every variant failed for the same root reason on unchanged state. Text-only deduplication treated each rewrite as new progress and allowed avoidable loops.

## Before / After

Live `openai/gpt-5.5` A/B through Doppler, three focused trials per binary:

```text
                               baseline   candidate
recovery pass rate                2/3        3/3
median task/tool calls              5          4
median failed calls                 3          2
median equivalent warnings          0          1
median calls after warning           -          1
median blocked retries               -          0
```

Focused run: `20260825T004828Z-9e96`.

The five-trial controls passed 20/20 across baseline and candidate with zero candidate equivalent-failure warnings and zero blocked retries. Control run: `20260825T004854Z-cb4c`.

## Risk

- Low
- A diagnostic containing one of the four narrow signatures could cause a recovery warning after two consecutive same-class failures. The guard preserves the complete result, requires unchanged workspace state, resets on success, mutation, or a different class, and has focused false-positive controls.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema -- --skip runtime::tests::cold_start_prompt_composition_is_measured_by_component`: 1,382 passed
- `cargo test -p yolop capabilities::progress_guard --features yolop-yep/schema`: 43 passed
- real llmsim hook recovery test passed
- harness Rust tests: 35 passed
- harness analyzer tests: 25 passed
- harness clippy passed
- `python3 scripts/validate_okf.py knowledge --check-links`: 42 concepts, 0 errors
- live focused and control A/B runs above

The one excluded local assertion reports `14102 > 12888` on both this branch and untouched commit `5a3fde1`; the exact main commit passed repository CI. The change does not increase that measured prompt size.

A post-rebase refresh attempt, run `20260825T012933Z-35bc`, was inconclusive because the shared OpenAI account reported `credit_balance_exhausted` before any arm consumed tokens or called tools. The valid pre-rebase study remains the cited behavioral evidence; deterministic exact-commit coverage verifies the rebased provider-visible transition.

## Knowledge

Updated `progress-guard` and the knowledge log with the failure classes, reset and enforcement behavior, evidence-preservation policy, evaluation contract, and ownership decision. Everruns already exposes the authoritative pre-tool call and post-tool structured result, so no upstream change or dependency bump is required.

## Security

- TM-FS: no path resolution, write policy, or blocklist changes. Persisted failure state contains only a semantic class, workspace signature, and bounded tool name.
- TM-BASH: no execution, retry, timeout, or output-cap changes. Failed commands are neither replayed nor suppressed, and their complete results remain visible.
- TM-LLM: warnings contain only fixed class labels, never command arguments, diagnostics, environment values, or credentials. Diagnostic inspection is capped at 4 KiB during collection and discarded after classification.
- TM-TOOL: no new capability or privileged tool. The existing per-reason tool-definition transform removes only the failed tool for the active session, and the existing progress checkpoint is reused as an explicit recovery transition.
- TM-DEP: no dependency changes.
- Resource review: failure diagnostics are capped at 4 KiB, warning history at 512 fingerprints, and session state at 32 sessions. No unbounded loop or new trust-boundary input is introduced.

No security issues found.

## Follow-ups

No follow-ups.
