### PR TITLE
docs(agent): clarify bash execution guidance

### DIFF
--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -463,14 +463,15 @@ impl Tool for BashTool {
         }
         #[cfg(not(windows))]
         {
-            "Run a bash command. Each call is a fresh non-interactive shell already \
-             rooted at the workspace, so no state persists between calls: the working \
-             directory, shell variables, and exports reset every time. A bare `cd` is \
-             pointless — you are already at the workspace root; use paths relative to \
-             it, or chain within one call (`cd sub && cmd`). Captures stdout/stderr \
-             with configurable verbosity. 120s timeout; run commands that wait on \
-             external events (CI runs, deploys) detached via `spawn_background` \
-             instead."
+            "Run a bash command. Every call starts a fresh non-interactive `bash -lc` \
+             already rooted at the workspace, so no state persists between calls: the \
+             working directory, shell variables, and exports reset every time. A bare \
+             `cd` is pointless, you are already at the workspace root; use paths relative \
+             to it, or chain within one call (`cd sub && cmd`). The tool reports the shell \
+             process status, so unless the script handles an expected failure, structure \
+             it to return nonzero when a step fails. Captures stdout/stderr with \
+             configurable verbosity. 120s timeout; run commands that wait on external \
+             events (CI runs, deploys) detached via `spawn_background` instead."
         }
     }
     fn parameters_schema(&self) -> Value {
@@ -752,12 +753,22 @@ mod tests {
     // burned ~30 turns issuing bare `cd <workdir>` commands expecting the cwd to
     // persist; spelling out the contract is what steers it away.
     #[test]
-    fn bash_description_documents_stateless_shell() {
+    fn bash_description_documents_process_isolation_and_status() {
         let tool = BashTool::new(Workspace::from_path(std::env::current_dir().unwrap()));
-        let desc = tool.description().to_lowercase();
-        assert!(desc.contains("no state persists") || desc.contains("state persists"));
-        assert!(desc.contains("cd"));
-        assert!(desc.contains("workspace root"));
+        let description = tool.description();
+
+        for guarantee in [
+            "fresh non-interactive `bash -lc`",
+            "working directory, shell variables, and exports reset every time",
+            "chain within one call (`cd sub && cmd`)",
+            "tool reports the shell process status",
+            "return nonzero when a step fails",
+        ] {
+            assert!(
+                description.contains(guarantee),
+                "missing Bash contract guarantee: {guarantee}"
+            );
+        }
     }
 
     #[test]
@@ -888,6 +899,42 @@ mod tests {
             root_name,
             "cwd should reset to the workspace root between calls"
         );
+    }
+
+    #[tokio::test]
+    async fn bash_does_not_preserve_exports_between_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(Workspace::from_path(dir.path().to_path_buf()));
+
+        let first = tool
+            .execute(json!({ "command": "export YOLOP_BASH_ISOLATION=leaked" }))
+            .await;
+        assert!(matches!(first, ToolExecutionResult::Success(_)));
+
+        let second = tool
+            .execute(json!({ "command": "test -z \"${YOLOP_BASH_ISOLATION-}\"" }))
+            .await;
+        let ToolExecutionResult::Success(second) = second else {
+            panic!("expected structured result");
+        };
+        assert_eq!(second["success"], true);
+    }
+
+    #[tokio::test]
+    async fn bash_reports_a_failing_chained_step() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(Workspace::from_path(dir.path().to_path_buf()));
+
+        let ToolExecutionResult::Success(result) = tool
+            .execute(json!({ "command": "printf before && false && printf after" }))
+            .await
+        else {
+            panic!("expected structured result");
+        };
+
+        assert_eq!(result["success"], false);
+        assert_eq!(result["exit_code"], 1);
+        assert_eq!(result["stdout"], "before");
     }
 
     #[cfg(target_os = "macos")]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8785,6 +8785,21 @@ mod tests {
     }
 
     #[test]
+    fn system_prompt_balances_parallel_calls_and_coherent_shell_phases() {
+        let prompt = include_str!("system.md")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(prompt.contains("Emit independent tool calls together"));
+        assert!(
+            prompt.contains(
+                "One script per coherent shell phase; unexpected failures return nonzero"
+            )
+        );
+    }
+
+    #[test]
     fn system_prompt_requires_owner_evidence_before_non_obvious_mutation() {
         let workflow = SYSTEM_PROMPT
             .split("## Workflow")
@@ -9144,7 +9159,7 @@ mod tests {
     /// stable composition components so prompt/tool budget changes are explicit.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cold_start_prompt_composition_is_measured_by_component() {
-        const BASELINE_PROMPT_BYTES: usize = 12_888;
+        const BASELINE_PROMPT_BYTES: usize = 14_138;
         // The tool baselines model what today's surface would cost undeferred,
         // so enabling a capability raises them by exactly that capability's
         // undeferred cost — otherwise the ratio guards below would read a

--- a/src/runtime/system.md
+++ b/src/runtime/system.md
@@ -11,9 +11,9 @@ validation; diagnose failures and fix the root cause.
 Use tool descriptions and schemas as the operational contract. Load hidden
 schemas with `tool_search`.
 
-Emit independent tool calls together, but keep calls whose inputs depend on
-earlier results sequential. Piggyback title, todo, and status updates on
-substantive batches, avoiding standalone bookkeeping rounds.
+Emit independent tool calls together; keep calls whose inputs depend
+sequential. One script per coherent shell phase; unexpected failures
+return nonzero. Piggyback title, todo, and status updates in the batch.
 
 ## Safety
 


### PR DESCRIPTION
## What changed
- Guides coding turns to group a coherent shell phase into one readable script.
- Documents that every Bash tool invocation is a fresh `bash -lc` process and that cwd, variables, and exports do not persist.
- Clarifies that unexpected script failures must reach a nonzero shell status, with focused tests for process isolation and chained failure reporting.

## Why
Agents were encouraged to batch independent tools but lacked equally explicit guidance for writing readable, phase-level shell scripts and preserving failure semantics inside those scripts.

## Before / After
Before: the Bash contract mentioned a fresh shell but did not fully explain state isolation or how a script's final status controls tool success.

After: the contract and coding prompt state the lifecycle and failure rules directly. The offline `llmsim` smoke test still completes successfully.

## Risk
- Low
- Prompt wording could affect tool-use choices; prompt budgets and the full workspace test suite guard the changed composition.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered; no Bash parameters or execution API changed
- [x] No knowledge update required; this clarifies existing tool behavior and agent guidance without changing durable architecture or policy

## Knowledge
No knowledge update required; this clarifies an existing tool contract and coding heuristic.

## Security
TM-BASH reviewed. The bounded execution model, timeout, output caps, sandbox policy, and command boundary are unchanged. Regression coverage confirms nonzero status is retained for an unexpected chained failure.

## Follow-ups
- Optional description, cwd, env, and timeout fields are deferred because they expand the tool API beyond this guidance fix.
- Windows shell support is deferred because it requires a separate cross-platform execution design.
- Tool narration formatting is unchanged because no locally owned multiline narration abstraction exists in this path.

Produced by [yolop](https://everruns.com/yolop)