### PR TITLE
fix(exec): avoid redundant output recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
 dependencies = [
- "quote 1.0.47",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -260,8 +260,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -437,8 +437,8 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -454,8 +454,8 @@ version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -730,9 +730,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.5.0",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -816,8 +816,8 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -861,8 +861,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9225bdcf4e4a9a4c08bf16607908eb2fbf746828d5e0b5e019726dbf6571f201"
 dependencies = [
  "darling 0.20.11",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -1002,8 +1002,8 @@ checksum = "b5ef80386dea3cda50570f22e1c6a474f0cc688ae220fc584fef354acaf41f2b"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "regex",
  "vob",
 ]
@@ -1079,8 +1079,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -1208,15 +1208,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "convert_case"
@@ -1419,20 +1410,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
- "cssparser-macros 0.6.1",
- "dtoa-short",
- "itoa",
- "phf 0.13.1",
- "smallvec 1.15.2",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
-dependencies = [
- "cssparser-macros 0.7.0",
+ "cssparser-macros",
  "dtoa-short",
  "itoa",
  "phf 0.13.1",
@@ -1445,17 +1423,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
- "quote 1.0.47",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
-dependencies = [
- "quote 1.0.47",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -1559,8 +1527,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -1602,8 +1570,8 @@ checksum = "06e172685d94b7b83800e3256a63261537b9d6129e10f21c8e13ddf9dba8c64d"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1616,8 +1584,8 @@ checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "strsim 0.11.1",
  "syn 2.0.119",
 ]
@@ -1629,8 +1597,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
  "ident_case",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "strsim 0.11.1",
  "syn 2.0.119",
 ]
@@ -1642,7 +1610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0618ac802792cebd1918ac6042a6ea1eeab92db34b35656afaa577929820788"
 dependencies = [
  "darling_core 0.11.0",
- "quote 1.0.47",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1653,7 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote 1.0.47",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -1664,7 +1632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
- "quote 1.0.47",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -1720,8 +1688,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -1741,8 +1709,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling 0.20.11",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -1771,12 +1739,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 2.0.119",
- "unicode-xid 0.2.6",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1858,32 +1826,9 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "dlopen"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e80ad39f814a9abe68583cd50a2d45c8a67561c3361ab8da240587dda80937"
-dependencies = [
- "dlopen_derive",
- "lazy_static",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "dlopen_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f236d9e1b1fbd81cea0f9cbdc8dcc7e8ebcd80e6659cd7cb2ad5f6c05946c581"
-dependencies = [
- "libc",
- "quote 0.6.13",
- "syn 0.15.44",
 ]
 
 [[package]]
@@ -2006,12 +1951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
-name = "ego-tree"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
-
-[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,8 +2005,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -2086,8 +2025,8 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -2112,8 +2051,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -2187,22 +2126,21 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.2"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb2ddfec0b80a4cec8b4db56f186089b116520f98987cedbcd87713bfa49688"
+checksum = "74f2be24e17656162a1131f96e9d57fe8be875a43187e1fc9220827c2984414f"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
  "chrono",
  "chrono-tz",
  "cron",
- "dirs",
  "everruns-capability",
  "everruns-core",
  "everruns-host",
  "everruns-llmsim",
  "everruns-platform",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "futures",
  "libc",
  "parking_lot",
@@ -2218,14 +2156,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d05ac521362f6b95cad7e853c69c6a02a5ee7b2c4c9a3dbacb24827affeeac1"
+checksum = "49aa974de720277edbb2044813f896da2628271d26a28f694c9cf8ab70dd43d2"
 dependencies = [
  "async-trait",
  "chrono",
  "eventsource-stream",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "futures",
  "reqwest 0.13.4",
  "serde",
@@ -2236,15 +2174,15 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d058e7860618183c9e76523af9e47759fb4f8a5ef99d91e6933fb1b854392684"
+checksum = "98ec8fe4c97177f9c355568b07456e412086a7e172341123460a3ba48528f654"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2267,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce9d9ce49a6345bd6c33163ed4cb80b55b49198c6b716c3e2f79a5759db2392"
+checksum = "2b6cb8dd6bcb1f8500338d818d8905c90baae6fcaf2efa0a3d0250417b30c875"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2277,7 +2215,7 @@ dependencies = [
  "chrono",
  "cron",
  "everruns-capability",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "futures",
  "globset",
  "inventory",
@@ -2299,15 +2237,15 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c0f09efd153f2f9d304a9f665cba1897c554d3cfc33bf229ecad45de4d3ff3"
+checksum = "cb8e144c8cc6caf3cbb0c4185ccc3a72f3e1c7f075f110690b9a16d479427a31"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "futures",
  "serde",
  "serde_json",
@@ -2320,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb67cc4e21942a9fc583950e2fa1824fd8d1056f50b65681dac931a3ff7dcef"
+checksum = "d0cf3b8d8e104d6b5b5b69f17ab3135fcd02d7930181b2c7265226954be60ad7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2330,7 +2268,7 @@ dependencies = [
  "everruns-core",
  "everruns-engine",
  "everruns-mcp",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "futures",
  "ignore",
  "regex",
@@ -2352,7 +2290,7 @@ checksum = "e38b07ac8e30d11181c9da9e1ba92757558c136453753e8cd64283b26800e064"
 dependencies = [
  "async-trait",
  "everruns-core",
- "everruns-provider",
+ "everruns-provider 0.18.0",
  "futures",
  "reqwest 0.13.4",
  "serde_json",
@@ -2360,15 +2298,15 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b225771ed74eb1596df5d5b094d81492e2eed432cea44c4ebf5155a646feb95"
+checksum = "cad2763c47184957b435f0e99daff6819c64ebafedf41b9fecf3e811da614d77"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
  "everruns-platform",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "inventory",
  "reqwest 0.13.4",
  "serde",
@@ -2379,14 +2317,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc6dd35f7a30836e7c9edcf4d7cee4125054355ea832b9e31da403a3fc130d4"
+checksum = "0cda5509eced9ce31c481c77bbef61f46aa3c476e66d637147cf27aa9dd0c896"
 dependencies = [
  "async-trait",
  "everruns-capability",
  "everruns-core",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "inventory",
  "reqwest 0.13.4",
  "serde",
@@ -2397,32 +2335,32 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e1a0342b995c6e329f4ba97df885ca1eae7f8b3b3ef053f4da4182d68e8add"
+checksum = "d3ed657a44a28a53367618ff5bb3c98afca2b2713429d6bd2d3e4c3c351c0501"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.23.1",
  "everruns-capability",
  "everruns-core",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "hex",
  "serde_json",
  "sha2 0.11.0",
- "similar 3.1.1",
+ "similar",
 ]
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d5558a810a39bcc20204369fffea7e5fe7d0733355b20922ba26edcce8edb3"
+checksum = "3c91a87d2f0b7b03ad85f81a9f141768aefb2ee448e7eef2f8b2e1d50266b7fc"
 dependencies = [
  "async-trait",
  "everruns-core",
  "everruns-platform",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "inventory",
  "reqwest 0.13.4",
  "serde",
@@ -2431,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-web-fetch"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "768ce7606171f76eadce1edd6683d0eb85b824d4f651b92d8e58072210cd5f7d"
+checksum = "46115a721e0a08a094b8cd53df7eafc29fb12d62654208eb9ba49d300d292a55"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2441,7 +2379,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "everruns-capability",
  "everruns-core",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "fetchkit",
  "futures",
  "serde_json",
@@ -2451,14 +2389,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5599529c280f5244ff2dfab034c0f3ce893d59eff7aa566ba39a363a74a625af"
+checksum = "03b9d96ffcd9b554beb66748d35f8b2433e8b68a65d2bfa9197e4df42e12425a"
 dependencies = [
  "anyhow",
  "async-trait",
  "everruns-host",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "futures",
  "llmsim",
  "serde_json",
@@ -2467,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2e8dbe707e257dfc21c5de789fae47828f521753959f5edf915a1b05163bdb"
+checksum = "f7385572f652b73673ac10386b5544c271b1a9543bab3007e0e6c7e5919cde99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2477,7 +2415,7 @@ dependencies = [
  "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -2492,26 +2430,26 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c868d96acf99ec7cc852350bb39939640b13dfc8de31fc826771d586cc171319"
+checksum = "6c9f2e2f7adedadbbcaa367a90350e74a1aac72008f5784e481cf59c45a902b1"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "reqwest 0.13.4",
  "serde",
 ]
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9930305f0e9774f97ab041f8bf17bbadd2995e144311a6a90d89dee08e3f5f8b"
+checksum = "c6a5217c92a0413fdc7853f598dc3797c72d5932e80b64191249c83483848630"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -2521,13 +2459,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3ccbea01fd9435aac81400e7205d726f81f9c049865f8785f6a7b46c13bcd"
+checksum = "17c287f4c574905b290bcc3dcb50aa9f5dfff7de4aef22c03afae9da88b1ef6a"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -2535,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0f0aa61c82eeedeea36571551cdefe9367c03dc043a6c2602def4e1c28ba2a"
+checksum = "0a2887b79e1211ce45fc0b52e11ade64334af30efccfd1e3e709822d671c5457"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2546,7 +2484,7 @@ dependencies = [
  "everruns-capability",
  "everruns-core",
  "everruns-host",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "inventory",
  "jsonschema",
  "serde",
@@ -2562,6 +2500,30 @@ name = "everruns-provider"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680827ffb10dd7e12a078cbababeea099ad791b9206918b6edf77e8d090defc3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.23.1",
+ "chrono",
+ "futures",
+ "hex",
+ "rand 0.10.2",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid 1.24.0",
+]
+
+[[package]]
+name = "everruns-provider"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b9c4398c122a7eef161ec9cc14ce5c6c65f586609644f6b2a9e5a87302313ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2704,7 +2666,6 @@ dependencies = [
  "futures",
  "libc",
  "percent-encoding",
- "rakers",
  "rand 0.10.2",
  "reqwest 0.13.4",
  "schemars 1.2.2",
@@ -2842,8 +2803,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -2978,8 +2939,8 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -3519,20 +3480,6 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.12.1",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
@@ -3881,8 +3828,8 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3952,8 +3899,8 @@ checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -3963,8 +3910,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -4040,8 +3987,8 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.119",
@@ -4062,7 +4009,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
- "quote 1.0.47",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -4396,20 +4343,6 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
- "tendril 0.4.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
@@ -4443,18 +4376,6 @@ dependencies = [
 
 [[package]]
 name = "markup5ever_rcdom"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
-dependencies = [
- "html5ever 0.27.0",
- "markup5ever 0.12.1",
- "tendril 0.4.3",
- "xml5ever 0.18.1",
-]
-
-[[package]]
-name = "markup5ever_rcdom"
 version = "0.39.0+unofficial"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac010f19d6c4af81eeb4018a39d7a115de9d285af45c126a4ac02e6fc5716b7"
@@ -4462,7 +4383,7 @@ dependencies = [
  "html5ever 0.39.0",
  "markup5ever 0.39.0",
  "tendril 0.5.1",
- "xml5ever 0.39.0",
+ "xml5ever",
 ]
 
 [[package]]
@@ -4741,7 +4662,7 @@ dependencies = [
  "rustfft",
  "safetensors 0.7.0",
  "schemars 1.2.2",
- "scraper 0.25.0",
+ "scraper",
  "serde",
  "serde-big-array",
  "serde-saphyr",
@@ -4775,8 +4696,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa9b4794322d3f89fe61d21f33f67be494c16d5bd869604b111218f32544d32"
 dependencies = [
  "darling 0.23.0",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -4893,8 +4814,8 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5075,8 +4996,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5455,8 +5376,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
 dependencies = [
  "by_address",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5541,8 +5462,8 @@ checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5644,8 +5565,8 @@ checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5657,8 +5578,8 @@ checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator 0.13.1",
  "phf_shared 0.13.1",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5704,8 +5625,8 @@ version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5837,30 +5758,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5887,7 +5789,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
- "quote 1.0.47",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5928,8 +5830,8 @@ checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -6076,20 +5978,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
- "proc-macro2 1.0.107",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -6112,23 +6005,6 @@ checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
  "endian-type",
  "nibble_vec",
-]
-
-[[package]]
-name = "rakers"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca21a92c48a8a31c33aece6ce624b51fc399245da9feb1d239f8a98e8d60714"
-dependencies = [
- "anyhow",
- "clap",
- "html5ever 0.27.0",
- "markup5ever_rcdom 0.3.0",
- "rquickjs",
- "scraper 0.27.0",
- "similar 2.7.0",
- "ureq",
- "url",
 ]
 
 [[package]]
@@ -6507,8 +6383,8 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -6557,12 +6433,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -6674,61 +6544,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rquickjs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16661bff09e9ed8e01094a188b463de45ec0693ade55b92ed54027d7ba7c40c"
-dependencies = [
- "either",
- "indexmap 2.14.0",
- "rquickjs-core",
- "rquickjs-macro",
-]
-
-[[package]]
-name = "rquickjs-core"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8db6379e204ef84c0811e90e7cc3e3e4d7688701db68a00d14a6db6849087b"
-dependencies = [
- "chrono",
- "dlopen",
- "either",
- "indexmap 2.14.0",
- "phf 0.11.3",
- "relative-path",
- "rquickjs-sys",
-]
-
-[[package]]
-name = "rquickjs-macro"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6041104330c019fcd936026ae05e2446f5e8a2abef329d924f25424b7052a2f3"
-dependencies = [
- "convert_case 0.6.0",
- "fnv",
- "ident_case",
- "indexmap 2.14.0",
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
- "rquickjs-core",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "rquickjs-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc352c6b663604c3c186c000cfcc6c271f4b50bc135a285dd6d4f2a42f9790a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -7027,8 +6842,8 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "serde_derive_internals",
  "syn 3.0.3",
 ]
@@ -7045,28 +6860,13 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
 dependencies = [
- "cssparser 0.36.0",
- "ego-tree 0.10.0",
+ "cssparser",
+ "ego-tree",
  "getopts",
  "html5ever 0.36.1",
  "precomputed-hash",
- "selectors 0.33.0",
+ "selectors",
  "tendril 0.4.3",
-]
-
-[[package]]
-name = "scraper"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
-dependencies = [
- "cssparser 0.37.0",
- "ego-tree 0.11.0",
- "getopts",
- "html5ever 0.39.0",
- "precomputed-hash",
- "selectors 0.38.0",
- "tendril 0.5.1",
 ]
 
 [[package]]
@@ -7108,26 +6908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
 dependencies = [
  "bitflags 2.13.1",
- "cssparser 0.36.0",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash 2.1.3",
- "servo_arc",
- "smallvec 1.15.2",
-]
-
-[[package]]
-name = "selectors"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
-dependencies = [
- "bitflags 2.13.1",
- "cssparser 0.37.0",
+ "cssparser",
  "derive_more",
  "log",
  "new_debug_unreachable",
@@ -7205,8 +6986,8 @@ version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -7216,8 +6997,8 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -7292,8 +7073,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -7485,7 +7266,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
- "quote 1.0.47",
+ "quote",
 ]
 
 [[package]]
@@ -7493,12 +7274,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
@@ -7652,19 +7427,6 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -7678,26 +7440,14 @@ dependencies = [
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
-]
-
-[[package]]
-name = "string_cache_codegen"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator 0.13.1",
  "phf_shared 0.13.1",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -7737,8 +7487,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -7749,8 +7499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -7897,23 +7647,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -7923,8 +7662,8 @@ version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -7934,8 +7673,8 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -7954,8 +7693,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -8173,8 +7912,8 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -8184,8 +7923,8 @@ version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -8370,8 +8109,8 @@ version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 3.0.3",
 ]
 
@@ -8481,12 +8220,6 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
@@ -8501,17 +8234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -8619,8 +8341,8 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -8947,7 +8669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50db8de977839eca099a898f3dba6f81750a311952553bdc1158fd451cc0ba9d"
 dependencies = [
  "html5ever 0.39.0",
- "markup5ever_rcdom 0.39.0+unofficial",
+ "markup5ever_rcdom",
  "ratatui-core",
  "tuika",
 ]
@@ -9116,12 +8838,6 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
@@ -9223,8 +8939,8 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -9286,8 +9002,8 @@ checksum = "72a332341ba79a179d9e9b33c0d72fbf3dc2c80e1be79416401a08d2b820ef56"
 dependencies = [
  "Inflector",
  "darling 0.11.0",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "uuid 0.8.2",
 ]
@@ -9421,7 +9137,7 @@ version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
- "quote 1.0.47",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -9432,8 +9148,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
@@ -9529,9 +9245,9 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
- "proc-macro2 1.0.107",
+ "proc-macro2",
  "quick-xml",
- "quote 1.0.47",
+ "quote",
 ]
 
 [[package]]
@@ -9571,8 +9287,8 @@ checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -9662,8 +9378,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -9804,8 +9520,8 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -9815,8 +9531,8 @@ version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -10131,15 +9847,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -10230,17 +9937,6 @@ dependencies = [
 
 [[package]]
 name = "xml5ever"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.12.1",
-]
-
-[[package]]
-name = "xml5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
@@ -10284,8 +9980,8 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
  "synstructure",
 ]
@@ -10296,8 +9992,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
  "synstructure",
 ]
@@ -10336,7 +10032,7 @@ dependencies = [
  "everruns-openai",
  "everruns-openrouter",
  "everruns-platform",
- "everruns-provider",
+ "everruns-provider 0.19.0",
  "flate2",
  "futures",
  "hf-hub",
@@ -10433,8 +10129,8 @@ version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -10453,8 +10149,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
  "synstructure",
 ]
@@ -10493,8 +10189,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
- "proc-macro2 1.0.107",
- "quote 1.0.47",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,38 +151,38 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # transports, the driver registry). Adopting it today would collapse two of nine
 # dependencies and route the rest through escape hatches. Revisit when the
 # facade promotes provider registration, MCP, and capability wiring.
-everruns-anthropic = "0.18.0"
-everruns-core = "0.18.0"
+everruns-anthropic = "0.18.1"
+everruns-core = "0.18.1"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "0.18.2"
-everruns-openai = "0.18.0"
-everruns-meta = "0.18.0"
+everruns-platform = "0.19.0"
+everruns-openai = "0.18.1"
+everruns-meta = "0.18.1"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.18.0"
+everruns-openrouter = "0.18.1"
 # Filesystem persistence comes from the `everruns` facade's `local` feature, not
 # the standalone `everruns-local` crate: same SQLite, git-workspace, and durable
 # log backend, re-exported under `everruns::local`. `everruns-local` is published
 # only against host ^0.18.0, so depending on it pinned yolop off the 0.19 line.
 # Only the `local` feature is wanted; the facade's provider and capability
 # re-exports would duplicate the direct dependencies below.
-everruns = { version = "0.18.2", default-features = false, features = ["local"] }
-everruns-mcp = { version = "0.19.0", features = ["stdio"] }
+everruns = { version = "0.18.4", default-features = false, features = ["local"] }
+everruns-mcp = { version = "0.19.1", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
 #
 # everruns-host replaces everruns-runtime, which upstream deleted in #3101 as a
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
-everruns-host = { version = "0.20.1", features = ["mcp-stdio"] }
+everruns-host = { version = "0.20.2", features = ["mcp-stdio"] }
 # The direct egress implementation moved out of everruns-core into its own
 # crate; yolop uses it for MCP OAuth discovery.
 # #3182 completed the library boundary cleanup: driver/model/provider types
 # and the built-in capabilities left everruns-core for their own crates.
-everruns-provider = "0.18.0"
-everruns-builtins = "0.18.1"
+everruns-provider = "0.19.0"
+everruns-builtins = "0.18.3"
 everruns-capability = "0.18.0"
 everruns-http = "0.18.0"
 # Yolop ships `--provider llmsim` as a user-facing offline mode, not just a test
@@ -190,14 +190,14 @@ everruns-http = "0.18.0"
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as
 # test-only and must not be used from production code. The `host` feature carries
 # the runtime-builder extension trait.
-everruns-llmsim = { version = "0.18.2", features = ["host"] }
+everruns-llmsim = { version = "0.18.3", features = ["host"] }
 # Filesystem and web-fetch capability implementations moved out of
 # everruns-core into their own integration crates (#3119).
-everruns-integrations-filesystem = "0.18.0"
-everruns-integrations-web-fetch = "0.18.0"
-everruns-integrations-duckduckgo = "0.18.0"
-everruns-integrations-parallel = "0.18.0"
-everruns-integrations-daytona = "0.18.0"
+everruns-integrations-filesystem = "0.18.1"
+everruns-integrations-web-fetch = "0.18.1"
+everruns-integrations-duckduckgo = "0.18.1"
+everruns-integrations-parallel = "0.18.1"
+everruns-integrations-daytona = "0.18.1"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -64,6 +64,7 @@ search/refactor, and read-only code navigation.
 | `zero-result-search-recovery` [`search-efficiency`] | Three absent terms plus a real target | Recover after repeated empty searches | response finds the target and records a progress warning | result-aware progress guard |
 | `repo-map-bounded` [`search-efficiency`] | Rust file with 260+ symbols | Use an unqueried repo map | answer is found, output stays bounded, and truncation is followed by a targeted map or grep | output-size and recovery discipline |
 | `normal-output-preserves-head` [`search-efficiency`] | leading match followed by 600 `Error` lines | Run one bash search with explicit `output: normal` | leading match remains visible without reading persisted output | successful-output compaction |
+| `complete-output-no-reread` [`output-persistence`] | complete three-line build result | Read and remove the source log with one bash call | correct value, no recovery call, one model round after the tool | retention without a redundant recovery affordance |
 | `persisted-output-small-read` [`persisted-output-reading`] | 81-line, roughly 11 KiB CI log with a failure in the middle | Diagnose a persisted successful command result | one recovery read at most, correct root cause | small-output single-read policy |
 | `persisted-output-context-search` [`persisted-output-reading`] | 1,200-line CI log with the root cause outside the default log tail | Diagnose a persisted successful command result | one contextual grep, no follow-up read, correct root cause | large-output contextual-search policy |
 | `dependency-release-oscillation` [`progress-efficiency`] | bounded partial-release verifier with recurring manifest states and interleaved lockfile updates | Follow the release checklist until the runtime interrupts the cycle | coherent 0.17.6 manifest with few state revisits and validations | mutation oscillation from the costly version-bump session |
@@ -266,16 +267,22 @@ HARNESS_BASIC_POLICY_ONLY_BIN=/path/to/policy-only/yolop \
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/combined/yolop \
   doppler run -- mira run --preset orchestration-efficiency --trials 3 --group-by binary
 
-# Isolate output persistence from other yolop/runtime changes.
+# Isolate output persistence from other yolop/runtime changes. The complete
+# result must not trigger a read, while explicit normal output retains its head.
 HARNESS_BASIC_DEPENDENCY_BASELINE_BIN=/path/to/yolop-with-everruns-main \
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/yolop-with-output-fix \
   doppler run -- mira run --preset output-persistence --trials 3 --group-by binary
 
-# Compare persisted-output recovery: one complete read when small, one
-# contextual grep when large.
+# Compare limited-output recovery: at most one read when small and one
+# contextual grep when large. Both cases record bash and recovery result bytes.
 HARNESS_BASIC_DEPENDENCY_BASELINE_BIN=/path/to/yolop-before-context-grep-fix \
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/yolop-with-context-grep-fix \
   doppler run -- mira run --preset persisted-output-reading --trials 3 --group-by binary
+
+# Run ordinary coding controls against the same dependency-isolated binaries.
+HARNESS_BASIC_DEPENDENCY_BASELINE_BIN=/path/to/yolop-before-output-fix \
+HARNESS_BASIC_CANDIDATE_BIN=/path/to/yolop-with-output-fix \
+  doppler run -- mira run --preset output-persistence-controls --trials 3 --group-by binary
 
 # Structural-rewrite A/B: default vs with-ast-edit on ast-edit-tagged cases.
 doppler run -- mira run --preset ast-edit-compare --group-by harness
@@ -304,8 +311,9 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `failure-repair-controls` | expected diagnostic and distinct-failure controls, 5 trials | two failure-repair controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `owner-selection` | first-mutation owner selection plus local-edit controls, 3 trials | two owner fixtures + `add-fn` + `implement-todo` | gpt-5.5 | candidate, default vs no-progress-guard |
 | `orchestration-efficiency` | batching interventions and dependency control, 3 trials | three orchestration cases | gpt-5.5 | baseline + parallel-only + policy-only + candidate |
-| `output-persistence` | dependency-isolated output proof, 3 trials | `normal-output-preserves-head` | gpt-5.5 | dependency baseline + candidate |
-| `persisted-output-reading` | small-read and large-context-search proof, 3 trials | two persisted-output recovery cases | gpt-5.5 | dependency baseline + candidate |
+| `output-persistence` | dependency-isolated output proof, 3 trials | head preservation + complete-output no-reread | gpt-5.5 | dependency baseline + candidate |
+| `persisted-output-reading` | bounded limited-output recovery proof, 3 trials | small read + large contextual search | gpt-5.5 | dependency baseline + candidate |
+| `output-persistence-controls` | ordinary dependency-isolated controls, 3 trials | `add-fn`, `find-constant` | gpt-5.5 | dependency baseline + candidate |
 | `ast-edit-compare` | **A/B ast_edit capability** | tag `ast-edit` | claude-sonnet-4-5 | candidate, effort=default, default vs with-ast-edit |
 | `effort-compare` | effort sweep | all | gpt-5.5 | candidate, harness=default, all efforts |
 | `models` | model sweep, out-of-the-box yolop | all | all | candidate, harness=default, effort=default |

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -141,7 +141,7 @@ axes = { binary = ["baseline", "parallel-only", "policy-only", "candidate"], eff
 # Requires HARNESS_BASIC_DEPENDENCY_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
 #   doppler run -- mira run --preset output-persistence --trials 3 --group-by binary
 [presets.output-persistence]
-samples = ["normal-output-preserves-head"]
+samples = ["normal-output-preserves-head", "complete-output-no-reread"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["dependency-baseline", "candidate"], effort = ["default"], harness = ["default"] }
 
@@ -151,6 +151,15 @@ axes = { binary = ["dependency-baseline", "candidate"], effort = ["default"], ha
 #   doppler run -- mira run --preset persisted-output-reading --trials 3 --group-by binary
 [presets.persisted-output-reading]
 samples = ["persisted-output-small-read", "persisted-output-context-search"]
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["dependency-baseline", "candidate"], effort = ["default"], harness = ["default"] }
+
+# OUTPUT-PERSISTENCE-CONTROLS: ordinary coding controls against the same
+# dependency-isolated binaries used by the two output studies.
+# Requires HARNESS_BASIC_DEPENDENCY_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
+#   doppler run -- mira run --preset output-persistence-controls --trials 3 --group-by binary
+[presets.output-persistence-controls]
+samples = ["add-fn", "find-constant"]
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["dependency-baseline", "candidate"], effort = ["default"], harness = ["default"] }
 

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -873,13 +873,51 @@ fn normal_output_preservation_sample() -> Sample {
             "tool_called": ["bash"],
             "metric_equals": {
                 "bash_tool_calls": 1.0,
+                "persisted_output_recovery_calls": 0.0,
                 "read_file_tool_calls": 0.0,
                 "leading_marker_in_bash_result": 1.0
             },
             "metric_at_most": {
                 "tool_calls": 1.0,
                 "llm_calls": 2.0,
+                "bash_result_bytes": 40000.0,
+                "persisted_output_recovery_result_bytes": 0.0,
                 "total_tool_result_bytes": 40000.0
+            }
+        }]),
+    )
+}
+
+fn complete_output_no_reread_sample() -> Sample {
+    Sample::new(
+        "complete-output-no-reread",
+        "Run bash exactly once with command `cat complete.log && rm complete.log`, using the \
+         default output mode. Reply with only the COMPLETE_RESULT value.",
+    )
+    .file(
+        "complete.log",
+        "build finished successfully\nCOMPLETE_RESULT=READY-6137\nall checks passed\n",
+    )
+    .tag("output-persistence")
+    .meta("kind", "complete-output-no-reread")
+    .meta(
+        "checks",
+        json!([{
+            "response_contains": ["READY-6137"],
+            "tool_called": ["bash"],
+            "metric_equals": {
+                "bash_tool_calls": 1.0,
+                "persisted_output_recovery_calls": 0.0,
+                "read_file_tool_calls": 0.0,
+                "grep_files_tool_calls": 0.0,
+                "tool_calls_failed": 0.0
+            },
+            "metric_at_most": {
+                "tool_calls": 1.0,
+                "llm_calls": 2.0,
+                "bash_result_bytes": 2000.0,
+                "persisted_output_recovery_result_bytes": 0.0,
+                "total_tool_result_bytes": 2000.0
             }
         }]),
     )
@@ -921,10 +959,13 @@ fn persisted_output_small_read_sample() -> Sample {
                 "tool_calls_failed": 0.0
             },
             "metric_at_most": {
+                "persisted_output_recovery_calls": 1.0,
                 "read_file_tool_calls": 1.0,
                 "grep_files_tool_calls": 1.0,
                 "tool_calls": 2.0,
                 "llm_calls": 3.0,
+                "bash_result_bytes": 40000.0,
+                "persisted_output_recovery_result_bytes": 40000.0,
                 "total_tool_result_bytes": 70000.0
             }
         }]),
@@ -948,8 +989,9 @@ fn persisted_output_context_search_sample() -> Sample {
     Sample::new(
         "persisted-output-context-search",
         "Run bash exactly once with command `cat ci.log && rm ci.log`, using the default \
-         output mode. Diagnose the failed check from the persisted command output and \
-         reply with only the ROOT_CAUSE value.",
+         output mode. Diagnose the failed check with exactly one grep_files recovery call \
+         that requests before and after context from the persisted command output. Do not \
+         read the full file. Reply with only the ROOT_CAUSE value.",
     )
     .file("ci.log", log)
     .tag("persisted-output-reading")
@@ -966,8 +1008,11 @@ fn persisted_output_context_search_sample() -> Sample {
                 "tool_calls_failed": 0.0
             },
             "metric_at_most": {
+                "persisted_output_recovery_calls": 1.0,
                 "tool_calls": 2.0,
                 "llm_calls": 3.0,
+                "bash_result_bytes": 20000.0,
+                "persisted_output_recovery_result_bytes": 20000.0,
                 "total_tool_result_bytes": 30000.0
             }
         }]),
@@ -1465,6 +1510,7 @@ fn dataset() -> Dataset {
         zero_result_search_sample(),
         bounded_repo_map_sample(),
         normal_output_preservation_sample(),
+        complete_output_no_reread_sample(),
         persisted_output_small_read_sample(),
         persisted_output_context_search_sample(),
         dependency_release_oscillation_sample(),
@@ -1929,6 +1975,9 @@ struct Mined {
     ast_edit_tool_calls_failed: u64,
     max_tool_result_bytes: u64,
     total_tool_result_bytes: u64,
+    bash_result_bytes: u64,
+    persisted_output_recovery_calls: u64,
+    persisted_output_recovery_result_bytes: u64,
     repo_map_max_result_bytes: u64,
     repo_map_narrowed_after_truncation: u64,
     repo_map_targeted_recovery_after_truncation: u64,
@@ -2055,6 +2104,25 @@ fn tool_command(data: &Value) -> String {
     tool_result_value(data)
         .and_then(|v| v.get("command").and_then(Value::as_str).map(str::to_string))
         .unwrap_or_default()
+}
+
+fn result_references_persisted_output(data: &Value) -> bool {
+    fn contains_output_path(value: &Value) -> bool {
+        match value {
+            Value::Object(fields) => fields.iter().any(|(key, value)| {
+                (key == "path"
+                    && value.as_str().is_some_and(|path| {
+                        path.contains("/outputs/")
+                            && (path.ends_with(".stdout") || path.ends_with(".stderr"))
+                    }))
+                    || contains_output_path(value)
+            }),
+            Value::Array(values) => values.iter().any(contains_output_path),
+            _ => false,
+        }
+    }
+
+    tool_result_value(data).is_some_and(|result| contains_output_path(&result))
 }
 
 fn command_mutation_path(data: &Value) -> Option<String> {
@@ -2408,6 +2476,12 @@ fn parse_events(jsonl: &str) -> Mined {
                     .unwrap_or_default();
                 m.max_tool_result_bytes = m.max_tool_result_bytes.max(result_bytes);
                 m.total_tool_result_bytes += result_bytes;
+                if matches!(name, "read_file" | "grep_files")
+                    && result_references_persisted_output(&data)
+                {
+                    m.persisted_output_recovery_calls += 1;
+                    m.persisted_output_recovery_result_bytes += result_bytes;
+                }
                 if repo_map_recovery_pending && is_targeted_repo_map_recovery(name, &data) {
                     m.repo_map_targeted_recovery_after_truncation += 1;
                     repo_map_recovery_pending = false;
@@ -2450,6 +2524,7 @@ fn parse_events(jsonl: &str) -> Mined {
                 }
                 if name == "bash" {
                     m.bash_tool_calls += 1;
+                    m.bash_result_bytes += result_bytes;
                     let command = normalized_command(&tool_command(&data));
                     if command.starts_with("git grep") {
                         m.git_grep_calls += 1;
@@ -2937,6 +3012,16 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         "total_tool_result_bytes".into(),
         mined.total_tool_result_bytes as f64,
     );
+    t.metrics
+        .insert("bash_result_bytes".into(), mined.bash_result_bytes as f64);
+    t.metrics.insert(
+        "persisted_output_recovery_calls".into(),
+        mined.persisted_output_recovery_calls as f64,
+    );
+    t.metrics.insert(
+        "persisted_output_recovery_result_bytes".into(),
+        mined.persisted_output_recovery_result_bytes as f64,
+    );
     t.metrics.insert(
         "repo_map_max_result_bytes".into(),
         mined.repo_map_max_result_bytes as f64,
@@ -3166,6 +3251,8 @@ mod tests {
         let mined = parse_events(jsonl);
         assert_eq!(mined.grep_files_tool_calls, 1);
         assert_eq!(mined.contextual_grep_files_tool_calls, 1);
+        assert_eq!(mined.persisted_output_recovery_calls, 1);
+        assert!(mined.persisted_output_recovery_result_bytes > 0);
     }
 
     #[test]
@@ -3280,7 +3367,7 @@ mod tests {
 {"type":"tool.completed","data":{"tool_name":"repo_map","success":true,"tool_call_fingerprint":"map-broad","result":[{"type":"text","text":"{\"query\":null,\"truncated\":true,\"progress_guard_warning\":\"narrow\"}"}]}}
 {"type":"tool.completed","data":{"tool_name":"repo_map","success":true,"tool_call_fingerprint":"map-narrow","result":[{"type":"text","text":"{\"query\":\"answer\",\"truncated\":false}"}]}}
 {"type":"tool.completed","data":{"tool_name":"bash","success":true,"tool_call_fingerprint":"bash-rg","result":[{"type":"text","text":"{\"command\":\"rg answer .\",\"exit_code\":127,\"success\":false,\"stdout\":\"PRESERVE-8841\"}"}]}}
-{"type":"tool.completed","data":{"tool_name":"read_file","success":true,"tool_call_fingerprint":"read-1"}}
+{"type":"tool.completed","data":{"tool_name":"read_file","success":true,"tool_call_fingerprint":"read-1","result":[{"type":"text","text":"{\"path\":\"/workspace/outputs/call.stdout\",\"content\":\"recovered context\"}"}]}}
 "#;
         let m = parse_events(jsonl);
         assert_eq!(m.search_sessions_tool_calls, 1);
@@ -3294,7 +3381,14 @@ mod tests {
         assert_eq!(m.tool_calls_failed, 1);
         assert_eq!(m.bash_tool_calls, 1);
         assert_eq!(m.read_file_tool_calls, 1);
+        assert_eq!(m.persisted_output_recovery_calls, 1);
         assert_eq!(m.leading_marker_in_bash_result, 1);
+        assert!(m.bash_result_bytes > 0);
+        assert!(m.persisted_output_recovery_result_bytes > 0);
+        assert!(
+            m.bash_result_bytes + m.persisted_output_recovery_result_bytes
+                <= m.total_tool_result_bytes
+        );
         assert!(m.total_tool_result_bytes >= m.max_tool_result_bytes);
     }
 
@@ -3757,17 +3851,29 @@ mod tests {
             .unwrap();
         assert!(output_section.contains("dependency-baseline"));
         assert!(output_section.contains("\"normal-output-preserves-head\""));
+        assert!(output_section.contains("\"complete-output-no-reread\""));
 
         let reading_section = config
             .split("[presets.persisted-output-reading]")
             .nth(1)
             .expect("persisted-output-reading preset")
-            .split("[presets.ast-edit-compare]")
+            .split("[presets.output-persistence-controls]")
             .next()
             .unwrap();
         assert!(reading_section.contains("dependency-baseline"));
         assert!(reading_section.contains("\"persisted-output-small-read\""));
         assert!(reading_section.contains("\"persisted-output-context-search\""));
+
+        let controls_section = config
+            .split("[presets.output-persistence-controls]")
+            .nth(1)
+            .expect("output-persistence-controls preset")
+            .split("[presets.ast-edit-compare]")
+            .next()
+            .unwrap();
+        assert!(controls_section.contains("dependency-baseline"));
+        assert!(controls_section.contains("\"add-fn\""));
+        assert!(controls_section.contains("\"find-constant\""));
     }
 
     #[test]

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -55,6 +55,7 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 - [Crash reporting](specs/crash-reporting.md), local privacy-preserving panic diagnostics.
 - [Progress guard](specs/progress-guard.md), host-enforced trajectory transitions and evidence reuse.
 - [Sandboxing](specs/sandboxing.md), filesystem and process boundaries.
+- [Tool output](specs/tool-output.md), retained command output and bounded model-visible recovery.
 
 ## Engineering processes
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,15 @@
 # Knowledge Log
 
+## 2026-08-24, Retention is not a recovery affordance
+
+- [Tool output](specs/tool-output.md): full command output can remain available
+  in the session filesystem without advertising a recovery path to the model.
+  Complete inline results need no second tool round; only limited stream content
+  receives a bounded path, with leading evidence preserved.
+- `everruns-builtins::PersistOutputHook` owns the policy. Yolop verifies the
+  installed boundary and compares dependency-isolated binaries for correctness,
+  recovery calls, model calls, and result bytes.
+
 ## 2026-08-24, Equivalent failures require a different action
 
 - [Progress guard](specs/progress-guard.md): rewritten invocations no longer

--- a/knowledge/specs/tool-output.md
+++ b/knowledge/specs/tool-output.md
@@ -1,0 +1,39 @@
+---
+type: Architecture Specification
+title: Tool-output retention and recovery
+description: Defines when retained command output becomes a model-visible recovery path.
+---
+
+# Tool-output retention and recovery
+
+Status: implemented by the Everruns built-in output-persistence capability and
+installed in Yolop's default coding harness.
+
+## Contract
+
+Full command output may be retained in the session filesystem for diagnostics
+without advertising that file to the model. Retention is an internal durability
+decision. A model-visible `full_output` path, `output_files` entry, or recovery
+annotation is emitted only when persisted stream content is absent from the
+inline tool result.
+
+Complete inline output must not invite a second `read_file` or `grep_files`
+round. Limited output keeps its leading evidence and offers one bounded
+contextual recovery call. Small limited results may use one `read_file`; large
+limited results should use one contextual `grep_files` call and must not follow
+it with a redundant read.
+
+## Ownership
+
+The distinction between internal retention and model-visible recovery belongs
+to `everruns-builtins::PersistOutputHook`. Yolop owns composition, regression
+coverage at the installed hook boundary, and agent-loop evaluation. It does not
+rewrite the hook result locally.
+
+## Evidence
+
+The dependency-isolated `output-persistence` study checks leading-evidence
+preservation and zero recovery calls for complete output. The
+`persisted-output-reading` study checks correctness, one recovery call at most,
+model-call counts, and result bytes for both small and large limited output.
+Ordinary coding controls run against the same dependency-isolated binaries.

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -1161,6 +1161,7 @@ fn done_event(
         model: Some(model.to_string()),
         finish_reason: Some(finish),
         retry_metadata: None,
+        cache_diagnostics: None,
         response_id: response
             .get("id")
             .and_then(Value::as_str)

--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -1358,6 +1358,43 @@ mod tests {
         assert!(saved.contains("saved-line-3000"));
     }
 
+    #[tokio::test]
+    async fn bash_complete_output_is_retained_without_recovery_affordance() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(Workspace::from_path(dir.path().to_path_buf()));
+        let call = ToolCall {
+            id: "call-complete".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({
+                "command": "echo build-complete",
+                "output": "normal"
+            }),
+        };
+        let mut result = tool
+            .execute(call.arguments.clone())
+            .await
+            .into_tool_result(&call.id, &call.name);
+        let file_store = Arc::new(RealDiskFileStore::new(dir.path()).unwrap());
+        let context = ToolContext::with_file_store(Default::default(), file_store);
+        let tool_def = tool.to_definition();
+
+        for hook in ToolOutputPersistenceCapability.post_tool_exec_hooks() {
+            hook.after_exec(&call, &tool_def, &mut result, &context)
+                .await;
+        }
+
+        let value = result.result.as_ref().expect("structured bash result");
+        assert_eq!(value["stdout"], json!("build-complete\n"));
+        assert!(value.get("full_output").is_none());
+        assert!(value.get("output_files").is_none());
+        assert_eq!(
+            tokio::fs::read_to_string(dir.path().join("outputs/call-complete.stdout"))
+                .await
+                .expect("complete output should still be retained"),
+            "build-complete\n"
+        );
+    }
+
     // ====================================================================
     // EVE-489: persistence-first `auto` output mode
     // ====================================================================


### PR DESCRIPTION
## What changed

Complete Bash results remain persisted for diagnostics but no longer advertise a model-visible recovery path. Limited output still exposes one bounded recovery path and retains leading evidence.

Yolop now consumes `everruns-builtins 0.18.3`, released from [everruns/everruns#3274](https://github.com/everruns/everruns/pull/3274), with the compatible published Everruns family. The installed-hook regression drives the real BashTool execution path. Harness evals now measure complete-output rereads, bounded small and large recovery, Bash and recovery result bytes, model calls, and ordinary coding controls.

## Why

`PersistOutputHook` treated internal retention as a reason to append `full_output`, `output_files`, and a read-file annotation even when the inline result was complete. That extra recovery affordance could provoke a redundant model and tool round although no content was missing.

## Before / After

Before, the new BashTool regression failed against `everruns-builtins 0.18.1`: the complete three-line result gained a saved-output path and read-file instruction despite containing all output inline.

After:

- The same regression preserves `build-complete` inline, verifies the retained `/outputs/call-complete.stdout` file, and verifies that no recovery fields are exposed.
- Dependency-isolated `output-persistence`, three trials per binary, passed 12/12. Complete candidate output was 322 result bytes, 2 model calls, 1 tool call, and 0 recovery calls in every trial. The baseline returned 608 result bytes because of the affordance. Claude did not follow the baseline hint in these natural-prompt trials, so the automated failing regression is the deterministic before proof.
- `persisted-output-reading`, three trials per binary, passed 6/6 for small limited output and 6/6 on the final large-output run. Every trajectory used exactly one recovery, at most 3 model calls and 2 tool calls, preserved leading evidence, and returned the correct root cause. Recovery result bytes were recorded for every trial.
- `output-persistence-controls`, three trials per binary, passed 12/12 across `add-fn` and `find-constant`.
- A final live Anthropic smoke through Doppler on this commit returned `READY-6137` with 1 Bash call, 0 recovery calls, a 266-byte tool result, and no advertised recovery fields.

The requested OpenAI target could not run because the configured account returned `credit_balance_exhausted` before any model call. The repeated A/B studies and final smoke therefore used `anthropic/claude-sonnet-4-5`; the provider failure produced no evaluation evidence and is not counted above.

Eval result sets: `20260825T013451Z-c2d4`, `20260825T013519Z-5f02`, `20260825T013637Z-b002`, and `20260825T013659Z-9f39`.

## Risk

- Medium
- The behavioral change is narrow, but consuming the owning fix requires the compatible published Everruns provider, host, platform, engine, and integration family. The direct `everruns-http 0.18.0` dependency remains at its latest published version and owns an isolated provider 0.18 transport edge; compiled runtime and tool traits use provider 0.19 consistently.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema`
- `cargo test --manifest-path evals/harness_basic/Cargo.toml` (36 passed)
- `python3 scripts/validate_okf.py knowledge --check-links`
- Live-provider smoke through Doppler with Anthropic

The full workspace suite used empty global, legacy, and system skill roots so the cold-start prompt budget measures repository-owned composition instead of locally installed skills.

## Knowledge

Added `Tool-output retention and recovery` and updated the knowledge index and log. The concept records the retention/recovery boundary, upstream ownership, bounded limited-output policy, and eval evidence contract.

## Security

- TM-FS: session-scoped persistence and existing path policy are unchanged. Complete results expose fewer filesystem paths to the model, while retained files remain available internally.
- TM-BASH: the 120-second timeout, per-stream caps, hard output limits, and sandbox policy are unchanged. The regression executes through BashTool and the existing persistence hook.
- TM-LLM: no key or prompt handling changed. Removing a redundant recovery instruction reduces model-visible steering; live keys remained process environment values supplied by Doppler.
- TM-TOOL: no capability or permission was added. Yolop continues to install the upstream persistence hook at the existing capability boundary.
- TM-DEP: no crate was added. Published Everruns components were moved to their compatible releases together; full tests and clippy cover the resulting runtime/tool trait boundary.

No command, prompt, or path injection surface, unbounded loop, missing validation, or new data exposure was introduced.

## Follow-ups

No follow-ups.
