### PR TITLE
feat(config): unify configuration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,9 +469,9 @@ tokens (`~/.config/yolop/settings.toml` on Linux,
 
 You rarely edit it by hand: the TUI's `/setup`, `/model`, and `/effort` commands
 update the active provider, keys, model, and reasoning effort, and yolop can read
-and edit the file itself through the `get_config` / `set_config` tools or the
-`yolop-config` skill (e.g. "use anthropic by default", "store my OpenAI key").
-Unknown keys are ignored, so the format stays forward-compatible.
+and manage persistent model selection through
+`yolop config model show|set|clear` or the `yolop-config` skill. Unknown keys are
+ignored, so the format stays forward-compatible.
 
 Both global directories can be moved: `--config-dir <PATH>` (settings, profiles,
 hooks, extensions) and `--data-dir <PATH>` (sessions, logs, models, prompt
@@ -535,8 +535,8 @@ ones. Paths resolve relative to the profiles directory.
 CLI and ACP live model choices override the selected profile; the profile
 overrides `settings.toml`. Credentials, theme, attribution, and background-wake
 behavior remain global and are rejected in a profile. When a profile is active,
-`/setup`, `set_config`, and extension enable/disable persist back to that
-profile while credential changes still update the global settings file.
+`/setup` and extension enable/disable persist back to that profile while
+credential changes still update the global settings file.
 Workspace `.mcp.json` still overlays a profile's servers by name, and `yolop
 mcp` / `/mcp` writes stay scoped to global settings or the workspace file.
 

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -32,7 +32,7 @@ forcing slash-command syntax.
 carries a canonical `key`, `aliases`, `title`, `description`, value `kind`
 (`text` / `bool` / `secret`), effective `default`, `examples`, and whether it is
 `provider_scoped` (addressed as `<key>.<provider>`). This one registry feeds
-every configuration surface, the tools below and the `yolop-config` skill, so
+every configuration surface and the `yolop-config` skill, so
 there is no second place to keep in sync.
 
 Keys are addressed the way a human would name them:
@@ -40,7 +40,7 @@ Keys are addressed the way a human would name them:
 | Key                       | Type   | Meaning                                                        |
 |---------------------------|--------|----------------------------------------------------------------|
 | `default_provider`        | text   | Provider used when no `--provider` flag is given; takes precedence over env auto-detection. |
-| `models`                  | list   | The ordered, cross-provider `[[models]]` menu `/model` and ACP offer; edited with `yolop models` (see [Model list](model-list.md)). |
+| `models`                  | list   | The ordered, cross-provider `[[models]]` menu `/model` and ACP offer; edited with `yolop config models` (see [Model list](model-list.md)). |
 | `default_models.<provider>` | text | Per-provider model spec, survives provider switches. Remembered state, not the menu. |
 | `tokens.<provider>`       | secret | Provider API token (owner-only on disk; env vars override). OpenRouter PKCE browser login stores the minted key as `tokens.openrouter`. |
 | `base_urls.<provider>`    | text   | Endpoint base URL (used by the `custom` provider).             |
@@ -68,6 +68,20 @@ Meta Model API is a first-class `meta` provider backed by `everruns-meta`, not a
 generic compatible endpoint. It reads `MODEL_API_KEY`, defaults to
 `muse-spark-1.2`, and exposes both the standard and
 `muse-spark-1.2-contributor` published profiles.
+
+### Top-level config command
+
+`yolop config` is the persistent configuration surface in both attached and
+detached execution. `get [key]` returns the whole schema-backed view or one
+field, `set <key> <value>` applies scalar and provider-scoped values, and
+`clear <key>` removes a stored value. Structured capability overrides use
+`set capabilities --json '<object>'`; this keeps object input distinct from
+scalar values and appends through the same schema and settings service used by
+the other forms. `clear capabilities` removes all stored overrides.
+
+The same command also owns `model show|set|clear` and the `models` list editor.
+It replaces the former `get_config` and `set_config` agent tools, which are no
+longer registered.
 
 ### Where the global directories live
 
@@ -175,24 +189,15 @@ The active profile is printed at startup, returned by `get_config`, and
 included in the terminal-independent safety status. Missing or malformed
 profiles fail before session construction.
 
-### Tools
+### Attached command
 
-The `config` capability (`src/capabilities/config.rs`) exposes two tools backed
-by the schema:
-
-- **`get_config`**: with no argument, returns every key with its semantics and
-  current value; with a `key`, returns just that entry. Secrets are reported as
-  `stored` / `unset`, never echoed. Use `key=capabilities` for the registered
-  catalog plus stored overrides and effective harness, or `key=capabilities.<ref>`
-  for one capability's schema metadata (`config_schema`, `config_ui_schema`).
-- **`set_config`**: validates and persists scalar keys via `value` (`clear`
-  unsets). Harness overrides: `key=capabilities` with a `json` object appends one
-  `[[capabilities]]` entry; `value=clear` drops all stored overrides. Capability
-  config is validated through each capability's `validate_config`.
-
-Both honor aliases and validate provider segments against the supported-provider
-list. Provider/model and capability edits take effect on the next run; `/setup`
-remains the way to switch the *live* model mid-session.
+`ConfigCapability` owns the attached `config` CLI. `yolop config get [key]`,
+`set KEY VALUE`, and `clear KEY` manage settings, while
+`yolop config model show|set MODEL|clear` manages the persistent model selection.
+The plural `yolop config models ...` form delegates catalog reads and edits to
+`ModelListCapability`; bare `models` is shorthand for `models list`. The
+model-list capability keeps its `models` control route but does not register a
+separate top-level CLI command. The capability exposes no agent tools.
 
 ### Configuration as a service
 
@@ -216,32 +221,25 @@ through the service handle, writes through the concrete `SettingsStore`, so the
 read/write split is explicit at the type level. `AttributionCapability` reads
 whether attribution is enabled through the service; `ApprovalCapability` reads
 its soft-approval paranoia level through `ConfigService::approval_mode()` each
-turn; the `config` capability's `get_config` reads single values through
-`ConfigService::current`; and `ModelsCapability` reads provider/token/model state
-through its config handle while persisting `/setup` changes through the store.
-`approval_mode` is also a first-class schema key, so `get_config`/`set_config`
-manage it alongside everything else.
+turn; `SetupController` reads provider/token/model state through its config
+handle while persisting `/setup` changes through the store. `approval_mode`
+remains a first-class schema key for internal configuration consumers.
 
 The per-target read helpers (`current_value`, `scoped_current`) live in the
-service module so the `config` tools and any other consumer share one
-implementation; secret redaction and unsupported-provider filtering therefore
-apply uniformly wherever config is read.
+service module so internal configuration consumers share one implementation;
+secret redaction and unsupported-provider filtering therefore apply uniformly
+wherever config is read.
 
 ### Context delivery
 
-The schema reaches the agent two ways:
-
-1. An always-on pointer: `ConfigCapability::system_prompt_contribution` adds a
-   compact note (settings path + "use `get_config`/`set_config` or the
-   `yolop-config` skill") to every turn.
-2. The bundled `yolop-config` system skill is the
-   detailed, on-demand reference. It instructs the agent to read the live schema
-   via `get_config` rather than duplicating key lists, and points at the
-   adjacent surfaces (`memory`, `yolop-hooks`, `/setup`).
+The configuration capability does not add tools or an always-on system-prompt
+block. The bundled `yolop-config` skill is the on-demand reference for the
+attached model commands and adjacent configuration surfaces.
 
 ## Boundaries
 
 Configuration is distinct from the neighbouring personalization surfaces:
 durable preferences are **memory**, behavioral rules are **hooks**, and
-interactive live provider/model switching is **`/setup`**. All settings keys,
-including harness capabilities, go through `get_config` / `set_config`.
+guided provider setup is **`/setup`**. Model selection and model-list edits go
+through the attached `config` command; other settings retain their dedicated
+setup and control surfaces.

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -64,14 +64,14 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 |---|---|---|
 | Reasoning effort | `set_reasoning_effort` | `/effort` overlay, `/setup effort` |
 | Model | `search_models` / `set_model` | `/model` overlay, `/setup model` |
-| Model list (the menu `/model` and ACP offer) | `yolop models …` (attached CLI) | `/model` overlay, `[[models]]` in settings |
+| Model list (the menu `/model` and ACP offer) | `yolop config models …` (attached CLI) | `/model` overlay, `[[models]]` in settings |
 | Provider | `set_provider` | `/setup provider` |
 | Skills, list | `list_skills` (upstream) | system-prompt listing |
 | Skills, search (skills.sh) | `search_skills` |, |
 | Skills, install from registry | `install_skill` |, |
 | Skills, install/update by content | `write_skill` (upstream) |, |
 | Skills, uninstall | `delete_skill` |, |
-| Settings (provider/model/tokens/urls/capabilities, next-run) | `get_config` / `set_config` | `/setup`, `yolop-config` skill |
+| Model selection and model-list edits | `yolop config model` / `yolop config models` | `/setup`, `yolop-config` skill |
 | Any slash command the host's registry holds (`/setup`, `/background`, `/undo`, `/redo`, `/rewind`, `/goal`, plus the terminal ones in the TUI) | `run_command` (every host) | the slash commands themselves |
 
 Notes:
@@ -82,8 +82,9 @@ Notes:
 - `search_models` queries usable providers through the runtime driver registry and
   returns provider-qualified matches. `set_model` rejects a partial name when it
   matches discovered models but is not an exact ID for the current provider.
-- `set_config` is intentionally next-run for provider/model edits, it edits the
-  settings file. The *live* equivalents are the `set_*` tools above.
+- `yolop config model show|set|clear` owns persistent model selection, while
+  `yolop config models` edits the persisted ordered list. Attached list edits
+  also refresh the current session menu; neither command switches the live model.
 - **Attached administration is the deliberate exception to "a model-facing tool".**
   Extension, coordination, and model-list administration is reachable conversationally by
   running `yolop <subcommand> ...` in the foreground Bash tool, which the host
@@ -113,7 +114,8 @@ Notes:
 - `crate::capabilities::skills` owns `delete_skill`; `crate::capabilities::skill_registry`
   owns `search_skills` / `install_skill`; the upstream `ScopedSkillsCapability`
   owns `list_skills` / `write_skill` (see [`skills.md`](./skills.md)).
-- `crate::capabilities::config` owns `get_config` / `set_config` (see
+- `crate::capabilities::config` owns the attached `config` command and delegates
+  model-list actions to `ModelListCapability` (see
   [`configuration.md`](./configuration.md)).
 - The command registry and `run_command` are owned by [`commands.md`](./commands.md).
 

--- a/knowledge/specs/model-list.md
+++ b/knowledge/specs/model-list.md
@@ -59,12 +59,13 @@ job".
 | `/model`, status-bar click | Opens the list. A trailing "Browse all models…" row falls through to the provider picker and that provider's catalog. |
 | `/model <id>` | Applies the entry directly when the id is on the list; otherwise the pre-list per-provider picker, as before. |
 | ACP `configOptions` | The `model` select option serves the list, filtered to entries whose provider is usable, plus the model in use. |
-| `yolop models …` | Shows and edits the list: `list`, `add`, `rm`, `move`, `use`, `reset`. |
+| `yolop config models …` | Shows and edits the list: bare `models` or `list`, plus `add`, `rm`, `move`, `edit`, `reset`. |
 
 Credential filtering differs by surface on purpose. ACP hides entries whose
 provider has no credential, because an editor cannot run a login wizard and an
-unusable option is a dead end there. The TUI picker and `yolop models list` show
-them marked instead: picking a model you have not signed in to yet is a
+unusable option is a dead end there. The TUI picker and both catalog-list forms,
+`yolop config models` and `yolop config models list`, show them marked instead:
+picking a model you have not signed in to yet is a
 legitimate way to start using it, and hiding rows from the command that edits
 them is how a user loses track of their own list.
 
@@ -78,18 +79,18 @@ Codex and OpenRouter browser login, custom endpoint) funnels through one hop for
 this, so authentication lands on the model the user picked rather than dropping
 them in a catalog.
 
-### Administration is an attached CLI, not a tool
+### Administration is a CLI, not a tool
 
-`yolop models` is a `CliCapability` on the attached control plane, the same
-pattern extensions and session coordination use, and for the same reason: the
-agent can edit the list on request without the schemas costing prompt budget
-every turn. `list` is read-only; every other operation is consequential. `use`
-requires a live session and says so when invoked detached; editing works either
-way, because it is an ordinary settings write.
+`yolop config` is a `CliCapability` available both detached and through the
+attached control plane. This lets the agent edit configuration on request without
+schemas costing prompt budget every turn. `models list` is read-only; every other
+catalog operation is consequential. `config model show|set|clear` reads and
+writes the persistent default model in either mode. Live session switching stays
+with `/model`, `/setup`, and the runtime model controls.
 
-Every mutation reads the resolved list, changes it, and writes the whole thing
-back, so ordering is explicit and there is one write path. `set_config` refuses
-`models` and points at the CLI rather than offering a second, weaker editor.
+Every list mutation reads the resolved list, changes it, and writes the whole thing
+back, so ordering is explicit and there is one write path. The capability does
+not expose a second agent-tool editor.
 
 A model reference resolves as `provider/model`, `provider:model`, or a bare
 model id when it names exactly one entry. Ambiguity is an error naming the
@@ -107,7 +108,7 @@ profile is still read as `default_models`.
 ## Ownership boundary
 
 - `crate::config::model_list` owns the entry type, defaults, and TOML parsing.
-- `crate::capabilities::model_list` owns the capability, the `yolop models` CLI,
+- `crate::capabilities::model_list` owns the capability, the `yolop config models` CLI,
   the credential filter (`offered_models`), and reference resolution.
 - `ModelState::model_options` (ACP) and `crate::tui::setup` (the picker) are
   consumers; neither keeps its own idea of what is offered.

--- a/src/bundled/system-skills/yolop-config/SKILL.md
+++ b/src/bundled/system-skills/yolop-config/SKILL.md
@@ -1,128 +1,40 @@
 ---
 name: yolop-config
-description: View and change yolop's own configuration, default provider and model, per-provider API tokens and models, endpoint base URLs, attribution, harness capabilities, and named --profile overlays. Use when the user asks to configure yolop, set a default provider/model, store an API key, point at a custom endpoint, enable/disable capabilities, set up a profile, or asks "what is your config / what can you configure".
+description: Manage yolop's persistent default model and ordered model catalog through the config command.
 user-invocable: true
 ---
 
 # Yolop configuration
 
-yolop stores its settings in a single TOML file (`settings.toml` in the yolop
-config dir). The file is loaded tolerantly, unknown keys are ignored, never
-fatal, and every known key carries semantics (title, description, type,
-default, examples) that you can read at runtime. This skill is the entry point
-for inspecting and editing that configuration the way a user describes it.
+Use the foreground Bash tool to run `yolop config` directly. The command works
+both detached and through the current Yolop session. Do not use a pipeline,
+redirection, substitution, or background execution when attached.
 
-Do not hand-edit the TOML with the file tools. Use the schema-aware tools so
-values are validated and persisted atomically.
+## Persistent settings
 
-## Inspect
+- `yolop config get [key]` shows all settings or one schema key.
+- `yolop config set <key> <value>` sets scalar and provider-scoped fields.
+- `yolop config set capabilities --json '<object>'` appends one capability override; `--json` preserves the former structured configuration semantics.
+- `yolop config clear <key>` clears a field, or all capability overrides when the key is `capabilities`.
 
-1. Call `get_config` with no arguments to list **every** configuration key with
-   its meaning, type, default, examples, and current value. Secrets (API
-   tokens) are shown only as `stored` / `unset`, never echoed.
-2. Call `get_config` with a single `key` (e.g. `default_provider`,
-   `default_models.anthropic`, `tokens.openai`) to focus on one entry.
-3. For harness capabilities, use `get_config key=capabilities` (registered catalog,
-   stored overrides, effective harness) or `get_config key=capabilities.<ref>`
-   (per-capability schema metadata from `config_schema` / `config_ui_schema`).
+## Persistent default model
 
-Lead with `get_config` whenever you are unsure of the exact key name or the
-accepted values, the returned schema is the source of truth, so you never have
-to guess.
+- `yolop config model show|set <model>|clear` inspects, sets, or clears the
+  persistent default provider and model used by future sessions.
+- A model may be `provider/model`, `provider:model`, or a bare id that is unique
+  in the configured list.
+- These commands do not switch the live session. Use `/model`, `/setup`, or the
+  runtime model controls for live switching.
 
-The model list (`models`) is read here but edited with the `yolop models`
-command, not `set_config`, see "Model list" below.
-
-## Change
-
-Call `set_config` with a `key` and a `value` for scalar settings:
-
-- `set_config key=default_provider value=anthropic`, the default provider when
-  neither `--provider` nor an env credential forces a choice.
-- `set_config key=default_models.anthropic value="claude-sonnet-4-5"`, provider
-  preference model for the active provider. A per-provider pick wins over it.
-- `set_config key=default_models.openai value="gpt-5.5 high"`, remember a model
-  for one provider (survives provider switches). The spec is
-  `model [reasoning-effort]`.
-- `set_config key=tokens.anthropic value=…`, store an API token (owner-only on
-  disk). Environment variables still override stored tokens.
-- `set_config key=base_urls.custom value=http://localhost:8000/v1`, endpoint
-  for the OpenAI-compatible `custom` provider.
-- `set_config key=attribution value=off`, turn commit/PR attribution on/off.
-
-Pass `value=clear` to unset an optional or secret key
-(e.g. `set_config key=tokens.openai value=clear`).
-
-### Harness capabilities
-
-Overrides are an ordered `[[capabilities]]` list in the same file. Append
-entries with `set_config key=capabilities` and a `json` object (validated via each
-capability's `validate_config`). Pass `value=clear` to drop all stored overrides.
-
-```toml
-[[capabilities]]
-ref = "message_metadata"
-fields = ["timestamp"]
-
-[[capabilities]]
-ref = "duckduckgo"
-enabled = false
-```
-
-Tool equivalents:
-
-- `set_config key=capabilities json={"ref":"message_metadata","fields":["timestamp"]}`
-- `set_config key=capabilities json={"ref":"duckduckgo","enabled":false}`
-- `set_config key=capabilities json={"ref":"web_fetch","enable_file_download":false}`
-- `set_config key=capabilities json={"ref":"some_cap","append":true,...}`, duplicate instance
-- `set_config key=capabilities value=clear`, remove all stored overrides
-
-Provider and model edits are persisted and take effect on the **next run**. To
-switch the *live* model in the current session, use the interactive `/setup`
-command instead.
-
-## Named profiles
-
-`yolop --profile <name>` loads `profiles/<name>.toml` next to `settings.toml` as
-a sparse overlay for that run. Profiles are how one machine hosts several
-purpose-built agents: besides provider, model, approval, sandbox, and worktree
-settings, a profile can carry its own `[[capabilities]]` (which is also how
-extensions are enabled or disabled), `[mcp.servers.<name>]`, `instructions` /
-`instructions_file` appended to the system prompt, and a `skills_dir`
-(defaulting to `profiles/<name>/skills/`). Set `capabilities_mode = "replace"`
-or `mcp_mode = "replace"` when the profile's set should be the only one.
-
-Credentials and personal settings (`tokens`, `codex_auth`, `theme`,
-`attribution`, `proactive_wake`) are global-only and make a profile fail to
-load. While a profile is active, `set_config` and `/setup` write profileable
-keys into it and credentials into `settings.toml`; `get_config` reports which
-layer each value came from. Profiles are edited as files, so use the file tools
-for a profile's `instructions_file` or its skills, and `set_config` for its
-keys.
-
-## Related surfaces
-
-- **Durable preferences / memory** ("remember that I prefer terse answers"):
-  these are not config keys. Use the `remember` / `recall` / `forget` tools
-  (the global `memory` capability), not `set_config`. Memory tuning
-  (`disclosed_titles`, `recall_limit`, `soft_cap`) is per-capability config
-  exposed via the capability's `config_schema`, not a `settings.toml` key.
-- **Behavioral hooks** (block/allow/audit tool calls): use the `yolop-hooks`
-  skill and the `hooks` capability tools.
 ## Model list
 
-`models` is the ordered, cross-provider menu `/model`, the status bar, and ACP
-offer: the handful of models the user switches between, not every model a
-provider publishes. Edit it by running the CLI, which affects the live session:
+- `yolop config models` (or `models list`) shows the ordered list.
+- `yolop config models add <provider> <model> [--effort E] [--label L] [--position N]` adds an entry.
+- `yolop config models rm <model>` removes an entry.
+- `yolop config models move <model> <position>` reorders an entry.
+- `yolop config models edit <model> [options]` edits an entry.
+- `yolop config models reset` restores defaults.
 
-- `yolop models list`, show it (entries needing sign-in are marked)
-- `yolop models add <provider> <model> [--effort E] [--label L] [--position N]`
-- `yolop models rm <model>` / `yolop models move <model> <position>`
-- `yolop models use <model>`, switch this session (provider and model together)
-- `yolop models reset`, restore the built-in default list
-
-Reference a model as `provider/model`, or by its bare id when only one entry has
-it. `set_config` refuses `models` on purpose: the CLI is the one editor.
-
-- **Interactive provider/model setup**: the `/setup` command runs a guided
-  wizard and switches the live model immediately.
+Model-list edits persist to `settings.toml`. When run attached, they also refresh
+the current session's menu. The config capability intentionally exposes no agent tools. Use these top-level
+commands instead of `get_config` or `set_config`.

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -70,15 +70,17 @@ the list.
 Entries whose provider you have not signed in to are shown and marked; picking
 one runs that provider's sign-in first, then switches to the model you picked.
 
-Edit the list from a shell (it applies to the running session):
+Manage the persistent model catalog and future-session default from a shell:
 
 ```bash
-yolop models list
-yolop models add openrouter anthropic/claude-opus-4-8 --label "Opus (OpenRouter)"
-yolop models move claude-opus-4-8 1
-yolop models rm gpt-5.4-mini
-yolop models use gpt-5.6-sol
-yolop models reset          # back to the built-in default list
+yolop config models
+yolop config models add openrouter anthropic/claude-opus-4-8 --label "Opus (OpenRouter)"
+yolop config models move claude-opus-4-8 1
+yolop config models rm gpt-5.4-mini
+yolop config model show
+yolop config model set gpt-5.6-sol
+yolop config model clear
+yolop config models reset          # back to the built-in default list
 ```
 
 It is stored as `[[models]]` in `settings.toml`, so it can also be edited by

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -1,21 +1,12 @@
-// The `config` capability — schema-described, human-friendly editing of the
-// yolop settings file.
+// The `config` capability owns the attached model-selection command.
 //
-// `settings.toml` is loaded tolerantly (unknown keys are ignored, never
-// fatal). This capability layers *semantics* on top of that file via the
-// informational schema in `crate::config::schema`: it exposes `get_config` (read
-// the schema + current values) and `set_config` (validate + persist any known
-// key) so the agent can configure yolop the way a user describes it.
-//
-// Its prompt block is reveal-gated (see `capabilities::tool_reveal`): both tools
-// defer their schemas, and the block only tells you things — where the file is,
-// when an edit lands — that you can act on once you are actually calling them.
-//
-// Provider/model edits are persisted here and take effect on the next run; use
-// the interactive `/setup` command to switch the *live* model mid-session.
+// It delegates model-list actions to `ModelListCapability`, which keeps the
+// shared control route and persistence behavior without registering a separate
+// top-level CLI command. The legacy configuration tool implementations remain
+// internal for focused tests, but this capability advertises no agent tools.
 
+use crate::capabilities::model_list::{ModelListAction, ModelListCapability, ModelsCliCommand};
 use crate::capabilities::narration::{narrate_get_config, narrate_set_config};
-use crate::capabilities::tool_reveal::RevealedTools;
 use crate::config::capability_settings::{
     CapabilityCatalog, apply_capability_settings, build_capability_override,
     capability_catalog_json, capability_catalog_list, effective_harness_json, overrides_to_json,
@@ -24,21 +15,172 @@ use crate::config::capability_settings::{
 use crate::config::schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config::service::{ConfigService, current_value, scoped_current};
 use crate::config::{ApprovalMode, Settings, SettingsStore};
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
 use crate::runtime::{SUPPORTED_PROVIDERS, coding_harness_defaults, resolve_for_settings};
 use async_trait::async_trait;
+use clap::{Args, Command, FromArgMatches, Subcommand};
 use everruns_core::tool_narration::ToolNarrationPhase;
 use everruns_core::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::{Tool, ToolExecutionResult};
 use everruns_provider::ToolCall;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::Arc;
+
+#[derive(Debug, Args)]
+pub(crate) struct ConfigCommandLine {
+    #[command(subcommand)]
+    command: ConfigCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigCommand {
+    Get {
+        key: Option<String>,
+    },
+    Set {
+        key: String,
+        value: Option<String>,
+        #[arg(long, value_name = "OBJECT", conflicts_with = "value")]
+        json: Option<String>,
+    },
+    Clear {
+        key: String,
+    },
+    Model {
+        #[command(subcommand)]
+        command: ConfigModelCommand,
+    },
+    Models {
+        #[command(subcommand)]
+        command: Option<ModelsCliCommand>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigModelCommand {
+    Show,
+    Set { model: String },
+    Clear,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum ConfigAction {
+    Get {
+        key: Option<String>,
+    },
+    Set {
+        key: String,
+        value: Option<String>,
+        json: Option<Value>,
+    },
+    Clear {
+        key: String,
+    },
+    ModelShow,
+    ModelSet {
+        model: String,
+    },
+    ModelClear,
+}
+
+impl ConfigCommandLine {
+    fn request(matches: &clap::ArgMatches) -> anyhow::Result<ControlRequest> {
+        let command = Self::from_arg_matches(matches)?.command;
+        let action = match command {
+            ConfigCommand::Get { key } => serde_json::to_value(ConfigAction::Get { key })?,
+            ConfigCommand::Set { key, value, json } => {
+                if value.is_none() && json.is_none() {
+                    anyhow::bail!("config set requires VALUE or --json OBJECT");
+                }
+                let json = json
+                    .map(|raw| {
+                        serde_json::from_str::<Value>(&raw)
+                            .map_err(|error| anyhow::anyhow!("invalid --json value: {error}"))
+                    })
+                    .transpose()?;
+                serde_json::to_value(ConfigAction::Set { key, value, json })?
+            }
+            ConfigCommand::Clear { key } => serde_json::to_value(ConfigAction::Clear { key })?,
+            ConfigCommand::Model { command } => match command {
+                ConfigModelCommand::Show => serde_json::to_value(ConfigAction::ModelShow)?,
+                ConfigModelCommand::Set { model } => {
+                    serde_json::to_value(ConfigAction::ModelSet { model })?
+                }
+                ConfigModelCommand::Clear => serde_json::to_value(ConfigAction::ModelClear)?,
+            },
+            ConfigCommand::Models { command } => serde_json::to_value(match command {
+                Some(command) => ModelListAction::from(command),
+                None => ModelListAction::List {
+                    json: false,
+                    connected: false,
+                },
+            })?,
+        };
+        Ok(ControlRequest::new("models", action)?)
+    }
+}
 
 pub(crate) const CONFIG_CAPABILITY_ID: &str = "yolop_config";
 
 pub(crate) struct ConfigCapability {
     pub(crate) settings: Arc<SettingsStore>,
     pub(crate) catalog: Arc<CapabilityCatalog>,
-    pub(crate) reveals: Arc<RevealedTools>,
+    pub(crate) model_list: Arc<ModelListCapability>,
+}
+
+#[async_trait]
+impl ControlCapability for ConfigCapability {
+    fn control_route(&self) -> ControlRoute {
+        self.model_list.control_route()
+    }
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        match serde_json::from_value::<ConfigAction>(action.clone()) {
+            Ok(action) => self.execute_config_action(action).await,
+            Err(_) => self.model_list.execute_control(action).await,
+        }
+    }
+
+    fn render_control(&self, action: &Value, response: &ControlResponse) -> String {
+        if serde_json::from_value::<ConfigAction>(action.clone()).is_ok() {
+            response.render_default()
+        } else {
+            self.model_list.render_control(action, response)
+        }
+    }
+}
+
+#[async_trait]
+impl CliCapability for ConfigCapability {
+    fn cli_command(&self) -> clap::Command {
+        ConfigCommandLine::augment_args(Command::new("config"))
+    }
+
+    fn control_request_from_cli(
+        &self,
+        matches: &clap::ArgMatches,
+    ) -> anyhow::Result<ControlRequest> {
+        ConfigCommandLine::request(matches)
+    }
+
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        if serde_json::from_value::<ConfigAction>(request.action.clone()).is_err() {
+            return self.model_list.execute_cli_request(request).await;
+        }
+        let response =
+            ControlResponse::from_tool_result(self.execute_control(&request.action).await);
+        let rendered = self.render_control(&request.action, &response);
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            anyhow::bail!(rendered)
+        }
+    }
 }
 
 #[async_trait]
@@ -59,44 +201,22 @@ impl Capability for ConfigCapability {
         Some("Personalization")
     }
 
-    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
-        // `get_config` / `set_config` describe the key space, the `capabilities`
-        // overrides, and the `json` argument. What is left is the file location
-        // and the two facts a caller cannot discover from a schema: edits are
-        // never fatal, and they land on the next run rather than immediately.
-        // Both are only actionable while editing config, so they wait until one
-        // of the tools has been revealed; the tool descriptions carry discovery.
-        if !self
-            .reveals
-            .any_revealed(ctx.session_id, &["get_config", "set_config"])
-        {
-            return None;
-        }
-        let profile = self
-            .settings
-            .active_profile_name()
-            .map(|name| format!(" Active profile: `{name}`."))
-            .unwrap_or_default();
-        Some(format!(
-            "<capability id=\"{}\">\nyolop's settings live at {}. Unknown keys are ignored, \
-             never fatal. Provider/model and capability edits apply on the next run; use \
-             `/setup` to switch the live model now.{}\n</capability>",
-            self.id(),
-            self.settings.path().display(),
-            profile,
-        ))
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        None
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
-        Some(
-            "<capability id=\"yolop_config\">\nyolop's settings and harness capabilities are \
-             schema-described; use `get_config` / `set_config` or the `yolop-config` skill.\n\
-             </capability>"
-                .to_string(),
-        )
+        None
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
+        Vec::new()
+    }
+}
+
+impl ConfigCapability {
+    #[allow(dead_code)]
+    fn legacy_tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
             Box::new(GetConfigTool {
                 settings: self.settings.clone(),
@@ -108,6 +228,79 @@ impl Capability for ConfigCapability {
             }),
         ]
     }
+
+    async fn execute_config_action(&self, action: ConfigAction) -> ToolExecutionResult {
+        match action {
+            ConfigAction::Get { key } => {
+                GetConfigTool {
+                    settings: self.settings.clone(),
+                    catalog: self.catalog.clone(),
+                }
+                .execute(json!({ "key": key }))
+                .await
+            }
+            ConfigAction::Set { key, value, json } => {
+                let mut arguments = json!({ "key": key });
+                if let Some(value) = value {
+                    arguments["value"] = parse_cli_value(&value);
+                }
+                if let Some(json) = json {
+                    arguments["json"] = json;
+                }
+                SetConfigTool {
+                    settings: self.settings.clone(),
+                    catalog: self.catalog.clone(),
+                }
+                .execute(arguments)
+                .await
+            }
+            ConfigAction::Clear { key } => {
+                SetConfigTool {
+                    settings: self.settings.clone(),
+                    catalog: self.catalog.clone(),
+                }
+                .execute(json!({ "key": key, "value": "clear" }))
+                .await
+            }
+            ConfigAction::ModelShow => {
+                let settings = self.settings.snapshot();
+                let model = settings.default_provider.as_ref().and_then(|provider| {
+                    settings
+                        .default_models
+                        .get(provider)
+                        .map(|model| format!("{provider}/{model}"))
+                });
+                ToolExecutionResult::success(json!({ "model": model }))
+            }
+            ConfigAction::ModelSet { model } => {
+                let models = self.settings.snapshot().model_list();
+                let index = match ModelListCapability::find(&models, &model) {
+                    Ok(index) => index,
+                    Err(error) => return ToolExecutionResult::tool_error(error),
+                };
+                let entry = &models[index];
+                if let Err(error) = self
+                    .settings
+                    .set_configured_model(entry.provider.clone(), entry.model.clone())
+                {
+                    return ToolExecutionResult::tool_error(error.to_string());
+                }
+                ToolExecutionResult::success(
+                    json!({ "model": format!("{}/{}", entry.provider, entry.model) }),
+                )
+            }
+            ConfigAction::ModelClear => {
+                if let Err(error) = self.settings.clear_configured_model() {
+                    return ToolExecutionResult::tool_error(error.to_string());
+                }
+                ToolExecutionResult::success(json!({ "model": Value::Null }))
+            }
+        }
+    }
+}
+
+fn parse_cli_value(value: &str) -> Value {
+    serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.to_string()))
 }
 
 // ---------- field rendering ----------
@@ -628,12 +821,12 @@ impl SetConfigTool {
                     "theme = {value}; applies to new interactive sessions"
                 )))
             }
