### PR TITLE
chore(release): prepare v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.17.1] - 2026-08-27
+
+### Highlights
+
+- Releases ship two binaries per target. `yolop-<target>.tar.gz` is the default-features build the Homebrew formula points at, and no longer carries the local-inference engine; `yolop-<target>-metal.tar.gz` and `yolop-x86_64-unknown-linux-gnu-cuda.tar.gz` carry the engine with the backend that target can use. The Linux tarball drops from 29.9 MB to 18.2 MB. Extension servers are now built for every target too, not just the last one the matrix collapsed onto.
+- The runtime recovers from failure loops instead of repeating them: consecutive equivalent invocation, missing-command, wrong-path, and usage failures on an unchanged workspace now require a different action or a bounded progress checkpoint, and a checkpoint is a real trajectory transition rather than a hook-only backstop.
+- File discovery is batch-native. `read_many_files` is advertised eagerly, so a model can read independent known paths in one call even when the provider emits one tool call per turn, and `repo_map` keeps its compact parameter schema in the first-turn profile.
+- Input routing is one ordered ownership table, so a paste while the sandbox-approval prompt owns the screen no longer lands in the composer behind it.
+- ACP prompts continue once after the provider exhausts its stream-stall retries, replaying from the durable transcript so settled tools are not re-run.
+- The everruns family moves to core 0.19 and provider 0.20, where reasoning is ordered `ContentPart::Reasoning` artifacts rather than a flat message field, and tuika to 0.11.0.
+
+### What's Changed
+
+* fix(ci): build extension servers for every target, not just the last ([#622](https://github.com/everruns/yolop/pull/622)) by @chaliy
+* feat(release): ship a portable binary and an accelerated one per target ([#623](https://github.com/everruns/yolop/pull/623)) by @chaliy
+* chore(deps): bump tuika to 0.11.0 and its companion crates ([#624](https://github.com/everruns/yolop/pull/624)) by @chaliy
+* refactor(tui): route every input event through one ownership table ([#625](https://github.com/everruns/yolop/pull/625)) by @chaliy
+* fix(runtime): make checkpoints a tool transition ([#626](https://github.com/everruns/yolop/pull/626)) by @chaliy
+* fix(runtime): repair equivalent failure loops ([#627](https://github.com/everruns/yolop/pull/627)) by @chaliy
+* fix(exec): avoid redundant output recovery ([#628](https://github.com/everruns/yolop/pull/628)) by @chaliy
+* feat(runtime): add batch-native file discovery ([#629](https://github.com/everruns/yolop/pull/629)) by @chaliy
+* fix(runtime): keep repo map schema eager ([#630](https://github.com/everruns/yolop/pull/630)) by @chaliy
+* fix(acp): continue after provider stream stalls ([#631](https://github.com/everruns/yolop/pull/631)) by @chaliy
+* fix(narration): name the agent spawn_agent spawns ([#632](https://github.com/everruns/yolop/pull/632)) by @chaliy
+* feat(deps): adopt everruns 0.19 core and 0.20 provider ([#633](https://github.com/everruns/yolop/pull/633)) by @chaliy
+* chore(deps): bump the cargo-minor-and-patch group with 3 updates ([#635](https://github.com/everruns/yolop/pull/635)) by @dependabot
+* chore(deps): bump jsonschema from 0.49.9 to 0.51.0 ([#636](https://github.com/everruns/yolop/pull/636)) by @dependabot
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.17.0...v0.17.1
+
 ## [0.17.0] - 2026-08-21
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10041,7 +10041,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts v0.17.1: `CHANGELOG.md` gains the 0.17.1 section, `Cargo.toml` and `Cargo.lock` move from 0.17.0 to 0.17.1. No source changes.

### Highlights

- Releases ship two binaries per target. `yolop-<target>.tar.gz` is the default-features build the Homebrew formula points at, and no longer carries the local-inference engine; `yolop-<target>-metal.tar.gz` and `yolop-x86_64-unknown-linux-gnu-cuda.tar.gz` carry the engine with the backend that target can use. The Linux tarball drops from 29.9 MB to 18.2 MB. Extension servers are now built for every target too, not just the last one the matrix collapsed onto.
- The runtime recovers from failure loops instead of repeating them: consecutive equivalent invocation, missing-command, wrong-path, and usage failures on an unchanged workspace now require a different action or a bounded progress checkpoint, and a checkpoint is a real trajectory transition rather than a hook-only backstop.
- File discovery is batch-native. `read_many_files` is advertised eagerly, so a model can read independent known paths in one call even when the provider emits one tool call per turn, and `repo_map` keeps its compact parameter schema in the first-turn profile.
- Input routing is one ordered ownership table, so a paste while the sandbox-approval prompt owns the screen no longer lands in the composer behind it.
- ACP prompts continue once after the provider exhausts its stream-stall retries, replaying from the durable transcript so settled tools are not re-run.
- The everruns family moves to core 0.19 and provider 0.20, where reasoning is ordered `ContentPart::Reasoning` artifacts rather than a flat message field, and tuika to 0.11.0.

### What's Changed

* fix(ci): build extension servers for every target, not just the last ([#622](https://github.com/everruns/yolop/pull/622)) by @chaliy
* feat(release): ship a portable binary and an accelerated one per target ([#623](https://github.com/everruns/yolop/pull/623)) by @chaliy
* chore(deps): bump tuika to 0.11.0 and its companion crates ([#624](https://github.com/everruns/yolop/pull/624)) by @chaliy
* refactor(tui): route every input event through one ownership table ([#625](https://github.com/everruns/yolop/pull/625)) by @chaliy
* fix(runtime): make checkpoints a tool transition ([#626](https://github.com/everruns/yolop/pull/626)) by @chaliy
* fix(runtime): repair equivalent failure loops ([#627](https://github.com/everruns/yolop/pull/627)) by @chaliy
* fix(exec): avoid redundant output recovery ([#628](https://github.com/everruns/yolop/pull/628)) by @chaliy
* feat(runtime): add batch-native file discovery ([#629](https://github.com/everruns/yolop/pull/629)) by @chaliy
* fix(runtime): keep repo map schema eager ([#630](https://github.com/everruns/yolop/pull/630)) by @chaliy
* fix(acp): continue after provider stream stalls ([#631](https://github.com/everruns/yolop/pull/631)) by @chaliy
* fix(narration): name the agent spawn_agent spawns ([#632](https://github.com/everruns/yolop/pull/632)) by @chaliy
* feat(deps): adopt everruns 0.19 core and 0.20 provider ([#633](https://github.com/everruns/yolop/pull/633)) by @chaliy
* chore(deps): bump the cargo-minor-and-patch group with 3 updates ([#635](https://github.com/everruns/yolop/pull/635)) by @dependabot
* chore(deps): bump jsonschema from 0.49.9 to 0.51.0 ([#636](https://github.com/everruns/yolop/pull/636)) by @dependabot

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.17.0...v0.17.1

## Why

14 commits have landed on `main` since v0.17.0 and none of them are released. PATCH was chosen over MINOR by the requester: the three `feat` commits are packaging and internal-runtime work rather than new user-facing surface (no new CLI flags, no new config keys, no new commands).

## Before / After

No behavior change from this PR itself.

- Before: `Cargo.toml` / `Cargo.lock` read 0.17.0; crates.io serves `yolop = "0.17.0"`; `CHANGELOG.md` newest section is `[0.17.0]`.
- After: both read 0.17.1; `CHANGELOG.md` newest section is `[0.17.1]`. On merge, `release.yml` tags v0.17.1 and dispatches `publish.yml` and `cli-binaries.yml`.

## Publish-readiness

- `cargo fmt --check` clean.
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings` clean.
- `cargo test --workspace --features yolop-yep/schema` green.
- `cargo publish --dry-run -p yolop-yep` packages and compiles clean. `yolop-yep` stays at 0.4.0, which is already live on crates.io, so `publish.yml` skips it; nothing under `crates/` or `extensions/` changed since v0.17.0, so no separate crate bump is due (`scripts/publish_order.py` reports `yolop-yep`, `yolop-extension-logfire`, `yolop`).
- `cargo search yolop` reports 0.17.0, so 0.17.1 is greater than what crates.io serves.
- `Cargo.toml` and `Cargo.lock` both read 0.17.1.
- The `yolop` dry-run is not run locally: it is only meaningful once its dependencies are live, and CI validates it after the SDK step.

## Risk

- Low
- The release automation is what can break, not the code: `release.yml` requires the commit subject `chore(release): prepare v0.17.1` to match `Cargo.toml`, which it does. `cli-binaries.yml` carries the extension-matrix fix from #622 and the two-build-per-target change from #623, so this is the first release exercising both; the post-merge list below verifies each artifact rather than trusting green workflows.

## Checklist

- [x] Tests added or updated (no source change; the full suite was run against the bump)
- [x] Backward compatibility considered (patch release, no API or CLI change)
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — the durable knowledge for every commit in this release landed with its own PR, and this change is version metadata plus the changelog.

## Post-merge verification

- [ ] `release.yml` green, tag `v0.17.1` and its GitHub Release created
- [ ] `publish.yml` green
- [ ] `cli-binaries.yml` green
- [ ] crates.io serves `yolop` 0.17.1
- [ ] Release carries `yolop-<target>.tar.gz` plus the `-metal` / `-cuda` archives for all three targets, each with its `.sha256`
- [ ] `everruns/homebrew-tap` formula points at v0.17.1

## Security

No security-relevant code changed: this PR is a version bump and a changelog entry.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_011cQB63ZXcN4Ai2zX6T3zKM)_