### PR TITLE
fix(acp): continue after provider stream stalls

### DIFF
--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -217,6 +217,12 @@ that is distinct from Yolop's narrated title.
 To avoid duplicating streamed text, a completed assistant message is only
 emitted as a chunk when no deltas streamed for it during the turn.
 
+When the provider exhausts its transparent stream-stall retries, the ACP prompt
+loop submits one fresh continuation against the durable session transcript. The
+continuation tells the model not to repeat completed tools or settled work. It
+is bounded to one attempt per client prompt, so a persistently stalled provider
+still terminates instead of entering an automatic recovery loop.
+
 After `session/new`, yolop sends `available_commands_update` with
 capability-sourced slash commands such as `/setup` and user-invocable skill
 commands. ACP clients run commands by sending their literal text in

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -1476,6 +1476,7 @@ async fn run_prompt(
     mut prompt: String,
     mut input: InputMessage,
 ) -> StopReason {
+    let mut provider_stall_followups = 0usize;
     loop {
         let (stop, result) = run_prompt_once(peer.clone(), session.clone(), prompt, input).await;
         if stop == StopReason::Cancelled {
@@ -1498,8 +1499,14 @@ async fn run_prompt(
             }
             return stop;
         };
-        let Some(next) = completion_followup(&peer, &session, &result).await else {
-            return stop;
+        let next = if let Some(next) = provider_stall_followup(&result, provider_stall_followups) {
+            provider_stall_followups = provider_stall_followups.saturating_add(1);
+            next
+        } else {
+            let Some(next) = completion_followup(&peer, &session, &result).await else {
+                return stop;
+            };
+            next
         };
         prompt = next;
         input = crate::session_state::task_completion::tag_continuation(
@@ -1609,6 +1616,25 @@ async fn run_prompt_once(
             (StopReason::EndTurn, None)
         }
         Err(_) => (StopReason::Cancelled, None),
+    }
+}
+
+const PROVIDER_STALL_CONTINUATION: &str = "The provider stopped responding during the previous model step. Continue the current task from the durable conversation state. Do not repeat completed tool calls or settled work.";
+
+fn provider_stall_followup(
+    turn_result: &everruns_host::TurnResult,
+    followups: usize,
+) -> Option<String> {
+    if followups == 0
+        && !turn_result.success
+        && turn_result
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("provider stream stall"))
+    {
+        Some(PROVIDER_STALL_CONTINUATION.to_string())
+    } else {
+        None
     }
 }
 
@@ -1797,6 +1823,45 @@ mod tests {
         assert_eq!(
             select_setup_auth_method(&methods, None, "openrouter").unwrap(),
             Some("openrouter_browser".to_string())
+        );
+    }
+
+    fn turn_result(success: bool, error: Option<&str>) -> everruns_host::TurnResult {
+        everruns_host::TurnResult {
+            response: String::new(),
+            iterations: 1,
+            tool_calls_count: 0,
+            success,
+            error: error.map(str::to_string),
+            stop_reason: if success {
+                everruns_core::turn::TurnStopReason::EndTurn
+            } else {
+                everruns_core::turn::TurnStopReason::Error
+            },
+            turn_id: everruns_provider::typed_id::TurnId::new(),
+        }
+    }
+
+    #[test]
+    fn provider_stall_gets_one_fresh_continuation() {
+        let stalled = turn_result(
+            false,
+            Some("LLM error: provider stream stall: no tokens for 120s"),
+        );
+
+        assert_eq!(
+            provider_stall_followup(&stalled, 0).as_deref(),
+            Some(PROVIDER_STALL_CONTINUATION)
+        );
+        assert_eq!(provider_stall_followup(&stalled, 1), None);
+    }
+
+    #[test]
+    fn provider_stall_followup_ignores_other_turn_results() {
+        assert_eq!(provider_stall_followup(&turn_result(true, None), 0), None);
+        assert_eq!(
+            provider_stall_followup(&turn_result(false, Some("permanent provider error")), 0),
+            None
         );
     }
 


### PR DESCRIPTION
## Summary

- continue an ACP prompt once after the provider exhausts stream-stall retries
- use the durable session transcript so settled tools and completed work are not replayed
- bound recovery to one continuation per client prompt to prevent retry loops

## Before / After

**Before:** after transparent provider retries exhausted, ACP ended the prompt with `LLM error: provider stream stall: no tokens for 120s`.

**After:** ACP submits one fresh continuation against the durable conversation state. If the provider stalls again, the prompt terminates normally instead of looping.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test editor::acp::server::tests --features yolop-yep/schema`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Full workspace suite: 1,283 tests passed; the cold-start prompt budget test fails identically on `origin/main` at 21,730 bytes versus its 20,480-byte cap. The unrelated timing-sensitive long-command test passed on rerun.

## Security

Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP. The change adds no filesystem or shell access, dependencies, credentials, or capability registration. The recovery prompt is static, is activated only by the host-generated provider-stall error marker, and is bounded to one attempt.

## Knowledge

Updated `knowledge/specs/acp.md` with the bounded stream-stall continuation contract.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
