### PR TITLE
feat(deps): adopt everruns 0.19 core and 0.20 provider

### DIFF
--- a/.agents/skills/maintenance/surfaces.md
+++ b/.agents/skills/maintenance/surfaces.md
@@ -14,11 +14,11 @@ the failing run linked and report the pass blocked.
 
 ## Dependency health
 
-The `everruns-*` family (`-runtime`, `-core`, `-anthropic`, `-openai`,
+The `everruns-*` family (`-host`, `-core`, `-anthropic`, `-openai`,
 `-integrations-duckduckgo`) moves in lockstep at one minor version.
 
 ```bash
-cargo search everruns-runtime --limit 1
+cargo search everruns-host --limit 1
 cargo update                    # transitive drift
 cargo tree --duplicates         # split transitive versions: fix or explain
 cargo audit                     # when available; otherwise Dependabot alerts

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -323,7 +323,7 @@ jobs:
           # frozen_string_literal: true
 
           class Yolop < Formula
-            desc "Minimal terminal coding agent built on everruns-runtime"
+            desc "Minimal terminal coding agent built on everruns-host"
             homepage "${HOMEPAGE}"
             # No explicit `version` — Homebrew scans it from the download URL
             # (the release tag in the path). Setting it again trips

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Yolop, coding-agent guidance
 
 Yolop is a terminal coding agent built on
-[`everruns-runtime`](https://crates.io/crates/everruns-runtime). The binary and
+[`everruns-host`](https://crates.io/crates/everruns-host). The binary and
 the crate are both named `yolop`.
 
 This file is read on every turn. It carries repository facts and gotchas only;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
  "everruns-host",
  "everruns-llmsim",
  "everruns-platform",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "futures",
  "libc",
  "parking_lot",
@@ -2163,7 +2163,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "eventsource-stream",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "futures",
  "reqwest 0.13.4",
  "serde",
@@ -2182,7 +2182,7 @@ dependencies = [
  "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2215,7 +2215,7 @@ dependencies = [
  "chrono",
  "cron",
  "everruns-capability",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "futures",
  "globset",
  "inventory",
@@ -2245,7 +2245,7 @@ dependencies = [
  "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "futures",
  "serde",
  "serde_json",
@@ -2268,7 +2268,7 @@ dependencies = [
  "everruns-core",
  "everruns-engine",
  "everruns-mcp",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "futures",
  "ignore",
  "regex",
@@ -2283,20 +2283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "everruns-http"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38b07ac8e30d11181c9da9e1ba92757558c136453753e8cd64283b26800e064"
-dependencies = [
- "async-trait",
- "everruns-core",
- "everruns-provider 0.18.0",
- "futures",
- "reqwest 0.13.4",
- "serde_json",
-]
-
-[[package]]
 name = "everruns-integrations-daytona"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,7 +2292,7 @@ dependencies = [
  "chrono",
  "everruns-core",
  "everruns-platform",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "inventory",
  "reqwest 0.13.4",
  "serde",
@@ -2324,7 +2310,7 @@ dependencies = [
  "async-trait",
  "everruns-capability",
  "everruns-core",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "inventory",
  "reqwest 0.13.4",
  "serde",
@@ -2344,7 +2330,7 @@ dependencies = [
  "base64 0.23.1",
  "everruns-capability",
  "everruns-core",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "hex",
  "serde_json",
  "sha2 0.11.0",
@@ -2360,7 +2346,7 @@ dependencies = [
  "async-trait",
  "everruns-core",
  "everruns-platform",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "inventory",
  "reqwest 0.13.4",
  "serde",
@@ -2379,7 +2365,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "everruns-capability",
  "everruns-core",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "fetchkit",
  "futures",
  "serde_json",
@@ -2396,7 +2382,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "everruns-host",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "futures",
  "llmsim",
  "serde_json",
@@ -2415,7 +2401,7 @@ dependencies = [
  "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -2436,7 +2422,7 @@ checksum = "6c9f2e2f7adedadbbcaa367a90350e74a1aac72008f5784e481cf59c45a902b1"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "reqwest 0.13.4",
  "serde",
 ]
@@ -2449,7 +2435,7 @@ checksum = "c6a5217c92a0413fdc7853f598dc3797c72d5932e80b64191249c83483848630"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -2465,7 +2451,7 @@ checksum = "17c287f4c574905b290bcc3dcb50aa9f5dfff7de4aef22c03afae9da88b1ef6a"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -2484,7 +2470,7 @@ dependencies = [
  "everruns-capability",
  "everruns-core",
  "everruns-host",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "inventory",
  "jsonschema",
  "serde",
@@ -2492,30 +2478,6 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
- "uuid 1.24.0",
-]
-
-[[package]]
-name = "everruns-provider"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680827ffb10dd7e12a078cbababeea099ad791b9206918b6edf77e8d090defc3"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.23.1",
- "chrono",
- "futures",
- "hex",
- "rand 0.10.2",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
  "uuid 1.24.0",
 ]
 
@@ -10020,7 +9982,6 @@ dependencies = [
  "everruns-capability",
  "everruns-core",
  "everruns-host",
- "everruns-http",
  "everruns-integrations-daytona",
  "everruns-integrations-duckduckgo",
  "everruns-integrations-filesystem",
@@ -10032,7 +9993,7 @@ dependencies = [
  "everruns-openai",
  "everruns-openrouter",
  "everruns-platform",
- "everruns-provider 0.19.0",
+ "everruns-provider",
  "flate2",
  "futures",
  "hf-hub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.4"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f2be24e17656162a1131f96e9d57fe8be875a43187e1fc9220827c2984414f"
+checksum = "ef79123793a55cb73d6ad16336ba6f627d81f7636b143d1129ef4f78a96ba49f"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa974de720277edbb2044813f896da2628271d26a28f694c9cf8ab70dd43d2"
+checksum = "28da83571906d0c18a23c62430da3022122084061b6e7b4f44c376bdeab5e079"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2174,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbc8f16b615cc88c74d687311be07e46593617442a8fed6032374d9eaa16593"
+checksum = "5d78420291af77ae17f4ebb1d0c937d4840cd8b0c8b3109a85f67c19ffff017a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2193,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79105a50ce58ca5d17b6aec30116535a8950c888316bf2cfaebb72e44a71027d"
+checksum = "64146edfc12e45718a50f08fedbb42971d6ec03c1550246e751251b71551c576"
 dependencies = [
  "async-trait",
  "schemars 1.2.2",
@@ -2205,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6cb8dd6bcb1f8500338d818d8905c90baae6fcaf2efa0a3d0250417b30c875"
+checksum = "76bdc8fecfb739bbb0622ad2a858722367308537521338d66a2df0acd24fb784"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8e144c8cc6caf3cbb0c4185ccc3a72f3e1c7f075f110690b9a16d479427a31"
+checksum = "d99bd3d66ddeb56d0124a56210d0e740f905ecf171e2e981ed77fbdcd51f2c20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cf3b8d8e104d6b5b5b69f17ab3135fcd02d7930181b2c7265226954be60ad7"
+checksum = "661b4e5b668b8f4ddf1f46d10f6375a543f3aa7a91fec1675206238aae2a3946"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2284,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad2763c47184957b435f0e99daff6819c64ebafedf41b9fecf3e811da614d77"
+checksum = "98449a0c88f8e98eb1b00d13b2e912dc0f3cc16931c9fd1a1b1ddee5eaac9723"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2303,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cda5509eced9ce31c481c77bbef61f46aa3c476e66d637147cf27aa9dd0c896"
+checksum = "4ffaa4d4815137a99b168db7c1a53efbfe590ccb0a164b97d758114196ae70e4"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2321,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc7c5828aab6a15686711afe88ca3d6b8681da2471882f49860ca3031c7bdae"
+checksum = "dbfeffe5a28af27dd5efbba0bbda07f5a971dbd9d7cf1949e7bfec6477fe8251"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2339,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c91a87d2f0b7b03ad85f81a9f141768aefb2ee448e7eef2f8b2e1d50266b7fc"
+checksum = "236d8a218342441dfc6334917e5bc7dec5c62dfc6609e7ab90d785717b396898"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2355,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-web-fetch"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46115a721e0a08a094b8cd53df7eafc29fb12d62654208eb9ba49d300d292a55"
+checksum = "0d6f7539d7e506ce2cdf91fb6a699103ec1ff2f4935176075e24c45525b02b12"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b9d96ffcd9b554beb66748d35f8b2433e8b68a65d2bfa9197e4df42e12425a"
+checksum = "5bd61800c3bd04180be2fb4b92b166b2f5419f1e34c86f9f32fa895d1e250cb7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7385572f652b73673ac10386b5544c271b1a9543bab3007e0e6c7e5919cde99"
+checksum = "9c50d380b0c21fa03eb33f355d0ff0063c0bd57b68319a158bf445040c5ac5eb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2416,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9f2e2f7adedadbbcaa367a90350e74a1aac72008f5784e481cf59c45a902b1"
+checksum = "678ea25d73733151047df63ffb286e9533328a164a1155a38535d77b515bc8fc"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2429,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a5217c92a0413fdc7853f598dc3797c72d5932e80b64191249c83483848630"
+checksum = "019a64e89e3141fcb2f382e9f738917856f1d8eaee0b96dd497607a9934f4e00"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2445,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c287f4c574905b290bcc3dcb50aa9f5dfff7de4aef22c03afae9da88b1ef6a"
+checksum = "d50bebe0830c26920caf7f147e140d760a608c8e65ceb0414e875a4b57b5fd4a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2459,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2887b79e1211ce45fc0b52e11ade64334af30efccfd1e3e709822d671c5457"
+checksum = "a2f5f0c2c67532f2d6d3502a1afa8885ae97399d421021db640285f975b0a5f0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2483,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9c4398c122a7eef161ec9cc14ce5c6c65f586609644f6b2a9e5a87302313ff"
+checksum = "e890de18e510543148a6c0e7260d733dcde6cd39c4c379621ed8b0e659b1d46a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.17.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
-description = "Yolop — a terminal coding agent built on everruns-runtime"
+description = "Yolop — a terminal coding agent built on everruns-host"
 homepage = "https://github.com/everruns/yolop"
 repository = "https://github.com/everruns/yolop"
 readme = "README.md"
@@ -177,14 +177,15 @@ everruns-mcp = { version = "0.19.1", features = ["stdio"] }
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
 everruns-host = { version = "0.20.2", features = ["mcp-stdio"] }
-# The direct egress implementation moved out of everruns-core into its own
-# crate; yolop uses it for MCP OAuth discovery.
+# DirectEgressService, which yolop uses for MCP OAuth discovery, is host's own
+# `direct-egress` module; `mcp-stdio` already turns that feature on. The
+# standalone everruns-http crate that used to carry it is yanked on crates.io,
+# and a yanked dependency would make yolop unpublishable.
 # #3182 completed the library boundary cleanup: driver/model/provider types
 # and the built-in capabilities left everruns-core for their own crates.
 everruns-provider = "0.19.0"
 everruns-builtins = "0.18.4"
 everruns-capability = "0.18.0"
-everruns-http = "0.18.0"
 # Yolop ships `--provider llmsim` as a user-facing offline mode, not just a test
 # fixture, so the simulator is a production dependency. 0.18 split it into the
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,54 +151,54 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # transports, the driver registry). Adopting it today would collapse two of nine
 # dependencies and route the rest through escape hatches. Revisit when the
 # facade promotes provider registration, MCP, and capability wiring.
-everruns-anthropic = "0.18.1"
-everruns-core = "0.18.1"
+everruns-anthropic = "0.18.2"
+everruns-core = "0.19.0"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "0.19.0"
-everruns-openai = "0.18.1"
-everruns-meta = "0.18.1"
+everruns-platform = "0.19.1"
+everruns-openai = "0.18.2"
+everruns-meta = "0.18.2"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.18.1"
+everruns-openrouter = "0.18.2"
 # Filesystem persistence comes from the `everruns` facade's `local` feature, not
 # the standalone `everruns-local` crate: same SQLite, git-workspace, and durable
 # log backend, re-exported under `everruns::local`. `everruns-local` is published
 # only against host ^0.18.0, so depending on it pinned yolop off the 0.19 line.
 # Only the `local` feature is wanted; the facade's provider and capability
 # re-exports would duplicate the direct dependencies below.
-everruns = { version = "0.18.4", default-features = false, features = ["local"] }
-everruns-mcp = { version = "0.19.1", features = ["stdio"] }
+everruns = { version = "0.19.1", default-features = false, features = ["local"] }
+everruns-mcp = { version = "0.19.2", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
 #
 # everruns-host replaces everruns-runtime, which upstream deleted in #3101 as a
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
-everruns-host = { version = "0.20.2", features = ["mcp-stdio"] }
+everruns-host = { version = "0.20.3", features = ["mcp-stdio"] }
 # DirectEgressService, which yolop uses for MCP OAuth discovery, is host's own
 # `direct-egress` module; `mcp-stdio` already turns that feature on. The
 # standalone everruns-http crate that used to carry it is yanked on crates.io,
 # and a yanked dependency would make yolop unpublishable.
 # #3182 completed the library boundary cleanup: driver/model/provider types
 # and the built-in capabilities left everruns-core for their own crates.
-everruns-provider = "0.19.0"
-everruns-builtins = "0.18.4"
-everruns-capability = "0.18.0"
+everruns-provider = "0.20.0"
+everruns-builtins = "0.18.5"
+everruns-capability = "0.18.1"
 # Yolop ships `--provider llmsim` as a user-facing offline mode, not just a test
 # fixture, so the simulator is a production dependency. 0.18 split it into the
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as
 # test-only and must not be used from production code. The `host` feature carries
 # the runtime-builder extension trait.
-everruns-llmsim = { version = "0.18.3", features = ["host"] }
+everruns-llmsim = { version = "0.18.4", features = ["host"] }
 # Filesystem and web-fetch capability implementations moved out of
 # everruns-core into their own integration crates (#3119).
-everruns-integrations-filesystem = "0.18.2"
-everruns-integrations-web-fetch = "0.18.1"
-everruns-integrations-duckduckgo = "0.18.1"
-everruns-integrations-parallel = "0.18.1"
-everruns-integrations-daytona = "0.18.1"
+everruns-integrations-filesystem = "0.18.3"
+everruns-integrations-web-fetch = "0.18.2"
+everruns-integrations-duckduckgo = "0.18.2"
+everruns-integrations-parallel = "0.18.2"
+everruns-integrations-daytona = "0.18.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Repo: Agent Friendly](https://img.shields.io/badge/Repo-Agent%20Friendly-blue)](AGENTS.md)
 
 A terminal coding agent built on
-[`everruns-runtime`](https://crates.io/crates/everruns-runtime). One binary
+[`everruns-host`](https://crates.io/crates/everruns-host). One binary
 that plans, edits, runs, and verifies code in your repository, autonomous by
 default, with persistent sessions, agent skills, MCP servers, and editor
 integration over the Agent Client Protocol.

--- a/build.rs
+++ b/build.rs
@@ -15,10 +15,12 @@ fn main() {
         .unwrap_or_else(|| git_short_sha().unwrap_or_else(|| "unknown".to_string()));
     println!("cargo:rustc-env=YOLOP_GIT_SHA={git_sha}");
 
-    let runtime_version = cargo_lock_package_version("everruns-runtime")
-        .or_else(|| cargo_toml_dependency_version("everruns-runtime"))
+    // everruns-host is what everruns-runtime became when upstream deleted the
+    // latter in 0.18; the version line names the crate that actually ships.
+    let host_version = cargo_lock_package_version("everruns-host")
+        .or_else(|| cargo_toml_dependency_version("everruns-host"))
         .unwrap_or_else(|| "unknown".to_string());
-    println!("cargo:rustc-env=YOLOP_EVERRUNS_RUNTIME_VERSION={runtime_version}");
+    println!("cargo:rustc-env=YOLOP_EVERRUNS_HOST_VERSION={host_version}");
 
     // The host's Rust target triple. Needed at runtime to pick the right
     // prebuilt extension binary; `std::env::consts` gives OS and arch but
@@ -86,14 +88,23 @@ fn cargo_toml_dependency_version(package_name: &str) -> Option<String> {
         if !line.starts_with(package_name) {
             continue;
         }
-        if let Some((_, raw_version)) = line.split_once('=') {
-            let version = raw_version.trim().trim_matches('"');
-            if !version.is_empty() {
-                return Some(version.to_string());
-            }
+        // Both `dep = "1.2.3"` and `dep = { version = "1.2.3", ... }` appear in
+        // the manifest, so read the first quoted value rather than the rest of
+        // the line.
+        if let Some((_, raw_value)) = line.split_once('=')
+            && let Some(version) = quoted_version(raw_value)
+            && !version.is_empty()
+        {
+            return Some(version.to_string());
         }
     }
     None
+}
+
+fn quoted_version(raw_value: &str) -> Option<&str> {
+    let (_, rest) = raw_value.split_once('"')?;
+    let (version, _) = rest.split_once('"')?;
+    Some(version)
 }
 
 fn quoted_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,25 @@
 # Knowledge Log
 
+## 2026-08-25, The runtime crate yolop names is everruns-host
+
+- [Maintenance](specs/maintenance.md): `everruns-runtime` has not existed since
+  upstream deleted it in 0.18, but yolop kept naming it. `yolop --version` and
+  the harness telemetry key both resolved their version from a package no
+  lockfile contains, so both had been reporting `unknown` since the 0.18 bump.
+  A clean compile hid it: `env!` on a build-script variable still expands when
+  the lookup fell back to a literal.
+- The dependency vector list, README, `AGENTS.md`, and the MCP, extensions,
+  checkpointing, and conversational-control specs now name `everruns-host`.
+  Historical references to the deleted crate stay as history.
+- `everruns-http` is yanked on crates.io and its `DirectEgressService` now
+  lives in `everruns-host` behind `direct-egress`, which `mcp-stdio` already
+  enables. Dropping the yanked dependency also collapsed a duplicate
+  `everruns-provider`, so the family is back to one version per crate.
+- The upstream `everruns-core` 0.19 / `everruns-provider` 0.20 wave is not
+  adoptable yet: the `everruns` facade and the five integration crates are
+  still published against `everruns-core ^0.18.1`, so the bump resolves two
+  cores and fails to compile.
+
 ## 2026-08-24, Repository mapping starts with its real contract
 
 - [Tool search](specs/tool-search.md): `repo_map` keeps its compact parameter

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,28 @@
 # Knowledge Log
 
+## 2026-08-26, Reasoning is ordered content, not a message field
+
+- everruns 0.19 / provider 0.20 replaced the flat `Message.thinking` and
+  `thinking_signature` pair with `ContentPart::Reasoning(ReasoningContentPart)`:
+  an ordered list of artifacts, each carrying its own provider, id, signature,
+  encrypted payload, and readable text. Ordering is the contract, every current
+  provider replays artifacts in the position it issued them, which one flattened
+  field per message could not express.
+- Readable reasoning is now typed by what the provider actually exposes:
+  verbatim chain-of-thought, a curated summary, or redacted. The stream carries
+  the same distinction on `LlmStreamEvent::ReasoningDelta { summary }`, so the
+  Codex driver reads it off the wire instead of downstream code guessing.
+- `ReasonItemData` no longer carries `encrypted_content`. Opaque replay state
+  lives on the message part and stays out of the event stream.
+- [Checkpointing](specs/checkpointing.md): the Codex driver replays the
+  provider's own `item_id` per artifact. It previously synthesized sequential
+  `rs_%08x` ids because the flat field carried none, which Codex could not key
+  replay against.
+- `ReasoningConfig::effort` is typed. Yolop still holds the effort as a string,
+  since model profiles and env are its sources, and parses once at the message
+  boundary; an unrecognized value is dropped rather than sent, which is what the
+  drivers used to do silently and inconsistently.
+
 ## 2026-08-25, The runtime crate yolop names is everruns-host
 
 - [Maintenance](specs/maintenance.md): `everruns-runtime` has not existed since

--- a/knowledge/specs/checkpointing.md
+++ b/knowledge/specs/checkpointing.md
@@ -173,7 +173,7 @@ On a new turn, Yolop:
 6. advances the active head.
 
 A failed model preflight does not create a checkpoint or append the ask. Once a
-provider request begins, everruns-runtime owns bounded transient recovery inside
+provider request begins, everruns-host owns bounded transient recovery inside
 the active reason phase. Yolop installs a stall liveness window and a recovery
 elapsed budget large enough to absorb full stall retries (upstream's default
 elapsed budget is shorter than one stall window). Retries reuse the persisted ask

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -103,7 +103,7 @@ Notes:
 ## Known gap
 
 - **Mid-turn reasoning-effort change** (within a single `run_turn`, not just at the
-  next turn boundary) requires upstream `everruns-runtime` support and is tracked in
+  next turn boundary) requires upstream `everruns-host` support and is tracked in
   **EVE-595**. `set_reasoning_effort` delivers turn-boundary escalation today.
 
 ## Ownership boundary

--- a/knowledge/specs/extensions.md
+++ b/knowledge/specs/extensions.md
@@ -230,7 +230,7 @@ its response cannot arrive until the server has handled every notification
 queued before it. Bounded, so a server that will not answer cannot hold up
 exit. Covered by `teardown_flushes_the_final_trace_events`.
 
-Attached control: `everruns-runtime` grew a live-reconfigure boundary
+Attached control: the upstream runtime (`everruns-host`) grew a live-reconfigure boundary
 (`InProcessRuntime::activate_capability`/`deactivate_capability` →
 `CapabilityDelta`, EVE-795). `yolop extensions enable|disable` persists the
 `ext:<name>` override to settings, and when invoked directly through the TUI's

--- a/knowledge/specs/maintenance.md
+++ b/knowledge/specs/maintenance.md
@@ -80,7 +80,7 @@ generic "tech debt" note.
 
 The `everruns-*` family is yolop's single most consequential dependency vector:
 
-- `everruns-runtime`
+- `everruns-host`
 - `everruns-core`
 - `everruns-platform`
 - `everruns-openai`
@@ -92,6 +92,11 @@ These crates ship together from one upstream workspace and are designed to be us
 Beyond the everruns family, dependency hygiene means:
 
 - no known CVEs in the tree (`cargo audit` when available, plus the repo's Dependabot alerts)
+- no yanked versions in `Cargo.lock`. A yanked dependency keeps building from
+  the committed lockfile, so nothing fails locally, while `cargo install yolop`
+  re-resolves and cannot pick it: yolop is unpublishable until the dependency
+  moves. Upstream yanks a crate when its contents move elsewhere, so the fix is
+  to find the new home, not to pin harder.
 - duplicate transitive versions reviewed (`cargo tree --duplicates`), fix or note why unfixable
 - no unused direct dependencies; prefer narrow sub-crates over umbrella crates when only a slice is used
 

--- a/knowledge/specs/mcp.md
+++ b/knowledge/specs/mcp.md
@@ -16,7 +16,7 @@ Supporting it lets yolop use the same `.mcp.json` server catalog that every
 other MCP client understands, with no bespoke per-tool integration.
 
 The MCP **client** lives upstream in `everruns-mcp` (transport-agnostic) and is
-wired into the in-process `everruns-runtime`; see the upstream
+wired into the in-process `everruns-host` runtime; see the upstream
 `knowledge/specs/runtime-mcp.md` decision record. Yolop does not implement the protocol
 itself, it configures servers and consumes the runtime's discovery + execution
 path, so MCP tools flow through the same agent loop as the built-in tools.
@@ -140,4 +140,4 @@ host's response text in the tool result; `/tools` includes live discovered
 | OAuth protocol (discovery, DCR, PKCE, exchange, refresh) | upstream `everruns-core::oauth`, `everruns-mcp::oauth` |
 | OAuth loopback host, token storage, egress adapter | `src/auth/mcp_oauth_login.rs`, `src/auth/mcp_oauth.rs` |
 | Auth policy (stored token, env fallback) | `src/runtime/mod.rs` (`StoredMcpAuthProvider`) |
-| Client / transports / executor | upstream `everruns-mcp`, `everruns-runtime` (`mcp-stdio` feature) |
+| Client / transports / executor | upstream `everruns-mcp`, `everruns-host` (`mcp-stdio` feature) |

--- a/src/auth/mcp_oauth.rs
+++ b/src/auth/mcp_oauth.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use everruns_core::{
     EgressRequest, EgressResponse, EgressResult, EgressService, EgressStreamResponse,
 };
-use everruns_http::DirectEgressService;
+use everruns_host::DirectEgressService;
 use everruns_mcp::oauth::McpTokenStore;
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -359,13 +359,10 @@ impl ChatDriver for CodexChatDriver {
             max_output_tokens: config.max_tokens,
             stream: true,
             tools: (!config.tools.is_empty()).then(|| convert_tools(&config.tools)),
-            reasoning: config
-                .reasoning_effort
-                .clone()
-                .map(|effort| CodexReasoning {
-                    effort,
-                    summary: "auto".to_string(),
-                }),
+            reasoning: config.reasoning_effort.map(|effort| CodexReasoning {
+                effort: effort.as_str().to_string(),
+                summary: "auto".to_string(),
+            }),
         };
 
         let headers = codex_headers(&tokens, config.metadata.get("session_id"));
@@ -608,21 +605,26 @@ struct ToolCallAccumulator {
 fn build_input(messages: &[LlmMessage]) -> (Option<String>, Vec<CodexInputItem>) {
     let mut instructions = Vec::new();
     let mut input = Vec::new();
-    let mut reasoning_counter = 0usize;
     for message in messages {
         if message.role == LlmMessageRole::System {
             instructions.push(message.content.to_text());
             continue;
         }
-        if message.role == LlmMessageRole::Assistant
-            && let Some(encrypted_content) = &message.thinking_signature
-        {
-            reasoning_counter += 1;
-            input.push(CodexInputItem::Reasoning {
-                r#type: "reasoning".to_string(),
-                id: format!("rs_{reasoning_counter:08x}"),
-                encrypted_content: encrypted_content.clone(),
-            });
+        if message.role == LlmMessageRole::Assistant {
+            // 0.19 replaced the single flat `thinking_signature` with an ordered
+            // list of reasoning parts, each carrying the id the provider issued.
+            // Codex keys replay by that id, so send the real one; a part with no
+            // encrypted payload has nothing to replay and is skipped.
+            for part in &message.reasoning {
+                let (Some(item_id), Some(encrypted)) = (&part.item_id, &part.encrypted) else {
+                    continue;
+                };
+                input.push(CodexInputItem::Reasoning {
+                    r#type: "reasoning".to_string(),
+                    id: item_id.clone(),
+                    encrypted_content: encrypted.clone(),
+                });
+            }
         }
         if message.role == LlmMessageRole::Assistant
             && message
@@ -984,16 +986,24 @@ fn handle_event(
             .and_then(Value::as_str)
             .map(|delta| LlmStreamEvent::TextDelta(delta.to_string()))
             .unwrap_or_else(|| LlmStreamEvent::TextDelta(String::new())),
-        Some("response.reasoning_summary_text.delta")
-        | Some("response.reasoning_text.delta")
-        | Some("response.reasoning.delta") => json
-            .get("delta")
-            .and_then(Value::as_str)
-            .map(|delta| match strip_reasoning_placeholder(delta) {
-                cleaned if cleaned.is_empty() => LlmStreamEvent::TextDelta(String::new()),
-                cleaned => LlmStreamEvent::ThinkingDelta(cleaned),
-            })
-            .unwrap_or_else(|| LlmStreamEvent::TextDelta(String::new())),
+        // `summary` separates a provider-curated gloss from raw chain-of-thought.
+        // Codex sends both on distinct event types, so the distinction is read
+        // off the wire rather than guessed downstream.
+        Some(event @ "response.reasoning_summary_text.delta")
+        | Some(event @ "response.reasoning_text.delta")
+        | Some(event @ "response.reasoning.delta") => {
+            let summary = event == "response.reasoning_summary_text.delta";
+            json.get("delta")
+                .and_then(Value::as_str)
+                .map(|delta| match strip_reasoning_placeholder(delta) {
+                    cleaned if cleaned.is_empty() => LlmStreamEvent::TextDelta(String::new()),
+                    cleaned => LlmStreamEvent::ReasoningDelta {
+                        delta: cleaned,
+                        summary,
+                    },
+                })
+                .unwrap_or_else(|| LlmStreamEvent::TextDelta(String::new()))
+        }
         Some("response.function_call_arguments.delta") => {
             if let (Some(item_id), Some(delta)) = (
                 json.get("item_id").and_then(Value::as_str),
@@ -1770,8 +1780,7 @@ mod tests {
                 }]),
                 tool_call_id: None,
                 phase: None,
-                thinking: None,
-                thinking_signature: None,
+                reasoning: Vec::new(),
             },
             message,
         ]);
@@ -1779,6 +1788,54 @@ mod tests {
             input.last(),
             Some(CodexInputItem::FunctionCallOutput { call_id, .. }) if call_id == "call_1"
         ));
+    }
+
+    #[test]
+    fn build_input_replays_provider_reasoning_ids_in_order() {
+        use everruns_provider::reasoning::ReasoningContentPart;
+
+        let mut assistant = LlmMessage::text(LlmMessageRole::Assistant, "");
+        assistant.reasoning = vec![
+            ReasoningContentPart::opaque("openai")
+                .with_item_id("rs_first")
+                .with_encrypted("blob-1"),
+            // No encrypted payload: nothing to replay, so Codex must not be
+            // sent a reasoning item it cannot key.
+            ReasoningContentPart::opaque("openai").with_item_id("rs_summary_only"),
+            ReasoningContentPart::opaque("openai")
+                .with_item_id("rs_second")
+                .with_encrypted("blob-2"),
+        ];
+
+        let (_, input) = build_input(&[assistant]);
+
+        let replayed: Vec<(&str, &str)> = input
+            .iter()
+            .filter_map(|item| match item {
+                CodexInputItem::Reasoning {
+                    id,
+                    encrypted_content,
+                    ..
+                } => Some((id.as_str(), encrypted_content.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            replayed,
+            vec![("rs_first", "blob-1"), ("rs_second", "blob-2")],
+            "reasoning must replay with the provider's own ids, in emission order"
+        );
+    }
+
+    #[test]
+    fn raw_reasoning_text_is_not_flagged_as_a_summary() {
+        // `response.reasoning_text.delta` is the model's own words, not a
+        // curated gloss, so consumers must be able to label it correctly.
+        let event =
+            reasoning_event(r#"{"type":"response.reasoning_text.delta","delta":"raw thought"}"#);
+        assert!(
+            matches!(event, LlmStreamEvent::ReasoningDelta { delta, summary } if delta == "raw thought" && !summary)
+        );
     }
 
     #[test]
@@ -1805,8 +1862,7 @@ mod tests {
                 ]),
                 tool_call_id: None,
                 phase: None,
-                thinking: None,
-                thinking_signature: None,
+                reasoning: Vec::new(),
             },
             paired_result,
             orphaned_result,
@@ -1924,7 +1980,7 @@ mod tests {
             r#"{"type":"response.reasoning_summary_text.delta","delta":"**Planning** real prose"}"#,
         );
         assert!(
-            matches!(event, LlmStreamEvent::ThinkingDelta(text) if text == "**Planning** real prose")
+            matches!(event, LlmStreamEvent::ReasoningDelta { delta, summary } if delta == "**Planning** real prose" && summary)
         );
     }
 
@@ -1944,7 +2000,9 @@ mod tests {
         let event = reasoning_event(
             r#"{"type":"response.reasoning_summary_text.delta","delta":"**Header**\n\n<!-- -->"}"#,
         );
-        assert!(matches!(event, LlmStreamEvent::ThinkingDelta(text) if text == "**Header**\n\n"));
+        assert!(
+            matches!(event, LlmStreamEvent::ReasoningDelta { delta, .. } if delta == "**Header**\n\n")
+        );
     }
 
     #[test]

--- a/src/drivers/local.rs
+++ b/src/drivers/local.rs
@@ -364,8 +364,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             phase: None,
-            thinking: None,
-            thinking_signature: None,
+            reasoning: Vec::new(),
         }
     }
 

--- a/src/editor/acp/bridge.rs
+++ b/src/editor/acp/bridge.rs
@@ -530,7 +530,6 @@ mod tests {
             provider: "openai".into(),
             model: Some("gpt-5".into()),
             item_id: "reason_1".into(),
-            encrypted_content: Some("opaque".into()),
             summary: vec![
                 "**Investigating event semantics**".into(),
                 " **Comparing ACP projections** ".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ impl Write for BoundedTraceWriter {
 #[command(
     name = "yolop",
     version = version::VERSION_DETAILS,
-    about = "Yolop coding agent — embedded terminal agent built on everruns-runtime"
+    about = "Yolop coding agent — embedded terminal agent built on everruns-host"
 )]
 struct Cli {
     #[command(subcommand)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -320,7 +320,7 @@ pub(crate) async fn discover_mcp_tool_names(
         return Vec::new();
     }
     let client = everruns_mcp::McpClient::new(
-        Arc::new(everruns_http::DirectEgressService::default()),
+        Arc::new(everruns_host::DirectEgressService::default()),
         Arc::new(StoredMcpAuthProvider::new(connections.clone())),
     );
     let mut names = Vec::new();
@@ -4369,10 +4369,7 @@ pub async fn build_with_options(
     let mut harness_builder = HarnessBuilder::new("yolop", harness_prompt)
         .metadata_entry("app", "yolop")
         .metadata_entry("yolop_version", env!("CARGO_PKG_VERSION"))
-        .metadata_entry(
-            "everruns_runtime_version",
-            env!("YOLOP_EVERRUNS_RUNTIME_VERSION"),
-        )
+        .metadata_entry("everruns_host_version", env!("YOLOP_EVERRUNS_HOST_VERSION"))
         // Attribute LLM calls routed through OpenRouter so they show up under
         // Yolop on OpenRouter's app dashboards. The driver forwards these as
         // the `HTTP-Referer` and `X-Title` headers (everruns 0.14+).
@@ -6121,9 +6118,9 @@ mod tests {
         assert_eq!(
             context
                 .embedder_metadata
-                .get("everruns_runtime_version")
+                .get("everruns_host_version")
                 .map(String::as_str),
-            Some(env!("YOLOP_EVERRUNS_RUNTIME_VERSION"))
+            Some(env!("YOLOP_EVERRUNS_HOST_VERSION"))
         );
         // OpenRouter attribution headers flow through embedder metadata.
         use everruns_provider::driver_registry::{

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -103,7 +103,9 @@ use everruns_platform::capabilities::{
 use everruns_provider::AgentLoopError;
 use everruns_provider::model_profiles::get_model_profile;
 use everruns_provider::typed_id::SessionId;
-use everruns_provider::{DriverId, ModelProfile, ReasoningEffortConfig, ReasoningEffortValue};
+use everruns_provider::{
+    DriverId, ModelProfile, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
+};
 use everruns_provider::{DriverRegistry, ProviderMetadata};
 use ignore::WalkBuilder;
 use regex::RegexBuilder;
@@ -2327,10 +2329,15 @@ impl ProviderChoice {
             metadata: None,
             tags: vec![],
         };
-        if let Some(effort) = self.reasoning_effort() {
+        // 0.19 typed `ReasoningConfig::effort`, so the closed taxonomy is parsed
+        // once here instead of by each driver. Yolop's own value is a string
+        // because it comes from model profiles and env; an unrecognized one is
+        // dropped rather than sent, which is what the drivers used to do
+        // silently and inconsistently.
+        if let Some(effort) = self.reasoning_effort().and_then(ReasoningEffort::parse) {
             input.controls = Some(Controls {
                 reasoning: Some(ReasoningConfig {
-                    effort: Some(effort.to_string()),
+                    effort: Some(effort),
                 }),
                 ..Default::default()
             });
@@ -2448,10 +2455,8 @@ fn reasoning_effort_option(value: &ReasoningEffortValue) -> ReasoningEffortOptio
     }
 }
 
-fn reasoning_effort_value(value: &everruns_provider::model::ReasoningEffort) -> Option<String> {
-    serde_json::to_value(value)
-        .ok()
-        .and_then(|value| value.as_str().map(str::to_string))
+fn reasoning_effort_value(value: &ReasoningEffort) -> Option<String> {
+    Some(value.as_str().to_string())
 }
 
 // Integration capabilities whose crates do not export an id constant
@@ -8654,7 +8659,7 @@ mod tests {
                 .controls
                 .and_then(|controls| controls.reasoning)
                 .and_then(|reasoning| reasoning.effort),
-            Some("medium".to_string())
+            Some(ReasoningEffort::Medium)
         );
     }
 
@@ -8673,7 +8678,7 @@ mod tests {
                 .controls
                 .and_then(|controls| controls.reasoning)
                 .and_then(|reasoning| reasoning.effort),
-            Some("high".to_string())
+            Some(ReasoningEffort::High)
         );
     }
 

--- a/src/runtime/session_log.rs
+++ b/src/runtime/session_log.rs
@@ -29,14 +29,14 @@
 //   title can repair the `workspace.json` projection after interruption.
 //   Streaming `*.delta` events have no replay value and would otherwise
 //   inflate the log O(n²) for long streamed responses.
-// * Assistant `thinking` / `thinking_signature` fields ARE persisted in
-//   yolop's per-session JSONL. The per-session folder is the local
-//   private session store (owner-only on Unix, see above) and provider
-//   continuation on resume requires the signature/encrypted_content
-//   (e.g. OpenAI Responses threads the encrypted reasoning context back
-//   via `thinking_signature`). The contract is local-store, not
-//   user-facing transcript export — see the yolop README for the
-//   public/private distinction.
+// * Assistant reasoning content parts ARE persisted whole in yolop's
+//   per-session JSONL, opaque signature and encrypted payload included.
+//   The per-session folder is the local private session store (owner-only
+//   on Unix, see above) and provider continuation on resume requires that
+//   state replayed verbatim, in the position the provider issued it (e.g.
+//   OpenAI Responses threads the encrypted reasoning context back). The
+//   contract is local-store, not user-facing transcript export — see the
+//   yolop README for the public/private distinction.
 // * Replay rejects events whose `session_id` doesn't match the resumed
 //   session — guards against accidentally merging logs across sessions.
 // * On open, if the file does not end with `\n` (previous run crashed
@@ -1560,11 +1560,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn output_message_thinking_is_persisted_for_provider_continuation() {
-        // yolop's per-session JSONL is the local session store: thinking
-        // and thinking_signature must round-trip so providers that thread
-        // encrypted reasoning context back (e.g. OpenAI Responses via
-        // `thinking_signature`) can continue across `--session <id>` resume.
+    async fn output_message_reasoning_is_persisted_for_provider_continuation() {
+        // yolop's per-session JSONL is the local session store: every reasoning
+        // artifact must round-trip whole, readable text and the opaque replay
+        // state alike, so providers that thread encrypted reasoning context back
+        // (e.g. OpenAI Responses) can continue across `--session <id>` resume.
+        // 0.19 made these ordered content parts, so position survives too.
+        use everruns_core::ContentPart;
+        use everruns_provider::reasoning::{ReasoningContentPart, ReasoningText};
+
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(4821);
         let session_dir = session_dir_path(dir.path(), session_id);
@@ -1572,8 +1576,17 @@ mod tests {
         let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
 
         let mut message = Message::assistant("I will inspect the files.");
-        message.thinking = Some("private model reasoning".to_string());
-        message.thinking_signature = Some("encrypted-thinking-token".to_string());
+        message.content.insert(
+            0,
+            ContentPart::reasoning(
+                ReasoningContentPart::opaque("openai")
+                    .with_item_id("rs_abc123")
+                    .with_encrypted("encrypted-thinking-token")
+                    .with_text(ReasoningText::Plain {
+                        text: "private model reasoning".to_string(),
+                    }),
+            ),
+        );
         let req = EventRequest::new(
             session_id,
             EventContext::default(),
@@ -1585,22 +1598,28 @@ mod tests {
         let on_disk = std::fs::read_to_string(&path).expect("read");
         assert!(
             on_disk.contains("private model reasoning"),
-            "session log must persist assistant thinking for restore: {on_disk}"
+            "session log must persist assistant reasoning for restore: {on_disk}"
         );
         assert!(
             on_disk.contains("encrypted-thinking-token"),
-            "session log must persist thinking_signature for provider continuation: {on_disk}"
+            "session log must persist the encrypted payload for provider continuation: {on_disk}"
         );
 
         let replayed = replay(&path, session_id).expect("replay");
         let replayed_message = replayed.messages.first().expect("message replayed");
+        let part = replayed_message
+            .reasoning_parts()
+            .next()
+            .expect("reasoning part replayed");
+        assert_eq!(part.item_id.as_deref(), Some("rs_abc123"));
+        assert_eq!(part.encrypted.as_deref(), Some("encrypted-thinking-token"));
         assert_eq!(
-            replayed_message.thinking.as_deref(),
+            part.display_text().as_deref(),
             Some("private model reasoning")
         );
-        assert_eq!(
-            replayed_message.thinking_signature.as_deref(),
-            Some("encrypted-thinking-token")
+        assert!(
+            replayed_message.content[0].is_reasoning(),
+            "reasoning must replay in the position the provider issued it"
         );
     }
 
@@ -1668,7 +1687,6 @@ mod tests {
                 provider: "openai".to_string(),
                 model: Some("gpt-5".to_string()),
                 item_id: "rs_abc123".to_string(),
-                encrypted_content: Some("opaque-encrypted-blob".to_string()),
                 summary: vec!["Considered file structure.".to_string()],
                 token_count: Some(42),
             },
@@ -1680,21 +1698,12 @@ mod tests {
             on_disk.contains("\"reason.item\""),
             "reason.item should be persisted: {on_disk}"
         );
-        assert!(
-            on_disk.contains("opaque-encrypted-blob"),
-            "encrypted_content must round-trip for provider continuation: {on_disk}"
-        );
-
         let replayed = replay(&path, session_id).expect("replay");
         assert_eq!(replayed.events.len(), 1);
         match &replayed.events[0].data {
             EventData::ReasonItem(data) => {
                 assert_eq!(data.provider, "openai");
                 assert_eq!(data.item_id, "rs_abc123");
-                assert_eq!(
-                    data.encrypted_content.as_deref(),
-                    Some("opaque-encrypted-blob")
-                );
                 assert_eq!(data.summary, vec!["Considered file structure.".to_string()]);
             }
             other => panic!("expected ReasonItem, got {other:?}"),

--- a/src/session_state/atif.rs
+++ b/src/session_state/atif.rs
@@ -180,10 +180,12 @@ pub fn trajectory_from_events(
                 if data.message.role != MessageRole::Agent {
                     continue;
                 }
+                // 0.19 moved reasoning onto ordered content parts, and only the
+                // readable half is exposed: `reasoning_display_text` joins the
+                // parts a provider is willing to show and skips redacted ones.
                 let reasoning_content = data
                     .message
-                    .thinking
-                    .clone()
+                    .reasoning_display_text()
                     .filter(|t| !t.trim().is_empty())
                     .or_else(|| {
                         (!pending_reasoning.is_empty()).then(|| pending_reasoning.join("\n\n"))
@@ -384,7 +386,16 @@ mod tests {
                 arguments: serde_json::json!({ "path": "src/lib.rs" }),
             }],
         );
-        with_tools.thinking = Some("The user wants the file contents.".to_string());
+        with_tools.content.insert(
+            0,
+            everruns_core::ContentPart::reasoning(
+                everruns_provider::reasoning::ReasoningContentPart::opaque("sim").with_text(
+                    everruns_provider::reasoning::ReasoningText::Plain {
+                        text: "The user wants the file contents.".to_string(),
+                    },
+                ),
+            ),
+        );
         vec![
             event(EventData::InputMessage(InputMessageData::new(
                 Message::user("fix the bug"),
@@ -394,7 +405,6 @@ mod tests {
                 provider: "sim".to_string(),
                 model: None,
                 item_id: "ri_1".to_string(),
-                encrypted_content: None,
                 summary: vec!["Looking at the bug report.".to_string()],
                 token_count: Some(5),
             })),
@@ -490,7 +500,6 @@ mod tests {
                 provider: "sim".to_string(),
                 model: None,
                 item_id: "ri_2".to_string(),
-                encrypted_content: None,
                 summary: vec!["First thought.".to_string(), "Second thought.".to_string()],
                 token_count: None,
             })),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5187,7 +5187,6 @@ mod tests {
                 provider: "openai".to_string(),
                 model: Some("gpt-5".to_string()),
                 item_id: "rs_abc".to_string(),
-                encrypted_content: Some("opaque".to_string()),
                 summary: vec![
                     "Considering file layout".to_string(),
                     "".to_string(),
@@ -5206,7 +5205,9 @@ mod tests {
     }
 
     #[test]
-    fn lines_for_event_hides_output_message_thinking() {
+    fn lines_for_event_hides_output_message_reasoning() {
+        use everruns_provider::reasoning::{ReasoningContentPart, ReasoningText};
+
         let mut message = everruns_core::Message::assistant_with_tools(
             "",
             vec![ToolCall {
@@ -5215,8 +5216,15 @@ mod tests {
                 arguments: serde_json::json!({ "path": "/repo/Cargo.toml" }),
             }],
         );
-        message.thinking = Some(
-            "**Inspecting package files**\n\nI should read the package manifest first.".to_string(),
+        message.content.insert(
+            0,
+            everruns_core::ContentPart::reasoning(
+                ReasoningContentPart::opaque("openai").with_text(ReasoningText::Plain {
+                    text: "**Inspecting package files**\n\nI should read the package manifest \
+                           first."
+                        .to_string(),
+                }),
+            ),
         );
         let event = RuntimeEvent::new(
             SessionId::new(),
@@ -5226,7 +5234,10 @@ mod tests {
 
         let lines = lines_for_event(&event);
 
-        assert!(lines.is_empty(), "thinking must not be rendered: {lines:?}");
+        assert!(
+            lines.is_empty(),
+            "reasoning must not be rendered: {lines:?}"
+        );
     }
 
     #[test]
@@ -5683,7 +5694,6 @@ mod tests {
                 provider: "openai".to_string(),
                 model: Some("gpt-5".to_string()),
                 item_id: "rs_tokens".to_string(),
-                encrypted_content: None,
                 summary: Vec::new(),
                 token_count: Some(120),
             },

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,8 +2,8 @@ pub const VERSION_DETAILS: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     " (commit ",
     env!("YOLOP_GIT_SHA"),
-    ", everruns-runtime ",
-    env!("YOLOP_EVERRUNS_RUNTIME_VERSION"),
+    ", everruns-host ",
+    env!("YOLOP_EVERRUNS_HOST_VERSION"),
     ")"
 );
 
@@ -12,7 +12,7 @@ pub const VERSION_LINE: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     " (commit ",
     env!("YOLOP_GIT_SHA"),
-    ", everruns-runtime ",
-    env!("YOLOP_EVERRUNS_RUNTIME_VERSION"),
+    ", everruns-host ",
+    env!("YOLOP_EVERRUNS_HOST_VERSION"),
     ")"
 );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -623,8 +623,12 @@ fn assert_version_output(stdout: &str) {
         "version output missing commit SHA: {stdout}"
     );
     assert!(
-        stdout.contains("everruns-runtime "),
-        "version output missing runtime version: {stdout}"
+        stdout.contains("everruns-host "),
+        "version output missing host version: {stdout}"
+    );
+    assert!(
+        !stdout.contains("everruns-host unknown"),
+        "version output could not resolve the host version: {stdout}"
     );
 }
 


### PR DESCRIPTION
Two commits: first correct what yolop calls the runtime crate and drop a yanked dependency, then move the whole `everruns-*` family onto the new line and adopt the reasoning model it ships.

## What changed

**Bump.** core 0.19.0, provider 0.20.0, host 0.20.3, platform 0.19.1, mcp 0.19.2, the `everruns` facade 0.19.1, plus the drivers and integration crates that ship with them. One version per crate, no duplicates.

**Reasoning is ordered content now.** `Message.thinking` / `thinking_signature` became `ContentPart::Reasoning(ReasoningContentPart)`: an ordered list of artifacts, each carrying its own provider, id, signature, encrypted payload, and readable text. Ordering is the contract — every current provider replays artifacts in the position it issued them, which one flattened field per message could not express. Session logs persist the parts whole; the ATIF and TUI paths read the readable half through `reasoning_display_text`, which skips redacted artifacts.

**The Codex driver replays real ids.** It used to synthesize sequential `rs_%08x` ids because the flat field carried none, and Codex keys replay by the id it issued. It now sends the provider's own `item_id` per artifact in emission order, and skips a part with no encrypted payload rather than sending an item Codex cannot key.

**Raw reasoning and curated summaries are distinguishable.** `LlmStreamEvent::ThinkingDelta` became `ReasoningDelta { delta, summary }`. Codex sends the two on distinct event types, so the flag is read off the wire instead of guessed downstream.

**`ReasonItemData` no longer carries `encrypted_content`.** Opaque replay state lives on the message part and stays off the event stream.

**`ReasoningConfig::effort` is typed.** Yolop keeps its own effort as a string, since model profiles and env are its sources, and parses once at the message boundary; an unrecognized value is dropped rather than sent, which is what each driver used to do silently and inconsistently. The serde round trip that read a wire value off the enum is now `as_str`.

**And from the first commit:** `yolop --version` had been printing `everruns-runtime unknown` since the 0.18 bump, because `everruns-runtime` was deleted upstream and `build.rs` looked for a package no lockfile contains. The same lookup feeds the harness telemetry entry, renamed `everruns_host_version`. The yanked `everruns-http` dependency is gone; its `DirectEgressService` is `everruns-host`'s `direct-egress` module, which `mcp-stdio` already enables, and the two sources are byte-identical.

## Why

The wave landed incomplete yesterday and is complete now: the facade republished as 0.19.1 and all five `everruns-integrations-*` crates moved onto `everruns-core ^0.19.0`, so the family resolves to a single version per crate again.

A clean compile is not evidence of adoption, and this wave proves it twice over. Reasoning replay compiles fine while sending Codex ids it cannot key, and `env!` on a build-script variable still expands when the lookup falls back to a literal — which is how a version line reporting `unknown` shipped for a whole minor cycle.

## Before / After

```
$ cargo run -q -- --version          # before
yolop 0.17.0 (commit 168c8765ee99, everruns-runtime unknown)

$ cargo run -q -- --version          # after
yolop 0.17.0 (commit f92f898d0425, everruns-host 0.20.3)
```

Reasoning replay, before and after, for an assistant turn with two artifacts:

```
# before: ids invented locally, one artifact per message maximum
{"type":"reasoning","id":"rs_00000001","encrypted_content":"blob-1"}

# after: the provider's own ids, every artifact, in emission order
{"type":"reasoning","id":"rs_first","encrypted_content":"blob-1"}
{"type":"reasoning","id":"rs_second","encrypted_content":"blob-2"}
```

Covered by `build_input_replays_provider_reasoning_ids_in_order`, which also
asserts an artifact with no encrypted payload is not sent.

Dependency resolution:

```
$ grep -A1 'name = "everruns-provider"' Cargo.lock | grep version
version = "0.18.0"     # before, pulled in only by the yanked everruns-http
version = "0.19.0"
version = "0.20.0"     # after, single version
```

## Risk

- Medium
- The reasoning surface changed shape across the session log, the ATIF export, the TUI, and the Codex driver. Session logs written by an older yolop carry the old flat fields and will not deserialize into reasoning parts, so reasoning does not survive a resume across this bump. Yolop is pre-1.0 and the log is a private local store, so no migration is provided.
- The Codex replay change is exercised by a unit test but not against a live Codex account; the ids it now sends are the provider's own, which is strictly closer to the wire contract than the synthesized ones.
- The telemetry metadata key changed from `everruns_runtime_version` to `everruns_host_version`. Anything keying off the old name sees the field disappear; it was reporting `unknown` anyway.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Two `knowledge/log.md` entries: the runtime-crate rename and the reasoning model. `knowledge/specs/maintenance.md` gains a constraint that no yanked version may sit in `Cargo.lock`, with why it passes locally and fails on install, and names `everruns-host` in the dependency vector. `knowledge/specs/mcp.md`, `extensions.md`, `checkpointing.md`, and `conversational-control.md` name `everruns-host` where they described the runtime as a live dependency.

## Security

TM-DEP and TM-LLM.

TM-DEP: the family moves together to one minor line, which is the rule; the yanked `everruns-http` is removed and nothing new is added. `DirectEgressService` relocates to a crate already in the tree and the two sources are byte-identical, so the egress boundary and its system allowlist are unchanged.

TM-LLM: reasoning artifacts carry opaque provider material (signatures, encrypted payloads). The upstream change narrows where that material travels — it is no longer published on `ReasonItemData`, and `ReasoningContentPart::to_public` strips it from any API projection. Yolop persists it only in the per-session JSONL, which is the private local store created `0o600` on Unix, unchanged by this PR and still required for provider continuation across `--session <id>`. Nothing reasoning-related is written to tracing output or the user-facing transcript; the TUI test asserting reasoning never renders was ported, not dropped. No key handling changed.

TM-FS, TM-BASH, TM-TOOL: no filesystem, shell, or capability-registration code changed.

Validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1391 passing), `python3 scripts/validate_okf.py knowledge --check-links`, `cargo run -- --provider llmsim -p "hi"`, and `cargo run -- --version`. No live-provider smoke run: no Doppler or provider key in this environment. CI's Live Provider Smoke covers it.

## Follow-ups

- The Codex driver consumes reasoning artifacts for replay but never emits a `ReasoningItem` of its own, so a Codex-originated turn contributes nothing to replay unless another driver produced the artifact. That gap predates this PR. Completing it means emitting the item on `response.output_item.done`, which needs a live Codex account to verify, so it is not guessed at here.
- Closes the deferred bump tracked in [#634](https://github.com/everruns/yolop/issues/634).