-            // The list has one editor: `yolop models`, which validates
+            // The list has one editor: `yolop config models`, which validates
             // provider/model pairs and owns ordering. A key/value setter here
             // would be a second, weaker write path for the same file.
             KeyTarget::Models => Err(
-                "the model list is edited with `yolop models add|rm|move|use`, not `set_config`; \
-                 run `yolop models list` to see it"
+                "the model list is edited with `yolop config models add|rm|move` or configured with `yolop config model set MODEL`, not `set_config`; \
+                 run `yolop config models list` to see it"
                     .to_string(),
             ),
             KeyTarget::Model(provider) => {
@@ -714,6 +907,99 @@ mod tests {
     use everruns_core::tool_narration::ToolNarrationPhase;
     use everruns_provider::ToolCall;
 
+    fn cli_request(args: &[&str]) -> ControlRequest {
+        let command = ConfigCommandLine::augment_args(Command::new("config"));
+        let matches = command.try_get_matches_from(args).expect("parse config");
+        ConfigCommandLine::request(&matches).expect("config request")
+    }
+
+    #[test]
+    fn config_cli_parses_persistent_grammar() {
+        for args in [
+            &["config", "get"][..],
+            &["config", "get", "theme"][..],
+            &["config", "set", "theme", "blue"][..],
+            &["config", "clear", "theme"][..],
+            &["config", "model", "show"][..],
+            &["config", "model", "set", "openai/gpt-5.6"][..],
+            &["config", "model", "clear"][..],
+            &["config", "models"][..],
+        ] {
+            cli_request(args);
+        }
+    }
+
+    #[test]
+    fn config_commands_dispatch_to_config_actions() {
+        let cases = [
+            (["config", "get", "theme"].as_slice(), "get"),
+            (["config", "set", "theme", "blue"].as_slice(), "set"),
+            (["config", "clear", "theme"].as_slice(), "clear"),
+            (["config", "model", "show"].as_slice(), "model_show"),
+            (["config", "model", "clear"].as_slice(), "model_clear"),
+        ];
+        for (args, expected) in cases {
+            let action = cli_request(args).action;
+            assert_eq!(action.get("op").and_then(Value::as_str), Some(expected));
+        }
+    }
+
+    #[test]
+    fn set_json_dispatches_object_separately_from_scalar_value() {
+        let request = cli_request(&[
+            "config",
+            "set",
+            "capabilities",
+            "--json",
+            r#"{"ref":"web_fetch","enabled":false}"#,
+        ]);
+        assert!(matches!(
+            serde_json::from_value::<ConfigAction>(request.action).expect("config action"),
+            ConfigAction::Set { key, value: None, json: Some(Value::Object(_)) }
+                if key == "capabilities"
+        ));
+    }
+
+    #[test]
+    fn set_requires_exactly_one_value_form() {
+        let missing = ConfigCommandLine::augment_args(Command::new("config"))
+            .try_get_matches_from(["config", "set", "theme"])
+            .expect("clap accepts the optional positional before request validation");
+        assert!(
+            ConfigCommandLine::request(&missing)
+                .expect_err("missing value must fail")
+                .to_string()
+                .contains("requires VALUE or --json OBJECT")
+        );
+        assert!(
+            ConfigCommandLine::augment_args(Command::new("config"))
+                .try_get_matches_from(["config", "set", "theme", "blue", "--json", "{}",])
+                .is_err(),
+            "scalar and JSON forms must be mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn singular_model_dispatches_to_persistent_action() {
+        let request = cli_request(&["config", "model", "set", "openai/gpt-5.6"]);
+        assert!(matches!(
+            serde_json::from_value::<ConfigAction>(request.action).expect("config action"),
+            ConfigAction::ModelSet { model } if model == "openai/gpt-5.6"
+        ));
+    }
+
+    #[test]
+    fn models_dispatches_to_existing_catalog_action() {
+        for args in [&["config", "models"][..], &["config", "models", "list"][..]] {
+            let request = cli_request(args);
+            assert!(matches!(
+                serde_json::from_value::<ModelListAction>(request.action)
+                    .expect("model-list action"),
+                ModelListAction::List { .. }
+            ));
+        }
+    }
+
     fn store() -> (tempfile::TempDir, Arc<SettingsStore>) {
         let tmp = tempfile::tempdir().expect("tmp");
         let store = Arc::new(SettingsStore::open(tmp.path().join("settings.toml")));
@@ -738,6 +1024,18 @@ mod tests {
             settings,
             catalog: catalog(),
         }
+    }
+
+    #[test]
+    fn config_capability_advertises_no_agent_tools() {
+        let (_tmp, settings) = store();
+        let capability = ConfigCapability {
+            model_list: Arc::new(ModelListCapability::new(settings.clone(), None)),
+            settings,
+            catalog: catalog(),
+        };
+
+        assert!(capability.tools().is_empty());
     }
 
     #[test]
@@ -1162,62 +1460,5 @@ mod tests {
         let snapshot = settings.snapshot();
         assert_eq!(snapshot.capabilities.len(), 2);
         assert!(snapshot.capabilities[1].is_remove());
-    }
-
-    /// The block is how-to for two deferred tools, so it stays out of the prompt
-    /// until `tool_search` has loaded one of them.
-    #[tokio::test]
-    async fn config_block_waits_for_a_tool_reveal() {
-        let (_tmp, settings) = store();
-        let reveals = Arc::new(RevealedTools::new());
-        let capability = ConfigCapability {
-            settings: settings.clone(),
-            catalog: catalog(),
-            reveals: reveals.clone(),
-        };
-        let session = everruns_provider::typed_id::SessionId::new();
-        let ctx = SystemPromptContext::without_file_store(session);
-
-        assert!(
-            capability.system_prompt_contribution(&ctx).await.is_none(),
-            "no reveal yet — `get_config`'s description carries discovery on its own"
-        );
-
-        reveals.record(session, ["get_config".to_string()]);
-
-        let block = capability
-            .system_prompt_contribution(&ctx)
-            .await
-            .expect("revealed tools bring the block back");
-        assert!(block.contains("settings live at"));
-        assert!(block.contains("apply on the next run"));
-    }
-
-    /// A reveal in one session must not unhide the block in another.
-    #[tokio::test]
-    async fn config_block_is_scoped_to_the_revealing_session() {
-        let (_tmp, settings) = store();
-        let reveals = Arc::new(RevealedTools::new());
-        let capability = ConfigCapability {
-            settings,
-            catalog: catalog(),
-            reveals: reveals.clone(),
-        };
-        let revealed = everruns_provider::typed_id::SessionId::new();
-        let other = everruns_provider::typed_id::SessionId::new();
-        reveals.record(revealed, ["set_config".to_string()]);
-
-        assert!(
-            capability
-                .system_prompt_contribution(&SystemPromptContext::without_file_store(revealed))
-                .await
-                .is_some()
-        );
-        assert!(
-            capability
-                .system_prompt_contribution(&SystemPromptContext::without_file_store(other))
-                .await
-                .is_none()
-        );
     }
 }

--- a/src/capabilities/model_list.rs
+++ b/src/capabilities/model_list.rs
@@ -10,22 +10,20 @@
 //!
 //! Administration follows the attached-CLI pattern extensions and session
 //! coordination use (`knowledge/specs/conversational-control.md`): `yolop
-//! models ...` rather than model tools, so the agent can edit the list on
-//! request without the schemas costing prompt budget every turn. `use` reaches
-//! the live session through [`SetupController::change_provider`], the same call
-//! `/setup provider <name> <model>` makes, so switching provider and model
-//! together is atomic and has one implementation.
+//! config models ...` rather than model tools, so the agent can edit the list
+//! on request without the schemas costing prompt budget every turn. `yolop
+//! The persistent `config` command delegates catalog operations here. Runtime switching
+//! remains on the existing `models` control route and uses
+//! [`SetupController::change_provider`], the same call `/setup provider <name> <model>` makes.
 
 use crate::capabilities::host::SetupController;
 use crate::capabilities::model_discovery::provider_is_usable;
 use crate::config::SettingsStore;
 use crate::config::model_list::{ModelEntry, default_models};
-use crate::control::{
-    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
-};
+use crate::control::{ControlCapability, ControlRequest, ControlResponse, ControlRoute};
 use crate::runtime::SUPPORTED_PROVIDERS;
 use async_trait::async_trait;
-use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
+use clap::{Args, Subcommand};
 use everruns_core::{Capability, CapabilityStatus, ToolExecutionResult};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -37,23 +35,13 @@ pub(crate) const MODEL_LIST_CAPABILITY_ID: &str = "model_list";
 /// the always-on prompt budget without constructing a session.
 pub(crate) const MODEL_LIST_CONTROL_ROUTE: ControlRoute = ControlRoute {
     resource: "models",
-    cli_subcommand: "models",
+    cli_subcommand: "config",
     read_only_operations: &["list"],
     summary: "show, reorder, and edit the model list, and switch this session to one of its models",
 };
 
-#[derive(Parser, Debug)]
-#[command(
-    name = "models",
-    about = "Show and edit the model list yolop offers when switching models"
-)]
-struct ModelsCommandLine {
-    #[command(subcommand)]
-    command: ModelsCliCommand,
-}
-
 #[derive(Subcommand, Debug)]
