### PR TITLE
fix(narration): name the agent spawn_agent spawns

### DIFF
--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod session_history;
 pub(crate) mod session_tasks_override;
 pub(crate) mod skill_registry;
 pub mod skills;
+pub(crate) mod subagents_override;
 pub(crate) mod tool_approval;
 pub(crate) mod tool_argument_validation;
 pub(crate) mod tool_reveal;

--- a/src/capabilities/narration.rs
+++ b/src/capabilities/narration.rs
@@ -65,6 +65,46 @@ pub fn narrate_cancel_task(tool_call: &ToolCall, phase: ToolNarrationPhase) -> S
     stable_labeled("Cancel task", detail, phase)
 }
 
+/// Everruns `spawn_agent` otherwise falls back to "Running Spawn Agent", which
+/// says nothing about the agent being spawned. Name the run, the target kind,
+/// and the blueprint or configured target id when one is set.
+pub fn narrate_spawn_agent(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
+    let arguments = &tool_call.arguments;
+    let name = arg_str(arguments, &["name"]).map(|name| truncate(name, 40));
+    let kind = match arguments
+        .get("target")
+        .and_then(|target| arg_str(target, &["type"]))
+        .unwrap_or("subagent")
+    {
+        "agent" => "agent",
+        "external_a2a" => "external agent",
+        _ => "subagent",
+    };
+    let identity = arg_str(arguments, &["blueprint"])
+        .map(|blueprint| truncate(blueprint, 40))
+        .or_else(|| {
+            arguments
+                .get("target")
+                .and_then(|target| arg_str(target, &["id", "external_agent_id"]))
+                .map(|id| truncate(id, 40))
+        });
+
+    let mut target = match &name {
+        Some(name) => format!("{name} {kind}"),
+        None => kind.to_string(),
+    };
+    if let Some(identity) = identity.filter(|identity| Some(identity) != name.as_ref()) {
+        target.push_str(&format!(" ({identity})"));
+    }
+
+    let verb = match phase {
+        ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => "Launching",
+        ToolNarrationPhase::Completed => "Launched",
+        ToolNarrationPhase::Failed => "Failed to launch",
+    };
+    format!("{verb} {target}")
+}
+
 /// Everruns `spawn_background` otherwise falls back to "Running Spawn Background".
 pub fn narrate_spawn_background(tool_call: &ToolCall, phase: ToolNarrationPhase) -> String {
     stable_labeled(
@@ -258,5 +298,68 @@ mod tests {
             arguments: json!({}),
         };
         assert!(narrate_session_task_tool(&unknown, ToolNarrationPhase::Started).is_none());
+    }
+
+    #[test]
+    fn spawn_agent_narration_names_the_spawned_agent() {
+        let plain = ToolCall {
+            id: "call-1".to_owned(),
+            name: "spawn_agent".to_owned(),
+            arguments: json!({
+                "name": "Orbit Scout",
+                "instructions": "Inspect the orbit subsystem.",
+                "target": { "type": "subagent" }
+            }),
+        };
+        assert_eq!(
+            narrate_spawn_agent(&plain, ToolNarrationPhase::Started),
+            "Launching Orbit Scout subagent"
+        );
+        assert_eq!(
+            narrate_spawn_agent(&plain, ToolNarrationPhase::Completed),
+            "Launched Orbit Scout subagent"
+        );
+
+        let blueprint = ToolCall {
+            id: "call-2".to_owned(),
+            name: "spawn_agent".to_owned(),
+            arguments: json!({
+                "name": "Orbit Scout",
+                "target": { "type": "subagent" },
+                "blueprint": "github_scout"
+            }),
+        };
+        assert_eq!(
+            narrate_spawn_agent(&blueprint, ToolNarrationPhase::Started),
+            "Launching Orbit Scout subagent (github_scout)"
+        );
+
+        let handoff = ToolCall {
+            id: "call-3".to_owned(),
+            name: "spawn_agent".to_owned(),
+            arguments: json!({
+                "name": "Release check",
+                "target": { "type": "agent", "id": "release-reviewer" }
+            }),
+        };
+        assert_eq!(
+            narrate_spawn_agent(&handoff, ToolNarrationPhase::Failed),
+            "Failed to launch Release check agent (release-reviewer)"
+        );
+    }
+
+    /// Arguments that are still streaming carry no target yet; the line must
+    /// stay a spawn line rather than the generic tool-name fallback.
+    #[test]
+    fn spawn_agent_narration_tolerates_missing_arguments() {
+        let bare = ToolCall {
+            id: "call-1".to_owned(),
+            name: "spawn_agent".to_owned(),
+            arguments: json!({}),
+        };
+        assert_eq!(
+            narrate_spawn_agent(&bare, ToolNarrationPhase::Started),
+            "Launching subagent"
+        );
     }
 }

