### PR TITLE
fix(runtime): keep repo map schema eager

### DIFF
--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -62,7 +62,8 @@ search/refactor, and read-only code navigation.
 | `expected-diagnostic-failure-control` [`search-efficiency-control`] [`progress-efficiency-control`] | Rust crate with one intentionally failing test | Reproduce, fix, and pass the test | source fixed with no semantic-failure warning | expected diagnostic failure control |
 | `distinct-failures-control` [`search-efficiency-control`] [`progress-efficiency-control`] | Missing command, wrong path, and usage failure in sequence | Finish through a built-in search without a warning | correct value and no equivalent-failure warning | false-positive guard across different root reasons |
 | `zero-result-search-recovery` [`search-efficiency`] | Three absent terms plus a real target | Recover after repeated empty searches | response finds the target and records a progress warning | result-aware progress guard |
-| `repo-map-bounded` [`search-efficiency`] | Rust file with 260+ symbols | Use an unqueried repo map | answer is found, output stays bounded, and truncation is followed by a targeted map or grep | output-size and recovery discipline |
+| `repo-map-bounded` [`search-efficiency`] | Rust file with 260+ symbols | Use an unqueried repo map | answer is found, output stays bounded, and truncation is followed by a queried map, queried symbols, or matching grep | output-size and recovery discipline |
+| `repo-map-scoped` [`repo-map-profile`] | Linked-worktree marker plus a nested repository | Map `/workspace/REPOS/service` without shell fallback | scoped answer is found with no failed repo-map call | alias, linked-worktree, nested-repository scope, and eager-schema adoption |
 | `normal-output-preserves-head` [`search-efficiency`] | leading match followed by 600 `Error` lines | Run one bash search with explicit `output: normal` | leading match remains visible without reading persisted output | successful-output compaction |
 | `complete-output-no-reread` [`output-persistence`] | complete three-line build result | Read and remove the source log with one bash call | correct value, no recovery call, one model round after the tool | retention without a redundant recovery affordance |
 | `persisted-output-small-read` [`persisted-output-reading`] | 81-line, roughly 11 KiB CI log with a failure in the middle | Diagnose a persisted successful command result | one recovery read at most, correct root cause | small-output single-read policy |
@@ -147,7 +148,8 @@ cost, `llm_calls`, `turns`, `tool_calls_failed`, `agent_reported_ms`,
 `progress_guard_warnings`, `calls_after_progress_warning`, structured inner
 `tool_calls_failed`, equivalent-failure warnings and blocked retries, duplicate
 exploration, total/maximum tool-result bytes,
-repo-map narrowing and targeted recovery (a narrower map or `grep_files` fallback),
+repo-map narrowing and targeted recovery (a queried `repo_map` or
+`repo_symbols`, or a matching `grep_files` fallback),
 session-search ordering, `ast_edit_tool_calls`, and
 `ast_edit_tool_calls_failed`, validation calls, redundant validations, and
 workspace-state revisits, first-mutation correctness, adapter mutations before
@@ -216,6 +218,17 @@ HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
 HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/change/yolop \
   doppler run -- mira run --preset search-controls --trials 5 --group-by binary
+
+# Decide the eager repo-tool profile, then check ordinary controls. The two
+# candidate paths may point at binaries from temporary comparison worktrees.
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_REPO_MAP_ONLY_BIN=/path/to/repo-map-only/yolop \
+HARNESS_BASIC_REPO_MAP_SYMBOLS_BIN=/path/to/repo-map-symbols/yolop \
+  doppler run -- mira run --preset repo-map-profile --trials 5 --group-by binary
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_REPO_MAP_ONLY_BIN=/path/to/repo-map-only/yolop \
+HARNESS_BASIC_REPO_MAP_SYMBOLS_BIN=/path/to/repo-map-symbols/yolop \
+  doppler run -- mira run --preset repo-map-controls --trials 5 --group-by binary
 
 # Cold-start disclosure A/B across both structured-call provider families and
 # all six required task shapes.
@@ -314,6 +327,8 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `progress-guard` | focused warning-behavior check | tag `progress-guard` | claude-sonnet-4-5 | candidate, effort=default, default vs no-progress-guard |
 | `search-efficiency` | baseline/candidate session/search proof, 3 trials | 8 focused cases | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `search-controls` | ordinary and semantic-failure controls, 5 trials | 4 controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
+| `repo-map-profile` | eager-schema adoption and recovery decision, 5 trials | scoped + bounded repo maps | gpt-5.5 | deferred baseline + map-only + map-and-symbols |
+| `repo-map-controls` | ordinary controls for the eager-schema decision, 5 trials | `add-fn`, `find-constant` | gpt-5.5 | deferred baseline + map-only + map-and-symbols |
 | `capability-disclosure` | first-request token and reveal-path proof, 5 trials | exact reply, read-only search, simple edit, complex coding, release/control, deferred history | gpt-5.5 + claude-sonnet-4-5 | baseline + candidate, harness=default, effort=default |
 | `progress-efficiency` | baseline/candidate state-progress proof, 3 trials | checkpoint transition, state cycle, redundant validation, equivalent failure | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `progress-controls` | ordinary and semantic-failure controls, 5 trials | 4 controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