-enum ModelsCliCommand {
+pub(crate) enum ModelsCliCommand {
     /// Show the model list.
     List {
         /// Emit the full machine-readable result.
@@ -77,17 +65,12 @@ enum ModelsCliCommand {
         /// New 1-based position.
         position: usize,
     },
-    /// Switch this session to a model on the list, provider included.
-    Use {
-        /// `provider/model`, `provider:model`, or a model id unique in the list.
-        model: String,
-    },
     /// Restore the built-in default list.
     Reset,
 }
 
 #[derive(Args, Debug)]
-struct AddArgs {
+pub(crate) struct AddArgs {
     /// Provider the model is reached through.
     provider: String,
     /// Provider-relative model id (`gpt-5.6-sol`, `anthropic/claude-opus-4-8`).
@@ -135,13 +118,6 @@ pub(crate) enum ModelListAction {
     Reset,
 }
 
-impl ModelListAction {
-    fn request(&self) -> ControlRequest {
-        ControlRequest::new(MODEL_LIST_CONTROL_ROUTE.resource, self)
-            .expect("model list action serializes")
-    }
-}
-
 impl From<ModelsCliCommand> for ModelListAction {
     fn from(command: ModelsCliCommand) -> Self {
         match command {
@@ -155,7 +131,6 @@ impl From<ModelsCliCommand> for ModelListAction {
             },
             ModelsCliCommand::Rm { model } => Self::Rm { model },
             ModelsCliCommand::Move { model, position } => Self::Move { model, position },
-            ModelsCliCommand::Use { model } => Self::Use { model },
             ModelsCliCommand::Reset => Self::Reset,
         }
     }
@@ -183,10 +158,10 @@ impl ModelListCapability {
     /// names exactly one entry — ambiguity is an error rather than a guess,
     /// because the whole point of the list is that one model can be reachable
     /// through more than one provider.
-    fn find(models: &[ModelEntry], reference: &str) -> Result<usize, String> {
+    pub(crate) fn find(models: &[ModelEntry], reference: &str) -> Result<usize, String> {
         let reference = reference.trim();
         if reference.is_empty() {
-            return Err("name a model from the list; run `yolop models list`".to_string());
+            return Err("name a model from the list; run `yolop config models list`".to_string());
         }
         let qualified = |entry: &ModelEntry| {
             let key = entry.key();
@@ -204,7 +179,7 @@ impl ModelListCapability {
         match matches.as_slice() {
             [index] => Ok(*index),
             [] => Err(format!(
-                "`{reference}` is not on the model list; run `yolop models list`, or add it with `yolop models add <provider> {reference}`"
+                "`{reference}` is not on the model list; run `yolop config models list`, or add it with `yolop config models add <provider> {reference}`"
             )),
             _ => {
                 let providers: Vec<&str> = matches
@@ -268,6 +243,23 @@ impl ModelListCapability {
         self.settings
             .set_models(models)
             .map_err(|err| format!("could not save the model list: {err}"))
+    }
+
+    pub(crate) async fn execute_cli_request(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let action = serde_json::from_value::<ModelListAction>(request.action.clone())?;
+        if matches!(action, ModelListAction::Use { .. }) {
+            anyhow::bail!(
+                "switching models requires a running Yolop session; invoke the command directly through that session's foreground Bash"
+            );
+        }
+        let response = ControlResponse::from_tool_result(self.execute_action(&action).await);
+        let rendered = self.render_control(&request.action, &response);
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            anyhow::bail!(rendered)
+        }
     }
 
     pub(crate) async fn execute_action(&self, action: &ModelListAction) -> ToolExecutionResult {
@@ -362,7 +354,7 @@ impl ModelListCapability {
                 let entry = &models[index];
                 let Some(controller) = &self.controller else {
                     return ToolExecutionResult::tool_error(
-                        "switching models requires a running Yolop session; invoke `yolop models use` through that session's foreground Bash",
+                        "switching models requires a running Yolop session; invoke the existing `models use` control route through that session",
                     );
                 };
                 // One implementation: this is exactly what `/setup provider
@@ -432,38 +424,6 @@ impl ControlCapability for ModelListCapability {
     }
 }
 
-#[async_trait]
-impl CliCapability for ModelListCapability {
-    fn cli_command(&self) -> clap::Command {
-        ModelsCommandLine::command()
-    }
-    fn control_request_from_cli(
-        &self,
-        matches: &clap::ArgMatches,
-    ) -> anyhow::Result<ControlRequest> {
-        let parsed = ModelsCommandLine::from_arg_matches(matches)?;
-        Ok(ModelListAction::from(parsed.command).request())
-    }
-    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
-        let action = serde_json::from_value::<ModelListAction>(request.action.clone())?;
-        // Editing the list is a global-settings write and works detached;
-        // only switching the live session needs a session to switch.
-        if matches!(action, ModelListAction::Use { .. }) {
-            anyhow::bail!(
-                "switching models requires a running Yolop session; invoke the command directly through that session's foreground Bash"
-            );
-        }
-        let response = ControlResponse::from_tool_result(self.execute_action(&action).await);
-        let rendered = self.render_control(&request.action, &response);
-        if response.ok {
-            println!("{rendered}");
-            Ok(())
-        } else {
-            anyhow::bail!(rendered)
-        }
-    }
-}
-
 fn render_response(action: &ModelListAction, response: &ControlResponse) -> String {
     if !response.ok {
         return response.render_default();
@@ -498,7 +458,8 @@ fn render_response(action: &ModelListAction, response: &ControlResponse) -> Stri
     }
     if models.is_empty() {
         lines.push(
-            "No models listed. Add one with `yolop models add <provider> <model>`.".to_string(),
+            "No models listed. Add one with `yolop config models add <provider> <model>`."
+                .to_string(),
         );
         return lines.join("\n");
     }
@@ -522,8 +483,9 @@ fn render_response(action: &ModelListAction, response: &ControlResponse) -> Stri
     if let ModelListAction::List { .. } = action
         && !value["configured"].as_bool().unwrap_or(false)
     {
-        lines
-            .push("(built-in default list; `yolop models add|rm|move` makes it yours)".to_string());
+        lines.push(
+            "(built-in default list; `yolop config models add|rm|move` makes it yours)".to_string(),
+        );
     }
     lines.join("\n")
 }
@@ -707,7 +669,7 @@ mod tests {
 
     /// The core promise of pairing provider with model: one selection moves
     /// both. Drives the real `SetupController` an attached session holds, so
-    /// this covers `yolop models use` past the CLI envelope.
+    /// this covers the runtime `models use` control route.
     #[tokio::test]
     async fn using_a_listed_model_switches_provider_and_model_on_the_live_session() {
         use crate::capabilities::host::test_support::test_controller_with_settings;
@@ -840,7 +802,7 @@ mod tests {
     #[test]
     fn an_unknown_reference_says_how_to_add_it() {
         let error = ModelListCapability::find(&list(), "gpt-4").expect_err("unknown");
-        assert!(error.contains("yolop models add"), "{error}");
+        assert!(error.contains("yolop config models add"), "{error}");
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -833,6 +833,51 @@ impl SettingsStore {
         )
     }
 
+    /// Set the configured provider and its default model in one persistent write.
+    pub fn set_configured_model(&self, provider: String, model: String) -> Result<()> {
+        let base_provider = provider.clone();
+        let base_model = model.clone();
+        self.update_profileable(
+            |settings| {
+                settings.default_provider = Some(base_provider.clone());
+                settings.default_models.insert(base_provider, base_model);
+            },
+            |profile| {
+                profile.default_provider = Some(Some(provider.clone()));
+                profile.default_models.insert(provider, Some(model));
+            },
+        )
+    }
+
+    /// Clear the configured provider and its provider-specific default model.
+    pub fn clear_configured_model(&self) -> Result<bool> {
+        let mut guard = self.inner.lock().expect("settings lock poisoned");
+        let base_provider = guard.base.default_provider.clone();
+        if let Some(active) = &mut guard.profile {
+            let provider = active
+                .overlay
+                .default_provider
+                .as_ref()
+                .and_then(Clone::clone)
+                .or(base_provider);
+            let existed = provider.is_some();
+            active.overlay.default_provider = Some(None);
+            if let Some(provider) = provider {
+                active.overlay.default_models.insert(provider, None);
+            }
+            save_profile_to(&active.path, &active.overlay)?;
+            Ok(existed)
+        } else {
+            let provider = guard.base.default_provider.take();
+            let existed = provider.is_some();
+            if let Some(provider) = provider {
+                guard.base.default_models.remove(&provider);
+            }
+            save_to(&self.path, &guard.base)?;
+            Ok(existed)
+        }
+    }
+
     pub fn set_attribution(&self, enabled: bool) -> Result<()> {
         let mut guard = self.inner.lock().expect("settings lock poisoned");
         guard.base.attribution = enabled;
@@ -955,7 +1000,7 @@ impl SettingsStore {
         Ok(existed)
     }
 
-    /// Replace the model list. Every `yolop models` edit reads the resolved
+    /// Replace the model list. Every `yolop config models` edit reads the resolved
     /// list, changes it, and writes the whole thing back, so ordering is
     /// explicit and there is one write path. Under an active profile this
     /// writes the profile's own `[[models]]`, which replaces the global menu.
@@ -1883,5 +1928,41 @@ Authorization = "Bearer ${LINEAR_API_KEY}"
 
         let mode = std::fs::metadata(&path).expect("meta").permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn configured_model_set_and_clear_persist_as_one_setting() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.toml");
+        let store = SettingsStore::open(path.clone());
+
+        store
+            .set_configured_model("openai".to_string(), "gpt-test".to_string())
+            .expect("set configured model");
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.default_provider.as_deref(), Some("openai"));
+        assert_eq!(
+            snapshot.default_models.get("openai").map(String::as_str),
+            Some("gpt-test")
+        );
+
+        assert!(
+            store
+                .clear_configured_model()
+                .expect("clear configured model")
+        );
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.default_provider, None);
+        assert_eq!(
+            snapshot.default_models.get("openai").map(String::as_str),
+            None
+        );
+
+        let reloaded = SettingsStore::open(path).snapshot();
+        assert_eq!(reloaded.default_provider, None);
+        assert_eq!(
+            reloaded.default_models.get("openai").map(String::as_str),
+            None
+        );
     }
 }

--- a/src/config/model_list.rs
+++ b/src/config/model_list.rs
@@ -59,7 +59,7 @@ impl ModelEntry {
     }
 
     /// Stable identity of an entry: what ACP sends back as the selected value
-    /// and what `yolop models rm` matches on. Effort is excluded so the same
+    /// and what `yolop config models rm` matches on. Effort is excluded so the same
     /// model at two efforts does not read as two different models here; use
     /// [`ModelEntry::spec`] where effort matters.
     pub fn key(&self) -> String {
@@ -75,7 +75,7 @@ impl ModelEntry {
         }
     }
 
-    /// One-line rendering for pickers and `yolop models list`.
+    /// One-line rendering for pickers and `yolop config models list`.
     pub fn display(&self) -> String {
         match &self.label {
             Some(label) => label.clone(),

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6,8 +6,8 @@
 //! drop extra keys into the file without breaking yolop. What the schema adds
 //! is **semantics**: a title, description, type, default, and examples for
 //! every known configuration key. That lets the agent explain and edit
-//! configuration in a human-friendly way through the `get_config` /
-//! `set_config` tools and the `yolop-config` skill — the schema here is the
+//! configuration in a human-friendly way through the
+//! `config` command and the `yolop-config` skill. The schema here is the
 //! single source of truth those surfaces render.
 //!
 //! Keys are addressed the way a human would name them. Scalar keys are plain
@@ -104,14 +104,14 @@ pub fn schema() -> &'static [ConfigField] {
             description: "The ordered, cross-provider menu of models to switch between: what \
                           `/model`, the status bar, and ACP offer. Stored as `[[models]]` \
                           entries with `provider`, `model`, and optional `effort`/`label`. \
-                          Edit it with `yolop models add|rm|move`, not `set_config`. Unset \
+                          Edit it with `yolop config models add|rm|move`. Unset \
                           means the built-in default list.",
             kind: ValueKind::List,
             default: Some(
                 "openai/gpt-5.6-sol, openai/gpt-5.4-mini, anthropic/claude-opus-4-8, \
                            anthropic/claude-sonnet-4-5, codex/gpt-5.6-sol",
             ),
-            examples: &["yolop models add openrouter anthropic/claude-opus-4-8"],
+            examples: &["yolop config models add openrouter anthropic/claude-opus-4-8"],
             provider_scoped: false,
         },
         ConfigField {
@@ -252,17 +252,10 @@ pub fn schema() -> &'static [ConfigField] {
                           harness. Each entry has a `ref` (capability id), optional \
                           `enabled=false` to remove every instance with that ref, optional \
                           `append=true` to add a duplicate instance, and capability-specific \
-                          config keys validated via `config_schema` / `validate_config`. Use \
-                          `get_config key=capabilities` for the full registered catalog, or \
-                          `get_config key=capabilities.<ref>` for one capability's schema \
-                          metadata. Append entries with `set_config key=capabilities json=…`; \
-                          pass `value=clear` to drop all stored overrides.",
+                          config keys validated via `config_schema` / `validate_config`.",
             kind: ValueKind::List,
             default: None,
-            examples: &[
-                "capabilities.message_metadata",
-                "set_config key=capabilities json={\"ref\":\"message_metadata\",\"config\":{\"fields\":[\"timestamp\"]}}",
-            ],
+            examples: &["capabilities.message_metadata"],
             provider_scoped: true,
         },
         ConfigField {
@@ -301,7 +294,7 @@ pub enum KeyTarget {
     Theme,
     /// Per-provider model spec, for the named provider.
     Model(String),
-    /// The ordered `[[models]]` list, edited through `yolop models`.
+    /// The ordered `[[models]]` list, edited through `yolop config models`.
     Models,
     /// Per-provider API token.
     Token(String),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1482,7 +1482,6 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
     let connections_path =
         connectors::default_connections_path().unwrap_or_else(|| fallback.join("connections.toml"));
     let settings = Arc::new(SettingsStore::open(settings_path));
-    let model_list_settings = settings.clone();
     let secrets = extensions::ExtensionSecrets::new(Arc::new(connectors::ConnectionStore::open(
         connections_path,
     )));
@@ -1491,7 +1490,7 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
         extensions::ExtensionsCapability::new(
             extensions_dir,
             workspace,
-            settings,
+            settings.clone(),
             extensions::LiveProcessRegistry::default(),
             None,
         )
@@ -1500,12 +1499,17 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
     );
     let mut registry = control::CliRegistry::default();
     registry.register(capability)?;
-    // `yolop models` edits the model list. Detached it writes global settings
-    // like any other CLI invocation; `use` needs a session and says so.
-    registry.register(Arc::new(capabilities::ModelListCapability::new(
-        model_list_settings,
+    let model_list = Arc::new(capabilities::ModelListCapability::new(
+        settings.clone(),
         None,
-    )))?;
+    ));
+    let mut catalog = config::capability_settings::CapabilityCatalog::new();
+    catalog.register_arc(Arc::new(everruns_builtins::MessageMetadataCapability));
+    registry.register(Arc::new(capabilities::ConfigCapability {
+        settings: settings.clone(),
+        catalog: Arc::new(catalog),
+        model_list,
+    }))?;
     let coordination_store = match runtime::session_log::default_sessions_dir()
         .ok()
         .and_then(|dir| capabilities::CoordinationStore::open(&dir).ok())
@@ -2415,6 +2419,25 @@ mod tests {
         assert!(uses_interactive_renderer(&gallery));
         assert!(!uses_interactive_renderer(&print));
         assert!(!uses_interactive_renderer(&command));
+    }
+
+    #[test]
+    fn attached_config_is_nested_and_top_level_models_is_absent() {
+        let registry = detached_cli_registry().expect("build detached CLI registry");
+        let root = registry
+            .augment(Cli::command())
+            .expect("augment root command");
+
+        root.clone()
+            .try_get_matches_from(["yolop", "config", "models", "list"])
+            .expect("parse nested model-list command");
+        root.clone()
+            .try_get_matches_from(["yolop", "config", "model", "set", "openai/gpt-5.6"])
+            .expect("parse configured model command");
+        assert!(
+            root.try_get_matches_from(["yolop", "models", "list"])
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3894,10 +3894,9 @@ pub async fn build_with_options(
     let live_processes = crate::extensions::LiveProcessRegistry::default();
     let mut session_control_registry = crate::control::ControlRegistry::default();
     session_control_registry.register(coordination_capability)?;
-    // The model list administers itself through the same attached-CLI plane:
-    // `yolop models ...`. It shares `ModelsCapability`'s controller, so
-    // `yolop models use` switches this live session exactly like `/setup
-    // provider <name> <model>`.
+    // The persistent config CLI delegates catalog operations to the model list.
+    // Runtime switching stays on the existing models control route, which shares
+    // `ModelsCapability`'s controller with `/setup provider <name> <model>`.
     let pending_model_choice = Arc::new(RwLock::new(None));
     let model_list = Arc::new(crate::capabilities::ModelListCapability::new(
         settings.clone(),
@@ -3909,7 +3908,8 @@ pub async fn build_with_options(
         )),
     ));
     session_control_registry.register(model_list.clone())?;
-    capabilities.register_arc(model_list);
+    // ConfigCapability owns the attached `config` CLI; the model list remains
+    // registered only as the `models` control route it delegates to.
     // Per-extension secrets ride the shared credential store (`connections.toml`,
     // 0600), keyed `ext:<name>` — never `settings.toml`. Injected as env at
     // spawn; never surfaced to the agent.
@@ -4222,7 +4222,7 @@ pub async fn build_with_options(
     capabilities.register(ConfigCapability {
         settings: settings.clone(),
         catalog: Arc::new(catalog),
-        reveals: tool_reveals.clone(),
+        model_list: model_list.clone(),
     });
 
     let mut driver_registry = DriverRegistry::new();
@@ -9144,7 +9144,7 @@ mod tests {
     /// stable composition components so prompt/tool budget changes are explicit.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cold_start_prompt_composition_is_measured_by_component() {
-        const BASELINE_PROMPT_BYTES: usize = 12_888;
+        const BASELINE_PROMPT_BYTES: usize = 14_138;
         // The tool baselines model what today's surface would cost undeferred,
         // so enabling a capability raises them by exactly that capability's
         // undeferred cost — otherwise the ratio guards below would read a

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1147,7 +1147,7 @@ pub(crate) fn setup_overlay_content(app: &App) -> (Vec<Line<'static>>, Option<(u
             }
             push_setup_error(&mut lines, error.as_deref());
             lines.push(setup_footer(
-                "Enter confirm · ↑/↓ move · Esc cancel · `yolop models` to edit",
+                "Enter confirm · ↑/↓ move · Esc cancel · `yolop config models` to edit",
             ));
         }
         Some(SetupStep::PickEffort { selected, error }) => {
@@ -1329,7 +1329,7 @@ pub(crate) fn setup_picker(app: &App) -> Option<SetupPicker> {
             let mut footer = Vec::new();
             push_setup_error(&mut footer, error.as_deref());
             footer.push(setup_footer(
-                "Enter confirm · ↑/↓ move · Esc cancel · `yolop models` to edit",
+                "Enter confirm · ↑/↓ move · Esc cancel · `yolop config models` to edit",
             ));
             Some(SetupPicker {
                 header,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,6 +21,7 @@
 
 mod support;
 
+use std::fs;
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -3179,4 +3180,160 @@ fn openrouter_tool_call_executes_end_to_end() {
          its result reached the model): {stdout}"
     );
     assert!(!stdout.contains("success="), "unexpected footer: {stdout}");
+}
+
+#[test]
+fn config_model_entry_point_persists_show_set_and_clear() {
+    let temp = tempfile::tempdir().expect("temp config dir");
+    let config_dir = temp.path();
+
+    let run = |args: &[&str]| {
+        Command::new(yolop_binary())
+            .env("YOLOP_CONFIG_DIR", config_dir)
+            .args(args)
+            .output()
+            .expect("run config model command")
+    };
+
+    let output = run(&["config", "model", "show"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("\"model\": null"),
+        "unexpected stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let output = run(&["config", "model", "set", "gpt-5.4-mini"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = run(&["config", "model", "show"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("openai/gpt-5.4-mini"),
+        "unexpected stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let settings =
+        fs::read_to_string(config_dir.join("settings.toml")).expect("read persisted settings");
+    assert!(settings.contains("default_provider = \"openai\""));
+    assert!(settings.contains("gpt-5.4-mini"));
+
+    let output = run(&["config", "models", "add", "custom", "qualified-model"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["config", "model", "set", "custom/qualified-model"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["config", "model", "show"]);
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("custom/qualified-model"),
+        "unexpected stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let output = run(&["config", "model", "clear"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = run(&["config", "model", "show"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("\"model\": null"),
+        "unexpected stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let settings =
+        fs::read_to_string(config_dir.join("settings.toml")).expect("read cleared settings");
+    assert!(!settings.contains("default_provider"));
+    assert!(!settings.contains("custom = \"qualified-model\""));
+    assert!(
+        settings.contains("qualified-model"),
+        "catalog entry was removed"
+    );
+}
+
+#[test]
+fn config_entry_point_get_set_json_and_clear() {
+    let temp = tempfile::tempdir().expect("temp config dir");
+    let config_dir = temp.path();
+
+    let run = |args: &[&str]| {
+        Command::new(yolop_binary())
+            .env("YOLOP_CONFIG_DIR", config_dir)
+            .args(args)
+            .output()
+            .expect("run config command")
+    };
+
+    let output = run(&["config", "set", "default_provider", "openai"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["config", "get", "default_provider"]);
+    assert!(output.status.success());
+    let provider =
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("provider JSON");
+    assert_eq!(provider["field"]["key"], "default_provider");
+    assert_eq!(provider["field"]["current"], "openai");
+
+    let output = run(&[
+        "config",
+        "set",
+        "capabilities",
+        "--json",
+        r#"{"ref":"message_metadata","enabled":false}"#,
+    ]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["config", "get", "capabilities"]);
+    assert!(output.status.success());
+    let capabilities =
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("capabilities JSON");
+    let overrides = capabilities["stored_overrides"]
+        .as_array()
+        .expect("stored overrides array");
+    assert_eq!(overrides.len(), 1);
+    assert_eq!(overrides[0]["ref"], "message_metadata");
+    assert_eq!(overrides[0]["enabled"], false);
+
+    let output = run(&["config", "clear", "default_provider"]);
+    assert!(output.status.success());
+    let output = run(&["config", "get", "default_provider"]);
+    assert!(output.status.success());
+    let cleared =
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("cleared provider JSON");
+    assert_eq!(cleared["field"]["key"], "default_provider");
+    assert!(cleared["field"]["current"].is_null());
 }


### PR DESCRIPTION
## What changed
- Replaced the model-facing `get_config` and `set_config` tools with one attached `yolop config` command family.
- Added general `config get`, `config set`, and `config clear` operations.
- Added `config model show|set|clear` for the persisted default model.
- Moved ordered model catalog administration to `config models list|add|rm|move|reset` and removed the old top-level `models` command.
- Kept attached and detached command behavior on the same config capability and persistence logic.

## Why
Configuration was split across agent tools and a separate model catalog command. The new hierarchy distinguishes persistent default-model configuration from model-catalog administration and gives all durable configuration one command namespace.

## Before / After
Before:
```text
get_config / set_config agent tools
yolop models list
```

After:
```text
yolop config get default_provider
yolop config set default_provider openai
yolop config model set openai/gpt-5.6-sol
yolop config model show
yolop config models list
```

Offline smoke tests exercised those commands against a temporary config directory and confirmed that the removed `yolop models` root is rejected.

## Risk
- Medium
- This intentionally removes the old `get_config`, `set_config`, and top-level `models` surfaces. Incorrect routing or persistence could affect configuration updates, default-model selection, or model catalog edits.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge
Updated configuration, conversational control, and model-list concepts to define the unified command namespace and persistence semantics.

## Security
Reviewed TM-FS and TM-TOOL. The command reuses schema-validated settings operations, preserves atomic settings persistence, and does not add arbitrary filesystem paths, shell execution, credential logging, or new dependencies. Capability override JSON remains schema-validated. TM-BASH, TM-LLM, and TM-DEP are unchanged.

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