--- a/src/capabilities/subagents_override.rs
+++ b/src/capabilities/subagents_override.rs
@@ -1,0 +1,170 @@
+//! Argument-aware narration for the everruns `spawn_agent` tool.
+//!
+//! `spawn_agent` is assembled by everruns core from the registered delegation
+//! targets rather than contributed by a capability, so no capability narration
+//! hook covers it and every spawn renders as the generic "Running Spawn Agent".
+//! Yolop wraps `SubagentCapability` so its narration hook answers for
+//! `spawn_agent` and the transcript says which agent is being spawned.
+//!
+//! Upstream fixed the root cause in everruns#3277: the act atom now asks the
+//! executing tool in the session tool registry for its own narration before the
+//! display-name fallback. That is merged but unreleased, and yolop consumes
+//! published crates, so this wrapper carries the behavior until the version bump
+//! and is deleted then.
+
+use crate::capabilities::narration::narrate_spawn_agent;
+use async_trait::async_trait;
+use everruns_core::capabilities::{CapabilityLocalization, DelegationTargetProvider, RiskLevel};
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::{Capability, CapabilityStatus, Tool};
+use everruns_platform::capabilities::SubagentCapability;
+use everruns_provider::{ToolCall, ToolDefinition};
+use serde_json::Value;
+
+pub(crate) struct NarratedSubagentCapability {
+    inner: SubagentCapability,
+}
+
+impl NarratedSubagentCapability {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: SubagentCapability,
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for NarratedSubagentCapability {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        self.inner.localizations()
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        self.inner.status()
+    }
+
+    fn icon(&self) -> Option<&str> {
+        self.inner.icon()
+    }
+
+    fn category(&self) -> Option<&str> {
+        self.inner.category()
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        self.inner.risk_level()
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        self.inner.features()
+    }
+
+    fn config_schema(&self) -> Option<Value> {
+        self.inner.config_schema()
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        self.inner.validate_config(config)
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        self.inner.system_prompt_addition()
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        self.inner.tools()
+    }
+
+    /// The delegation seam is what actually contributes `spawn_agent`; a
+    /// wrapper that forgot it would withhold subagents from the model.
+    fn delegation_target_with_config(&self, config: &Value) -> Option<DelegationTargetProvider> {
+        self.inner.delegation_target_with_config(config)
+    }
+
+    fn narrate(
+        &self,
+        _tool_def: Option<&ToolDefinition>,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        (tool_call.name == "spawn_agent").then(|| narrate_spawn_agent(tool_call, phase))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn spawn_call(arguments: Value) -> ToolCall {
+        ToolCall {
+            id: "call-1".to_owned(),
+            name: "spawn_agent".to_owned(),
+            arguments,
+        }
+    }
+
+    #[test]
+    fn narrates_spawn_agent_with_the_target_agent() {
+        let capability = NarratedSubagentCapability::new();
+        let narration = capability.narrate(
+            None,
+            &spawn_call(json!({
+                "name": "Orbit Scout",
+                "target": { "type": "subagent" },
+                "blueprint": "github_scout"
+            })),
+            ToolNarrationPhase::Started,
+            None,
+            everruns_core::tool_narration::ToolNarrationContext::default(),
+        );
+        assert_eq!(
+            narration.as_deref(),
+            Some("Launching Orbit Scout subagent (github_scout)")
+        );
+    }
+
+    #[test]
+    fn leaves_other_tools_to_their_owners() {
+        let capability = NarratedSubagentCapability::new();
+        let mut call = spawn_call(json!({}));
+        call.name = "read_file".to_owned();
+        assert!(
+            capability
+                .narrate(
+                    None,
+                    &call,
+                    ToolNarrationPhase::Started,
+                    None,
+                    everruns_core::tool_narration::ToolNarrationContext::default(),
+                )
+                .is_none()
+        );
+    }
+
+    /// The wrapper must keep contributing the delegation target, otherwise
+    /// `spawn_agent` disappears from the model's tools entirely.
+    #[test]
+    fn keeps_contributing_the_subagent_delegation_target() {
+        let capability = NarratedSubagentCapability::new();
+        let target = capability
+            .delegation_target_with_config(&json!({}))
+            .expect("subagent delegation target");
+        assert_eq!(target.target_type, "subagent");
+        assert_eq!(target.tool.name(), "spawn_agent");
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -97,8 +97,8 @@ use everruns_llmsim::LlmSimConfig;
 use everruns_llmsim::LlmSimRuntimeExt;
 use everruns_mcp::{McpAuthProvider, McpAuthRequest, McpCredential};
 use everruns_platform::capabilities::{
-    SESSION_TASKS_CAPABILITY_ID, SUBAGENTS_CAPABILITY_ID, SubagentCapability,
-    USER_HOOKS_CAPABILITY_ID, UserHooksCapability,
+    SESSION_TASKS_CAPABILITY_ID, SUBAGENTS_CAPABILITY_ID, USER_HOOKS_CAPABILITY_ID,
+    UserHooksCapability,
 };
 use everruns_provider::AgentLoopError;
 use everruns_provider::model_profiles::get_model_profile;
@@ -4055,7 +4055,8 @@ pub async fn build_with_options(
     capabilities.register(
         crate::capabilities::session_tasks_override::TruthfulSessionTasksCapability::new(),
     );
-    capabilities.register(SubagentCapability);
+    capabilities
+        .register(crate::capabilities::subagents_override::NarratedSubagentCapability::new());
     capabilities.register(crate::capabilities::NarratedBackgroundExecutionCapability::new());
     capabilities.register(SessionStorageCapability);
     capabilities.register(DaytonaCapability);
@@ -6003,6 +6004,32 @@ mod tests {
             message.role == MessageRole::Agent
                 && message.text() == Some("Orbit subsystem inspected.")
         }));
+
+        // The transcript line must name the spawned agent, not read
+        // "Running Spawn Agent" (the generic display-name fallback).
+        let events = built
+            .handles
+            .runtime
+            .events()
+            .await
+            .expect("runtime events");
+        let narrations = events
+            .iter()
+            .filter_map(|event| match &event.data {
+                everruns_core::EventData::ToolStarted(data)
+                    if data.tool_call.name == "spawn_agent" =>
+                {
+                    data.narration.clone()
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            narrations
+                .iter()
+                .any(|narration| narration == "Launching Orbit Scout subagent"),
+            "spawn_agent narration should name the agent: {narrations:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What changed

Delegation now reads as a delegation in the transcript. `spawn_agent` calls
narrate with the run name, the target kind (subagent, agent, external agent),
and the blueprint or configured target id when one is set:

- `Launching Orbit Scout subagent`
- `Launching Orbit Scout subagent (github_scout)`
- `Failed to launch Release check agent (release-reviewer)`

`NarratedSubagentCapability` wraps the upstream `SubagentCapability` so its
narration hook answers for `spawn_agent`, the same shape yolop already uses for
`spawn_background` and the session-task tools. The wrapper delegates every
upstream method, the delegation-target seam included, so the tool itself is
unchanged.

## Why

Spawning three subagents produced three identical transcript rows reading
"Running Spawn Agent" — no run name, no target, nothing to tell them apart.

everruns assembles `spawn_agent` in core from the registered delegation targets
rather than contributing it from a capability, and narration reaches events
through one hook per applied capability that only matches tools that capability
lists in `tools()`. Nothing lists `spawn_agent`, so its own narration was never
asked for and the generic display-name fallback won.

The root cause is fixed upstream in everruns#3277 (merged): the act atom now
asks the executing tool in the session tool registry before the display-name
fallback. Yolop consumes published crates, so this host-side wrapper carries the
behavior until the version bump, and is deleted then. The comment on the module
says so.

## Before / After

`scripted_subagent_runs_in_a_real_child_session` now asserts the narration on the
emitted `tool.started` event, so the counterfactual is one registration away.
With the wrapper swapped back for the bare upstream capability:

```
spawn_agent narration should name the agent: ["Running Spawn Agent"]
test result: FAILED. 0 passed; 1 failed
```

With the wrapper:

```
test runtime::tests::scripted_subagent_runs_in_a_real_child_session ... ok
```

Live-provider smoke (Anthropic, real subagent spawn, `-p` mode):

```
$ cargo run -- --provider anthropic -p "Use spawn_agent to delegate to a subagent
  named Orbit Scout with instructions to reply with the single word ok. …"
The Orbit Scout subagent replied: **ok**
```

and the narration recorded on that session's events:

```
tool.completed: Launched Orbit Scout subagent
```

## Risk

- Low
- The wrapper is the only new failure surface: a delegated method it forgot would
  change subagent behavior rather than wording. `delegation_target_with_config`
  is the load-bearing one (it is what contributes `spawn_agent` at all) and has
  its own test asserting the target type and tool name; config schema,
  validation, system prompt, risk level, and features are delegated too.
  Narration text itself is display-only.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

`No knowledge update required` — narration wording for one upstream tool is
source-level detail, and the module comment records the temporary-wrapper
decision next to the code. `knowledge/specs/presentation.md` describes the
presentation model, which is unchanged: the narration string is authored in the
runtime and rendered as-is.

## Security

Reviewed TM-LLM and TM-TOOL; no findings.

- TM-LLM: narration renders only `name`, `target.type`, `target.id` /
  `external_agent_id`, and `blueprint`, each truncated to 40 characters.
  Instructions, blueprint config, and result/message schemas are never rendered,
  so nothing credential-bearing reaches the transcript or session JSONL.
  `target.type` maps to a fixed set of literals, so no model-supplied text passes
  through as the agent kind.
- TM-TOOL: the wrapper registers no new tool and adds no execution path. It
  delegates `tools()` and the delegation target to the upstream capability and
  overrides presentation only, so the write blocklist and approval behavior are
  untouched.
- TM-FS, TM-BASH, TM-DEP: not touched. No filesystem or shell surface in the
  diff, and no new dependency.

## Follow-ups

`No follow-ups.` Deleting this wrapper is not deferred work but a consequence of
the next everruns version bump, and the module comment carries that instruction
to whoever does the bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcJrDLr9U1V1hciNaUpAko)_