@@ -419,6 +434,16 @@ rates**, when a sample applies `when_binary` checks: `repo-map-bounded` holds
 `candidate` to bounds `baseline` never faces, so raw pass counts across binaries
 are not comparable there.
 
+## Repository-map profile
+
+[`repo_map_profile_baseline.json`](repo_map_profile_baseline.json) records the
+real-session failure counts, upstream ownership check, deterministic schema
+cost, three-arm OpenAI study, ordinary controls, and focused live smoke. The
+measured policy keeps `repo_map` eager and `repo_symbols` deferred. Compare the
+scoped task-tool trajectory and targeted recovery metrics, not only aggregate
+pass rate: the bounded case deliberately fails a run that repeats a queried
+recovery even when its final answer is correct.
+
 ## Layout
 
 ```
@@ -428,6 +453,7 @@ evals/harness_basic/
   analyze_search_efficiency.py  # baseline/candidate distribution gates
   search_efficiency_baseline.json  # immutable pre-fix revision + evidence
   prompt_composition_baseline.json # immutable pre-trim revision + evidence
+  repo_map_profile_baseline.json   # eager repo-tool decision + evidence
   capability_disclosure_baseline.json # cold-start byte baseline + A/B contract
   analyze_progress_efficiency.py  # state-progress distribution gates
   failure_repair_baseline.json # semantic failure A/B contract and evidence

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -75,6 +75,20 @@ samples = ["add-fn", "find-constant", "expected-diagnostic-failure-control", "di
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "candidate"], effort = ["default"], harness = ["default"] }
 
+# REPO-MAP-PROFILE compares the current deferred profile, repo_map eager alone,
+# and both repo tools eager. Five trials are required when making the profile
+# decision so one stochastic trajectory cannot dominate the result.
+[presets.repo-map-profile]
+samples = ["repo-map-scoped", "repo-map-bounded"]
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["baseline", "repo-map-only", "repo-map-symbols"], effort = ["default"], harness = ["default"] }
+
+# Ordinary controls for the same three schema profiles.
+[presets.repo-map-controls]
+samples = ["add-fn", "find-constant"]
+targets = ["openai/gpt-5.5"]
+axes = { binary = ["baseline", "repo-map-only", "repo-map-symbols"], effort = ["default"], harness = ["default"] }
+
 # CAPABILITY-DISCLOSURE — first-turn context and success proof across exact
 # reply, read-only discovery, simple edit, complex coding, release/control, and
 # an explicitly deferred tool. Compare first_request_*_tokens and cumulative

--- a/evals/harness_basic/repo_map_profile_baseline.json
+++ b/evals/harness_basic/repo_map_profile_baseline.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "git_commit": "5a3fde105f935eb3d7469f5badc4e4119efbb1b8",
+    "description": "Deferred repo_map and repo_symbols schemas before the profile change."
+  },
+  "diagnosis": {
+    "recent_discovery_heavy_sessions": 18,
+    "sessions_using_repo_map": 6,
+    "repo_map_calls": 10,
+    "repo_map_calls_failed": 6,
+    "failure_stage": "Yolop pre-tool argument validation, before path resolution",
+    "invented_arguments": [
+      "depth",
+      "max_depth",
+      "max_symbols"
+    ],
+    "affected_valid_scopes": [
+      "/workspace",
+      "linked worktree paths",
+      "nested repository subpaths"
+    ],
+    "resolver_control": "Valid repo_symbols calls succeeded against the same linked-worktree scopes, and focused repo_map tests accept /workspace plus relative nested-repository paths.",
+    "upstream_owner_check": {
+      "everruns_main_commit": "5fe85ffd67edf62f77d1d29e7fb827b8bc8ffdf1",
+      "decision": "No upstream change or release is required. The observed calls never reached Everruns path resolution; Yolop owns the eager/deferred disclosure profile and pre-tool validation wiring."
+    }
+  },
+  "deterministic_cold_start": {
+    "undeferred_reference": {
+      "provider_visible_tool_definition_bytes": 30836,
+      "parameter_schema_bytes": 14719
+    },
+    "deferred_baseline": {
+      "provider_visible_tool_definition_bytes": 22786,
+      "parameter_schema_bytes": 8704,
+      "note": "Current main totals include the independently measured 828-byte eager read_many_files schema."
+    },
+    "repo_map_only": {
+      "repo_map_schema_bytes": 261,
+      "provider_visible_tool_definition_bytes": 23181,
+      "parameter_schema_bytes": 8920,
+      "historical_parameter_schema_bytes": 8092,
+      "definition_reduction_from_undeferred_percent": 24.8,
+      "historical_schema_reduction_from_undeferred_percent": 45.0
+    },
+    "repo_map_and_symbols": {
+      "provider_visible_tool_definition_bytes": 23397,
+      "parameter_schema_bytes": 9136,
+      "historical_parameter_schema_bytes": 8308,
+      "historical_schema_reduction_from_undeferred_percent": 43.6,
+      "control_result": "fails the unchanged 45 percent schema-reduction floor"
+    }
+  },
+  "live_ab": {
+    "provider": "openai/gpt-5.5",
+    "profile_run": {
+      "run_id": "20260825T031434Z-f2f8",
+      "preset": "repo-map-profile",
+      "trials": 5,
+      "cases": 30,
+      "correct_answers": "30/30",
+      "scored_passes": "28/30",
+      "strict_efficiency_failures": "one repeated queried repo_map recovery in repo-map-only and one in repo-map-symbols",
+      "scoped_task_tool_calls": {
+        "baseline": [2, 1, 1, 2, 1],
+        "repo_map_only": [1, 1, 1, 1, 1],
+        "repo_map_and_symbols": [1, 1, 1, 1, 1]
+      },
+      "scoped_repo_map_failures": {
+        "baseline": 0,
+        "repo_map_only": 0,
+        "repo_map_and_symbols": 0
+      },
+      "bounded_targeted_recoveries": {
+        "baseline": "5/5",
+        "repo_map_only": "5/5",
+        "repo_map_and_symbols": "5/5"
+      },
+      "first_request_token_median": {
+        "baseline": 7198,
+        "repo_map_only": 7283,
+        "repo_map_and_symbols": 7322
+      }
+    },
+    "corrected_schema_guidance_confirmation": {
+      "run_id": "20260825T031243Z-f1a6",
+      "result": "30/30 passed after the tool description made optional defaults explicit"
+    },
+    "ordinary_controls": {
+      "run_id": "20260825T031545Z-e7ef",
+      "preset": "repo-map-controls",
+      "trials": 5,
+      "cases": 30,
+      "result": "30/30 passed",
+      "samples": [
+        "add-fn",
+        "find-constant"
+      ]
+    },
+    "focused_smoke": {
+      "run_id": "20260825T031646Z-5205",
+      "result": "1/1 passed",
+      "tool_calls": [
+        "write_session_title",
+        "repo_map"
+      ],
+      "repo_map_failures": 0
+    }
+  },
+  "decision": {
+    "never_deferred": [
+      "repo_map"
+    ],
+    "still_deferred": [
+      "repo_symbols"
+    ],
+    "reason": "The real repo_map schema removes the historical validation failures and eliminated extra scoped discovery calls in the focused A/B. Eager repo_symbols produced no recovery or call-count benefit, added first-request tokens, and broke the unchanged schema-cost floor."
+  }
+}

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -37,6 +37,8 @@ const EFFORTS: &[&str] = &["default", "low", "high"];
 const BINARIES: &[&str] = &[
     "candidate",
     "baseline",
+    "repo-map-only",
+    "repo-map-symbols",
     "parallel-only",
     "policy-only",
     "dependency-baseline",
@@ -819,6 +821,7 @@ fn bounded_repo_map_sample() -> Sample {
     )
     .file("src/lib.rs", source)
     .tag("search-efficiency")
+    .tag("repo-map-profile")
     .meta("kind", "bounded-repo-map")
     .meta(
         "checks",
@@ -828,13 +831,52 @@ fn bounded_repo_map_sample() -> Sample {
             "metric_equals": {"duplicate_exploration_calls": 0.0},
             "metric_at_most": {"repo_map_max_result_bytes": 20000.0},
         }, {
+            // Recovery is correctness and truncation discipline, not a
+            // candidate-only efficiency preference. Apply it to every binary;
+            // the miner accepts only a successful queried tool with a match.
+            "metric_at_least": {"repo_map_targeted_recovery_after_truncation": 1.0}
+        }, {
             "when_binary": "candidate",
-            "metric_at_least": {"repo_map_targeted_recovery_after_truncation": 1.0},
             "metric_at_most": {
                 "tool_calls": 3.0,
                 "llm_calls": 4.0,
                 "total_tool_result_bytes": 30000.0
             }
+        }]),
+    )
+}
+
+fn scoped_repo_map_sample() -> Sample {
+    Sample::new(
+        "repo-map-scoped",
+        "This checkout is a linked Git worktree with a nested repository at \
+         `/workspace/REPOS/service`. Use repo_map to orient within that nested \
+         repository, then reply with only the string returned by scoped_answer. \
+         Do not use bash.",
+    )
+    .file(
+        ".git",
+        "gitdir: /tmp/source/.git/worktrees/harness-fixture\n",
+    )
+    .file(
+        "REPOS/service/src/lib.rs",
+        "pub fn scoped_answer() -> &'static str { \"SCOPE-7319\" }\n",
+    )
+    .file(
+        "outside.rs",
+        "pub fn outside_scope() -> &'static str { \"WRONG\" }\n",
+    )
+    .tag("repo-map-profile")
+    .meta("kind", "scoped-repo-map")
+    .meta(
+        "checks",
+        json!([{
+            "response_contains": ["SCOPE-7319"],
+            "response_lacks": ["WRONG"],
+            "tool_called": ["repo_map"],
+            "tool_not_called": ["bash"],
+            "metric_at_least": {"repo_map_tool_calls": 1.0},
+            "metric_equals": {"repo_map_tool_calls_failed": 0.0}
         }]),
     )
 }
@@ -1521,6 +1563,7 @@ fn dataset() -> Dataset {
         expected_diagnostic_failure_control_sample(),
         distinct_failures_control_sample(),
         zero_result_search_sample(),
+        scoped_repo_map_sample(),
         bounded_repo_map_sample(),
         normal_output_preservation_sample(),
         complete_output_no_reread_sample(),
@@ -1888,6 +1931,8 @@ fn yolop_bin(binary: &str) -> Result<PathBuf, String> {
     let axis_override = match binary {
         "candidate" => "HARNESS_BASIC_CANDIDATE_BIN",
         "baseline" => "HARNESS_BASIC_BASELINE_BIN",
+        "repo-map-only" => "HARNESS_BASIC_REPO_MAP_ONLY_BIN",
+        "repo-map-symbols" => "HARNESS_BASIC_REPO_MAP_SYMBOLS_BIN",
         "parallel-only" => "HARNESS_BASIC_PARALLEL_ONLY_BIN",
         "policy-only" => "HARNESS_BASIC_POLICY_ONLY_BIN",
         "dependency-baseline" => "HARNESS_BASIC_DEPENDENCY_BASELINE_BIN",
@@ -1994,6 +2039,10 @@ struct Mined {
     persisted_output_recovery_calls: u64,
     persisted_output_recovery_result_bytes: u64,
     repo_map_max_result_bytes: u64,
+    repo_map_tool_calls: u64,
+    repo_map_tool_calls_failed: u64,
+    repo_symbols_tool_calls: u64,
+    repo_symbols_tool_calls_failed: u64,
     repo_map_narrowed_after_truncation: u64,
     repo_map_targeted_recovery_after_truncation: u64,
     search_sessions_tool_calls: u64,
@@ -2273,6 +2322,7 @@ fn is_targeted_repo_map_recovery(tool_name: &str, data: &Value) -> bool {
     }
     match tool_name {
         "repo_map" => result_has_query(data),
+        "repo_symbols" => result_has_query(data) && result_has_positive_u64(data, "count"),
         "grep_files" => {
             result_has_nonempty_string(data, "pattern")
                 && result_has_positive_u64(data, "match_count")
@@ -2521,6 +2571,22 @@ fn parse_events(jsonl: &str) -> Mined {
                     .and_then(Value::as_str)
                     .unwrap_or("unknown");
                 m.tool_calls.push(name.to_string());
+                let tool_succeeded = data.get("success").and_then(Value::as_bool) == Some(true);
+                match name {
+                    "repo_map" => {
+                        m.repo_map_tool_calls += 1;
+                        if !tool_succeeded {
+                            m.repo_map_tool_calls_failed += 1;
+                        }
+                    }
+                    "repo_symbols" => {
+                        m.repo_symbols_tool_calls += 1;
+                        if !tool_succeeded {
+                            m.repo_symbols_tool_calls_failed += 1;
+                        }
+                    }
+                    _ => {}
+                }
                 // The mandatory checkpoint lands after the warning by definition;
                 // counting it here would consume the whole post-warning allowance
                 // before the agent can make its recovery call.
@@ -3110,6 +3176,22 @@ async fn run_yolop(sample: Sample, cx: RunCx) -> Transcript {
         mined.repo_map_max_result_bytes as f64,
     );
     t.metrics.insert(
+        "repo_map_tool_calls".into(),
+        mined.repo_map_tool_calls as f64,
+    );
+    t.metrics.insert(
+        "repo_map_tool_calls_failed".into(),
+        mined.repo_map_tool_calls_failed as f64,
+    );
+    t.metrics.insert(
+        "repo_symbols_tool_calls".into(),
+        mined.repo_symbols_tool_calls as f64,
+    );
+    t.metrics.insert(
+        "repo_symbols_tool_calls_failed".into(),
+        mined.repo_symbols_tool_calls_failed as f64,
+    );
+    t.metrics.insert(
         "repo_map_narrowed_after_truncation".into(),
         mined.repo_map_narrowed_after_truncation as f64,
     );
@@ -3460,6 +3542,9 @@ mod tests {
         assert_eq!(m.duplicate_exploration_calls, 1);
         assert_eq!(m.repo_map_narrowed_after_truncation, 1);
         assert_eq!(m.repo_map_targeted_recovery_after_truncation, 1);
+        assert_eq!(m.repo_map_tool_calls, 3);
+        assert_eq!(m.repo_map_tool_calls_failed, 0);
+        assert_eq!(m.repo_symbols_tool_calls, 0);
         assert_eq!(m.progress_guard_warnings, 1);
         assert_eq!(m.calls_after_progress_warning, 3);
         assert_eq!(m.inner_tool_failures, 1);
@@ -3567,6 +3652,23 @@ mod tests {
         let m = parse_events(jsonl);
         assert_eq!(m.repo_map_narrowed_after_truncation, 0);
         assert_eq!(m.repo_map_targeted_recovery_after_truncation, 1);
+        assert_eq!(m.repo_symbols_tool_calls, 0);
+    }
+
+    #[test]
+    fn parse_events_counts_only_successful_matching_repo_symbols_as_recovery() {
+        let jsonl = r#"
+{"type":"tool.completed","data":{"tool_name":"repo_map","success":true,"result":[{"type":"text","text":"{\"query\":null,\"truncated\":true}"}]}}
+{"type":"tool.completed","data":{"tool_name":"repo_symbols","success":false,"result":[{"type":"text","text":"{\"query\":\"bounded_map_answer\",\"count\":1}"}]}}
+{"type":"tool.completed","data":{"tool_name":"repo_symbols","success":true,"result":[{"type":"text","text":"{\"query\":null,\"count\":1}"}]}}
+{"type":"tool.completed","data":{"tool_name":"repo_symbols","success":true,"result":[{"type":"text","text":"{\"query\":\"wrong_name\",\"count\":0,\"symbols\":[]}"}]}}
+{"type":"tool.completed","data":{"tool_name":"repo_symbols","success":true,"result":[{"type":"text","text":"{\"query\":\"bounded_map_answer\",\"count\":1,\"symbols\":[{\"path\":\"src/lib.rs\"}]}"}]}}
+"#;
+        let m = parse_events(jsonl);
+        assert_eq!(m.repo_map_narrowed_after_truncation, 0);
+        assert_eq!(m.repo_map_targeted_recovery_after_truncation, 1);
+        assert_eq!(m.repo_symbols_tool_calls, 4);
+        assert_eq!(m.repo_symbols_tool_calls_failed, 1);
     }
 
     #[test]
@@ -3919,7 +4021,7 @@ mod tests {
             .split("[presets.search-controls]")
             .nth(1)
             .expect("search-controls preset")
-            .split("[presets.output-persistence]")
+            .split("[presets.repo-map-profile]")
             .next()
             .unwrap();
         assert!(controls_section.contains("binary = [\"baseline\", \"candidate\"]"));
@@ -3959,6 +4061,33 @@ mod tests {
         assert!(controls_section.contains("dependency-baseline"));
         assert!(controls_section.contains("\"add-fn\""));
         assert!(controls_section.contains("\"find-constant\""));
+    }
+
+    #[test]
+    fn repo_map_profile_preset_compares_both_eager_candidates() {
+        let config = include_str!("../mira.toml");
+        let section = config
+            .split("[presets.repo-map-profile]")
+            .nth(1)
+            .expect("repo-map-profile preset")
+            .split("[presets.repo-map-controls]")
+            .next()
+            .unwrap();
+        assert!(section.contains(
+            "binary = [\"baseline\", \"repo-map-only\", \"repo-map-symbols\"]"
+        ));
+        assert!(section.contains("\"repo-map-scoped\""));
+        assert!(section.contains("\"repo-map-bounded\""));
+
+        let controls = config
+            .split("[presets.repo-map-controls]")
+            .nth(1)
+            .expect("repo-map-controls preset")
+            .split("[presets.capability-disclosure]")
+            .next()
+            .unwrap();
+        assert!(controls.contains("\"add-fn\""));
+        assert!(controls.contains("\"find-constant\""));
     }
 
     #[test]

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,23 @@
 # Knowledge Log
 
+## 2026-08-24, Repository mapping starts with its real contract
+
+- [Tool search](specs/tool-search.md): `repo_map` keeps its compact parameter
+  schema in the first-turn profile, while `repo_symbols` remains deferred.
+  Recent apparent `/workspace`, linked-worktree, and nested-repository path
+  failures were rejected before path resolution because a deferred stub hid
+  every argument name and models invented foreign depth controls.
+- A five-trial, three-arm OpenAI study kept all 30 answers correct. On the
+  uncoached linked-worktree case, map-only used one task tool in every trial;
+  the deferred baseline needed an extra discovery/control tool in two of five.
+  Making `repo_symbols` eager bought no recovery or call-count improvement and
+  exceeded the unchanged cold-start schema floor.
+- The eager map schema stays at 261 bytes. Its tool description carries the
+  optional defaults that strict providers need, after the first live pass
+  showed that types and bounds alone encouraged an explicit 200-symbol limit.
+  The map-only cold start retains the required tool-definition and schema
+  reductions from the undeferred surface.
+
 ## 2026-08-24, Retention is not a recovery affordance
 
 - [Tool output](specs/tool-output.md): full command output can remain available

--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -212,11 +212,12 @@ separate rounds with logical read width 1.
 
 The stable prompt and tool catalogue always disclose every capability name and
 description. Only parameter schemas are progressive: the first-turn profile
-keeps repository discovery, bookkeeping, and the mandatory progress-checkpoint
-transition eager, while mutation, background, release/control, and specialized
+keeps repository discovery, including the compact `repo_map` schema,
+bookkeeping, and the mandatory progress-checkpoint transition eager, while
+mutation, background, release/control, `repo_symbols`, and other specialized
 schemas load through `tool_search`. An explicitly enabled host profile may add
-eager schemas (LSP is the measured case), and extension manifests may opt
-individual tools out of deferral.
+eager schemas, and extension manifests may opt individual tools out of
+deferral.
 
 This policy is static for a host/session. A model classifier must not rewrite
 the system prefix from the wording of each new task; that would make cache
@@ -230,7 +231,12 @@ stable prompt remains capped at 12,888 bytes, provider-visible tool definitions
 must fall by at least 24%, and the historical parameter-schema surface by at
 least 45%. Keeping the mandatory checkpoint and bounded batch-read schemas eager
 intentionally spends schema bytes so neither a host-required transition nor an
-independent-read plan depends on another schema-discovery round.
+independent-read plan depends on another schema-discovery round. The compact
+`repo_map` schema spends another 261 bytes so the first broad repository
+orientation has its real argument contract. Its tool description states that
+fields are optional and records the compact defaults. Making `repo_symbols`
+eager offered no recovery benefit and exceeded the unchanged schema floor, so
+it stays deferred.
 
 ### The budget is a test
 

--- a/knowledge/specs/tool-search.md
+++ b/knowledge/specs/tool-search.md
@@ -41,7 +41,7 @@ vendor was deleted and yolop now consumes upstream directly:
    always uses the real tools; only the advertised schema changes.
 
 2. **Static host-shaped eager profile.** Yolop passes first-turn repository
-   discovery (`read_file`, `list_directory`, `grep_files`), bookkeeping
+   discovery (`read_file`, `list_directory`, `grep_files`, `repo_map`), bookkeeping
    (`write_todos`, `write_session_title`), the shell (`bash`), and the mandatory
    progress-guard transition (`progress_checkpoint`) to
    `ToolSearchCapability::new().with_never_defer([...])`. Mutation,
@@ -53,12 +53,25 @@ vendor was deleted and yolop now consumes upstream directly:
    deferred stub names no parameters while allowing extras, so a model fills the
    gap from other harnesses' shell schemas and yolop's
    `additionalProperties: false` schema then rejects the call: the most-used
-   tool in the harness spent a round trip on a correction. LSP tools defer with
-   every other opt-in surface; this reverses an earlier eager profile justified
-   by an LSP adoption eval that measured lower adoption with stubbed schemas, so
-   re-measure before treating the current profile as settled. Extension tools
-   explicitly marked `never_defer` retain their manifest contract. Yolop does not own the built-in definitions, so it sets this policy
-   by name rather than changing each tool's `DeferrablePolicy`.
+   tool in the harness spent a round trip on a correction. `repo_map` is eager
+   for the same contract reason: its deferred stub exposed no argument names,
+   so models supplied foreign `depth`, `max_depth`, or `max_symbols` controls
+   and validation rejected otherwise valid `/workspace`, linked-worktree, and
+   nested-repository scopes before execution. Its authoritative schema keeps
+   only types and bounds, 261 bytes instead of 966, so adding it preserves the
+   cold-start schema-reduction gate. Optional defaults live in the tool
+   description: a strict-provider A/B showed that types and bounds alone led
+   the model to supply every optional field and expand an unqueried map to 200
+   symbols. `repo_symbols` remains deferred: across five trials per arm, making
+   it eager added 39 median first-request tokens over map-only without reducing
+   recovery calls, and its schema would lower the cold-start reduction from
+   45.0% to 43.6%. LSP tools
+   defer with every other opt-in surface; this reverses an earlier eager profile
+   justified by an LSP adoption eval that measured lower adoption with stubbed
+   schemas, so re-measure before treating the current profile as settled.
+   Extension tools explicitly marked `never_defer` retain their manifest
+   contract. Yolop does not own the built-in definitions, so it sets this
+   policy by name rather than changing each tool's `DeferrablePolicy`.
 
    When `progress_guard` requires its checkpoint, the guard removes
    `tool_search` and other statically blocked exploration paths from the next

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -135,13 +135,13 @@ impl Tool for RepoMapTool {
 
     fn description(&self) -> &str {
         "Build a compact, grouped multi-language symbol map for the workspace or a subpath. \
-         Use this for broad orientation before targeted grep/read."
+         All arguments are optional; omit unused fields and omit `limit` for compact output. \
+         The limit defaults to 50 without `query` and 200 with it; `max_file_bytes` defaults \
+         to 524288. Use this for broad orientation before targeted grep/read."
     }
 
     fn parameters_schema(&self) -> Value {
-        scan_schema(
-            "Optional space-separated terms. Symbols matching any term (in name, path, kind, parent, or signature) are returned, ranked by relevance with the strongest matches first.",
-        )
+        compact_scan_schema()
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
@@ -241,6 +241,32 @@ impl Tool for RepoSymbolsTool {
 
 fn scan_narration_query(arguments: &serde_json::Value) -> Option<String> {
     arg_str(arguments, &["query", "path"]).map(|v| truncate(v, 48))
+}
+
+// repo_map is eager because models need its real argument names on the first
+// turn. Keep the always-on schema to authoritative types and bounds; the tool
+// descriptions own when and why to use the map, while result metadata owns
+// truncation recovery.
+fn compact_scan_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": { "type": "string" },
+            "query": { "type": "string" },
+            "language": { "type": "string" },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_LIMIT
+            },
+            "max_file_bytes": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_FILE_BYTES
+            }
+        },
+        "additionalProperties": false
+    })
 }
 
 fn scan_schema(query_description: &str) -> Value {
@@ -1423,6 +1449,62 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    #[test]
+    fn eager_repo_map_schema_stays_compact_and_bounded() {
+        let schema = compact_scan_schema();
+        let properties = schema["properties"].as_object().expect("properties");
+        assert_eq!(
+            properties.keys().map(String::as_str).collect::<Vec<_>>(),
+            ["path", "query", "language", "limit", "max_file_bytes"]
+        );
+        assert_eq!(schema["additionalProperties"], json!(false));
+        assert_eq!(schema["properties"]["limit"]["maximum"], json!(MAX_LIMIT));
+        assert_eq!(
+            schema["properties"]["max_file_bytes"]["maximum"],
+            json!(MAX_FILE_BYTES)
+        );
+        let bytes = serde_json::to_vec(&schema).expect("serialize schema").len();
+        assert_eq!(bytes, 261, "eager repo_map schema cost changed");
+    }
+
+    #[test]
+    fn deferred_repo_symbols_keeps_its_descriptive_reveal_schema() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workspace = host(dir.path());
+        let map_schema = RepoMapTool {
+            workspace: workspace.clone(),
+        }
+        .parameters_schema();
+        let symbols_schema = RepoSymbolsTool { workspace }.parameters_schema();
+
+        assert!(
+            symbols_schema["properties"]["query"]["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("ranked by relevance"))
+        );
+        assert!(
+            serde_json::to_vec(&symbols_schema)
+                .expect("serialize symbols schema")
+                .len()
+                > serde_json::to_vec(&map_schema)
+                    .expect("serialize map schema")
+                    .len()
+        );
+    }
+
+    #[test]
+    fn eager_repo_map_description_explains_optional_defaults() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let tool = RepoMapTool {
+            workspace: host(dir.path()),
+        };
+        let description = tool.description();
+
+        assert!(description.contains("All arguments are optional"));
+        assert!(description.contains("omit `limit`"));
+        assert!(description.contains("defaults to 50"));
+    }
+
     fn host(path: &Path) -> Arc<WorkspaceHost> {
         Arc::new(
             WorkspaceHost::new(
@@ -1962,6 +2044,48 @@ trait Named {
         };
         assert_eq!(sub["count"], json!(1));
         assert_eq!(sub["files"][0]["symbols"][0]["name"], json!("pkg_fn"));
+    }
+
+    #[tokio::test]
+    async fn repo_map_scans_nested_repository_in_linked_worktree_layout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A linked Git worktree identifies its repository with a .git file,
+        // not a .git directory. The scanner must treat that as metadata while
+        // still accepting the model-facing alias for a nested repository.
+        write(
+            &dir.path().join(".git"),
+            "gitdir: /tmp/repo/.git/worktrees/fixture\n",
+        );
+        write(
+            &dir.path().join("REPOS/nested/src/lib.rs"),
+            "pub fn nested_owner() {}\n",
+        );
+        write(
+            &dir.path().join("outside.rs"),
+            "pub fn outside_scope() {}\n",
+        );
+
+        let capability = RepoMapCapability::new(host(dir.path()));
+        let tools = capability.tools();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name() == "repo_map")
+            .expect("repo_map tool");
+
+        for path in ["/workspace/REPOS/nested", "REPOS/nested"] {
+            let ToolExecutionResult::Success(result) = tool
+                .execute(json!({ "path": path, "language": "rust" }))
+                .await
+            else {
+                panic!("expected success scanning {path}");
+            };
+            assert_eq!(result["count"], json!(1), "scope {path}");
+            assert_eq!(
+                result["files"][0]["symbols"][0]["name"],
+                json!("nested_owner"),
+                "scope {path}"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1292,6 +1292,10 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "read_many_files",
     "list_directory",
     "grep_files",
+    // A deferred stub exposes no argument names. Recent sessions consequently
+    // invented depth/max_depth/max_symbols for repo_map and were rejected by
+    // the authoritative schema before the valid workspace scope was resolved.
+    "repo_map",
     "write_todos",
     "write_session_title",
     // The most-called tool in the harness, and the one a deferred stub hurts
@@ -8812,6 +8816,10 @@ mod tests {
             "read_file",
             "list_directory",
             "grep_files",
+            // Real-session regression: a deferred repo_map stub exposed no
+            // parameter names, so models invented depth/max_depth and the
+            // authoritative schema rejected the call before path resolution.
+            "repo_map",
             "write_todos",
             "write_session_title",
             "progress_checkpoint",
@@ -8822,6 +8830,7 @@ mod tests {
         let deferred = [
             "write_file",
             "edit_file",
+            "repo_symbols",
             // Opt-in surfaces defer, LSP included.
             "lsp_definition",
             "lsp_hover",


### PR DESCRIPTION
## What changed

repo_map now keeps its real compact parameter schema in the first-turn tool profile. The provider-visible description makes optional defaults explicit, while repo_symbols retains its descriptive reveal-time schema and stays deferred.

The harness now covers /workspace aliases, linked-worktree metadata, nested repository scopes, schema adoption, tool failures, result bytes, and three-arm profile controls. A successful queried repo_symbols result now counts as targeted recovery after a truncated map.

## Why

Recent sessions made 10 repo_map calls and 6 failed. The apparent path failures never reached path resolution: the deferred stub hid every argument name, models invented depth, max_depth, or max_symbols, and the authoritative Yolop pre-tool validation rejected the calls. Valid repo_symbols calls succeeded on the same linked-worktree scopes, so the owning issue is the Yolop eager/deferred disclosure profile, not Everruns path resolution.

## Before / After

Before:

- 6 of 10 recent repo_map calls failed before execution.
- Deferred baseline on the uncoached linked-worktree case used task-tool counts [2, 1, 1, 2, 1] across five trials.
- Types and bounds alone led OpenAI strict calling to populate every optional field and expand an unqueried map to 200 symbols.

After:

- Map-only used exactly one task tool in 5/5 scoped trials, with zero map failures.
- Final profile run 20260825T031434Z-f2f8: 30/30 correct answers and 15/15 bounded targeted recoveries. Two runs failed only the unchanged duplicate-recovery discipline, one in each eager arm.
- Corrected optional-guidance confirmation 20260825T031243Z-f1a6: 30/30 passed.
- Ordinary controls 20260825T031545Z-e7ef: 30/30 passed.
- Focused live smoke 20260825T031646Z-5205: 1/1 passed with write_session_title, then repo_map.
- Current main plus map-only: 23,181 provider-visible definition bytes and 8,920 total schema bytes. Excluding the independently measured 828-byte eager batch-read schema on main leaves 8,092 historical bytes, preserving the 45% floor.
- Making repo_symbols eager added 39 median first-request tokens over map-only, reduced no recovery calls, and raised the historical schema component to 8,308 bytes, only a 43.6% reduction. It therefore remains deferred.

All live runs used synthetic harness fixtures through openai/gpt-5.5; no repository contents or session logs were sent.

## Risk

- Low.
- A read-only tool has more first-turn schema context, adding 261 schema bytes and explicit optional-default guidance.
- Existing containment, symlink skipping, numeric bounds, result limits, and truncation behavior are unchanged.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated system-prompt, tool-search, and the knowledge log with the ownership diagnosis, measured profile decision, cost floor, and provider behavior.

## Security

- TM-FS: existing workspace containment and symlink defenses are unchanged; focused tests cover aliases, linked-worktree metadata, nested scopes, outside-scope exclusion, and existing traversal controls.
- TM-TOOL: no new capability or write authority. Only an existing read-only schema becomes eager; repo_symbols remains deferred.
- TM-LLM: the compact schema retains types, integer bounds, and additionalProperties false; optional defaults move to the tool description. Live-provider evidence used synthetic fixtures only.
- Resource exhaustion: symbol limits, max_file_bytes, candidate caps, bounded results, and truncation recovery remain enforced.
- TM-DEP and secret handling: no dependency, credential, logging, or environment-key changes.

## Follow-ups

No follow-ups.