### PR TITLE
feat(worktree): make auto initialization model-driven

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,14 @@
 # Knowledge Log
 
+## 2026-08-28, Auto worktrees are model-initialized
+
+- [Git worktrees](specs/worktrees.md): `auto` no longer classifies prompt text
+  with implementation-verb heuristics. The system prompt directs the model to
+  run the attached `yolop worktree init` command before repository mutation.
+- `/worktree` uses the same idempotent session initializer, while persistent mode
+  changes remain owned by the config subsystem. Generic Git worktree lifecycle
+  operations are not duplicated as Yolop session commands.
+
 ## 2026-08-26, Reasoning is ordered content, not a message field
 
 - everruns 0.19 / provider 0.20 replaced the flat `Message.thinking` and

--- a/knowledge/specs/worktrees.md
+++ b/knowledge/specs/worktrees.md
@@ -21,7 +21,7 @@ main checkout stays untouched.
 
 | Value | Behavior |
 |-------|----------|
-| `auto` (default) | Provision a worktree when a user prompt looks like implementation work |
+| `auto` (default) | Start in the resolved cwd; the model initializes a session worktree before the first repository mutation |
 | `always` | Provision at session start inside git repositories |
 | `off` | Never create worktrees; operate in the resolved cwd |
 
@@ -60,17 +60,26 @@ config/secrets.json
 - `repo_root` is the git toplevel of the user's checkout; git identity/remote context comes from there.
 - Sub-agents inherit the parent session's active worktree.
 - Resume reattaches to a saved worktree or recreates it when tmp was cleared.
+- In `auto`, the system prompt instructs the model to run `yolop worktree init`
+  before its first repository mutation. Read-only investigation does not create
+  a worktree. The host does not infer intent from prompt keywords.
+- Initialization is idempotent and serialized. The attached command asks the
+  running session to create or reuse its owned worktree, then updates the shared
+  active root. A standalone process never creates a disconnected worktree.
 - The TUI compact status bar shows `wt <slug>` when a worktree is active; expand
   the status bar for branch and path. Mid-session activation posts a light
   `Switched to worktree · <branch>` system line instead of the raw path.
 
 ### Commands
 
-- `/worktree`, show active worktree, branch, and path (or mode when inactive)
-- `/worktree off`, disable auto-activation for future turns in this session
-- `yolop worktree list`, list worktree directories on disk
-- `yolop worktree prune`, remove worktrees not referenced by any saved session (`--dry-run` to preview)
-
+- `/worktree` and `/worktree init`, initialize the running session worktree
+- `/worktree status`, show mode, state, branch, and active root
+- `yolop worktree init`, attach to the running session and initialize its worktree
+- `yolop worktree status`, inspect the running session's worktree state
+- Worktree mode changes use the config subsystem. `init` refuses when mode is
+  `off`; it does not silently change persistent configuration.
+- Generic listing, switching, removal, and pruning remain Git operations. Yolop
+  does not present registered Git worktrees as live sessions.
 
 Harness and `<environment_context>` tell the model to edit and commit only in
 the session worktree and never change git state in `repo_root`.

--- a/src/capabilities/worktree_cmd.rs
+++ b/src/capabilities/worktree_cmd.rs
@@ -1,54 +1,170 @@
-//! `/worktree` — session git worktree status and auto-activation control.
+//! Session worktree initialization through slash command and attached CLI.
 
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
 use crate::exec::worktree::WorktreeManager;
 use async_trait::async_trait;
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
-use everruns_core::{Capability, CapabilityStatus};
+use everruns_core::tools::ToolExecutionResult;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
-pub(crate) const WORKTREE_CAPABILITY_ID: &str = "yolop_worktree";
-const WORKTREE_COMMAND_NAME: &str = "worktree";
+pub(crate) const WORKTREE_CONTROL_ROUTE: ControlRoute = ControlRoute {
+    resource: "worktree",
+    cli_subcommand: "worktree",
+    read_only_operations: &["status", "list"],
+    summary: "initialize and inspect the running session worktree",
+};
 
-pub(crate) struct WorktreeCapability {
-    pub(crate) manager: Arc<WorktreeManager>,
+#[derive(Debug, Clone, Parser)]
+#[command(name = "worktree", about = "Control this session's Yolop worktree")]
+struct WorktreeCommandLine {
+    #[command(subcommand)]
+    command: WorktreeCliCommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+enum WorktreeCliCommand {
+    /// Ensure this session has a Yolop-owned worktree and make it active.
+    Init,
+    /// Show this session's worktree policy and active workspace.
+    Status,
+    /// List Yolop worktree directories on disk.
+    List,
+    /// Remove worktrees no longer referenced by saved sessions.
+    Prune {
+        /// Preview removals without deleting anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Session storage parent directory (default: platform data dir).
+        #[arg(long)]
+        session_dir: Option<std::path::PathBuf>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+enum WorktreeAction {
+    Init,
+    Status,
+    List,
+    Prune {
+        dry_run: bool,
+        session_dir: Option<std::path::PathBuf>,
+    },
+}
+
+impl From<WorktreeCliCommand> for WorktreeAction {
+    fn from(value: WorktreeCliCommand) -> Self {
+        match value {
+            WorktreeCliCommand::Init => Self::Init,
+            WorktreeCliCommand::Status => Self::Status,
+            WorktreeCliCommand::List => Self::List,
+            WorktreeCliCommand::Prune {
+                dry_run,
+                session_dir,
+            } => Self::Prune {
+                dry_run,
+                session_dir,
+            },
+        }
+    }
+}
+
+impl WorktreeAction {
+    fn request(&self) -> ControlRequest {
+        ControlRequest::new(WORKTREE_CONTROL_ROUTE.resource, self)
+            .expect("worktree action serializes")
+    }
+}
+
+pub struct WorktreeCommandCapability {
+    manager: Option<Arc<WorktreeManager>>,
+}
+
+impl WorktreeCommandCapability {
+    pub fn new(manager: Arc<WorktreeManager>) -> Self {
+        Self {
+            manager: Some(manager),
+        }
+    }
+
+    pub fn detached() -> Self {
+        Self { manager: None }
+    }
+
+    fn manager(&self) -> Result<&WorktreeManager, ToolExecutionResult> {
+        self.manager.as_deref().ok_or_else(|| {
+            ToolExecutionResult::tool_error("worktree commands require a running Yolop session")
+        })
+    }
+
+    fn status_value(&self, created: Option<bool>) -> Value {
+        let manager = self.manager.as_deref().expect("session manager required");
+        let info = manager.worktree_info();
+        json!({
+            "mode": manager.mode().as_str(),
+            "state": if info.is_some() { "active" } else { "starting_checkout" },
+            "created": created,
+            "active_root": manager.active_root(),
+            "branch": info.as_ref().map(|value| value.branch.as_str()),
+            "checkpointing_available": info.is_some(),
+        })
+    }
+
+    fn execute_action(&self, action: &WorktreeAction) -> ToolExecutionResult {
+        let manager = match self.manager() {
+            Ok(manager) => manager,
+            Err(error) => return error,
+        };
+        match action {
+            WorktreeAction::Init => match manager.ensure_initialized(None) {
+                Ok(created) => ToolExecutionResult::success(self.status_value(Some(created))),
+                Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+            },
+            WorktreeAction::Status => ToolExecutionResult::success(self.status_value(None)),
+            WorktreeAction::List | WorktreeAction::Prune { .. } => ToolExecutionResult::tool_error(
+                "list and prune are standalone maintenance commands",
+            ),
+        }
+    }
 }
 
 #[async_trait]
-impl Capability for WorktreeCapability {
+impl Capability for WorktreeCommandCapability {
     fn id(&self) -> &str {
-        WORKTREE_CAPABILITY_ID
+        "worktree"
     }
-
     fn name(&self) -> &str {
-        "Worktree"
+        "Session Worktree"
     }
-
     fn description(&self) -> &str {
-        "Show session git worktree status or disable auto-activation."
+        "Initializes and reports the Yolop-owned worktree for the current session."
     }
-
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
     }
-
     fn category(&self) -> Option<&str> {
-        Some("System")
+        Some("Workspace")
     }
 
     fn commands(&self) -> Vec<CommandDescriptor> {
         vec![CommandDescriptor {
-            name: WORKTREE_COMMAND_NAME.to_string(),
-            description: "Show worktree status, or pass `off` to disable auto-activation."
-                .to_string(),
+            name: "worktree".to_string(),
+            description: "initialize or inspect this session's Yolop-owned worktree".to_string(),
             source: CommandSource::System,
             args: vec![CommandArg {
                 name: "action".to_string(),
-                description: "`off` disables auto worktree creation for future turns.".to_string(),
+                description: "init (default) or status".to_string(),
                 required: false,
-                suggestions: vec!["off".to_string()],
+                suggestions: vec!["init".to_string(), "status".to_string()],
             }],
         }]
     }
@@ -58,33 +174,130 @@ impl Capability for WorktreeCapability {
         request: &ExecuteCommandRequest,
         _ctx: &CommandExecutionContext,
     ) -> everruns_provider::error::Result<CommandResult> {
-        if request.name != WORKTREE_COMMAND_NAME {
-            return Err(everruns_provider::error::AgentLoopError::config(format!(
-                "{} cannot execute /{}",
-                self.id(),
-                request.name
-            )));
-        }
-
-        let arg = request.arguments.as_deref().unwrap_or("").trim();
-        let message = if arg.eq_ignore_ascii_case("off") {
-            self.manager.disable_auto();
-            "worktrees: auto activation disabled for this session (already-active worktrees \
-             are unchanged)"
-                .to_string()
-        } else if arg.is_empty() {
-            self.manager.status_message()
-        } else {
-            return Err(everruns_provider::error::AgentLoopError::config(format!(
-                "unknown /worktree argument `{arg}`; use `/worktree` or `/worktree off`"
-            )));
+        let action = match request.arguments.as_deref().map(str::trim) {
+            None | Some("") | Some("init") => WorktreeAction::Init,
+            Some("status") => WorktreeAction::Status,
+            Some(_) => {
+                return Ok(CommandResult {
+                    success: false,
+                    message: "usage: /worktree [init|status]".to_string(),
+                    error_code: None,
+                    error_fields: None,
+                });
+            }
         };
-
+        let response = ControlResponse::from_tool_result(self.execute_action(&action));
         Ok(CommandResult {
-            success: true,
-            message,
+            success: response.ok,
+            message: self.render_control(
+                &serde_json::to_value(action).unwrap_or(Value::Null),
+                &response,
+            ),
             error_code: None,
             error_fields: None,
         })
     }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        let manager = self.manager.as_deref()?;
+        if !manager.needs_explicit_init() {
+            return None;
+        }
+        Some(
+            "<capability id=\"session_worktree\">\n\
+Before the first repository mutation, run `yolop worktree init` as a direct foreground Bash command. \
+Do not initialize for read-only investigation, explanation, review, or planning. \
+After initialization, continue in the active workspace reported by the command. \
+Do not create, switch, move, or remove the session worktree with raw `git worktree` commands.\n\
+</capability>"
+                .to_string(),
+        )
+    }
 }
+
+#[async_trait]
+impl ControlCapability for WorktreeCommandCapability {
+    fn control_route(&self) -> ControlRoute {
+        WORKTREE_CONTROL_ROUTE
+    }
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        match serde_json::from_value::<WorktreeAction>(action.clone()) {
+            Ok(action) => self.execute_action(&action),
+            Err(error) => {
+                ToolExecutionResult::tool_error(format!("invalid worktree action: {error}"))
+            }
+        }
+    }
+
+    fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+        if !response.ok {
+            return response.render_default();
+        }
+        let value = response.value.as_ref().unwrap_or(&Value::Null);
+        let state = value["state"].as_str().unwrap_or("unknown");
+        let root = value["active_root"].as_str().unwrap_or("unknown");
+        match value["created"].as_bool() {
+            Some(true) => format!("initialized session worktree at {root}"),
+            Some(false) => format!("session worktree already active at {root}"),
+            None => format!(
+                "worktree mode: {}; state: {state}; active root: {root}",
+                value["mode"].as_str().unwrap_or("unknown")
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl CliCapability for WorktreeCommandCapability {
+    fn cli_command(&self) -> clap::Command {
+        WorktreeCommandLine::command()
+    }
+
+    fn control_request_from_cli(
+        &self,
+        matches: &clap::ArgMatches,
+    ) -> anyhow::Result<ControlRequest> {
+        let parsed = WorktreeCommandLine::from_arg_matches(matches)?;
+        Ok(WorktreeAction::from(parsed.command).request())
+    }
+
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let action: WorktreeAction = serde_json::from_value(request.action.clone())?;
+        match action {
+            WorktreeAction::List => {
+                for entry in crate::exec::worktree::list_worktree_paths_on_disk()? {
+                    println!("{}", entry.display());
+                }
+                Ok(())
+            }
+            WorktreeAction::Prune {
+                dry_run,
+                session_dir,
+            } => {
+                let sessions_dir = match session_dir {
+                    Some(path) => path,
+                    None => crate::runtime::session_log::default_sessions_dir()?,
+                };
+                let report = crate::exec::worktree::prune_orphan_worktrees(&sessions_dir, dry_run)?;
+                for path in &report.removed {
+                    println!(
+                        "{} {}",
+                        if dry_run { "would remove" } else { "removed" },
+                        path.display()
+                    );
+                }
+                if report.errors.is_empty() {
+                    Ok(())
+                } else {
+                    anyhow::bail!("{} worktree removal(s) failed", report.errors.len())
+                }
+            }
+            WorktreeAction::Init | WorktreeAction::Status => {
+                anyhow::bail!("worktree init and status require a running Yolop session")
+            }
+        }
+    }
+}
+
+pub(crate) type WorktreeCapability = WorktreeCommandCapability;

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -40,7 +40,6 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::capabilities::{ApprovalDecision, ToolApprover};
 use crate::config::{ApprovalMode, SettingsStore};
-use crate::exec::worktree::WorktreeManager;
 use crate::runtime::background_wake::{WakeReceiver, coalesce_pending_wakes, frame_wake_prompt};
 use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles};
 use crate::session_state::task_completion::{CompletionBudget, GateDecision};
@@ -260,7 +259,6 @@ struct Session {
     acp_id: String,
     handles: RuntimeHandles,
     model: ModelState,
-    worktree: Arc<WorktreeManager>,
     commands: StdMutex<Vec<CommandDescriptor>>,
     cancel: StdMutex<Option<oneshot::Sender<()>>>,
     /// Settings source, read for the `proactive_wake` opt-out and the
@@ -702,7 +700,6 @@ fn register_session<F: RuntimeFactory>(
         acp_id: acp_id.clone(),
         handles: built.handles,
         model: built.model,
-        worktree: built.worktree,
         commands: StdMutex::new(commands.clone()),
         cancel: StdMutex::new(None),
         last_mode: StdMutex::new(built.settings.snapshot().approval_mode()),
@@ -1529,10 +1526,6 @@ async fn run_prompt_once(
     // broadcast only delivers events emitted after `subscribe`.
     let mut live = handles.events.subscribe();
     let events_before = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
-
-    if let Err(err) = session.worktree.ensure_before_turn(&prompt) {
-        tracing::warn!(%err, "acp: worktree activation failed");
-    }
     let turn_handles = handles.clone();
     let turn =
         tokio::spawn(async move { turn_handles.run_checkpointed_turn(&prompt, input).await });

--- a/src/exec/worktree.rs
+++ b/src/exec/worktree.rs
@@ -15,8 +15,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 /// Patterns naming git-ignored paths to copy into freshly-created worktrees,
 /// `.gitignore`-style. Lives at the repo root.
@@ -25,36 +24,6 @@ const WORKTREE_INCLUDE_FILE: &str = ".worktreeinclude";
 /// Copied into managed worktrees automatically, without needing a
 /// `.worktreeinclude` entry (mirrors Codex). Only copied when git-ignored.
 const IMPLICIT_INCLUDE: &str = "AGENTS.override.md";
-
-const IMPLEMENT_VERBS: &[&str] = &[
-    "fix",
-    "implement",
-    "add",
-    "create",
-    "build",
-    "write",
-    "update",
-    "change",
-    "refactor",
-    "ship",
-    "debug",
-    "patch",
-    "remove",
-    "delete",
-    "migrate",
-    "replace",
-    "introduce",
-    "integrate",
-    "wire",
-    "hook",
-    "land",
-    "port",
-    "rewrite",
-    "repair",
-    "correct",
-    "extend",
-    "modify",
-];
 
 const STOP_WORDS: &[&str] = &[
     "a", "an", "the", "to", "for", "in", "on", "at", "of", "and", "or", "with", "from", "this",
@@ -76,9 +45,9 @@ pub struct WorktreeManager {
     repo_root: Option<PathBuf>,
     active_root: Arc<RwLock<PathBuf>>,
     worktree: RwLock<Option<WorktreeInfo>>,
+    initialize_lock: Mutex<()>,
     session_id: SessionId,
     session_dir: PathBuf,
-    auto_disabled: AtomicBool,
 }
 
 impl WorktreeManager {
@@ -99,9 +68,9 @@ impl WorktreeManager {
             repo_root,
             active_root: Arc::new(RwLock::new(active)),
             worktree: RwLock::new(restored),
+            initialize_lock: Mutex::new(()),
             session_id,
             session_dir,
-            auto_disabled: AtomicBool::new(false),
         }
     }
 
@@ -132,76 +101,47 @@ impl WorktreeManager {
         (worktree_path != main_path).then_some(info)
     }
 
-    pub fn disable_auto(&self) {
-        self.auto_disabled.store(true, Ordering::SeqCst);
-    }
-
-    pub fn auto_disabled(&self) -> bool {
-        self.auto_disabled.load(Ordering::SeqCst)
-    }
-
-    pub fn status_message(&self) -> String {
-        if let Some(info) = self.worktree_info() {
-            let repo = self
-                .repo_root
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "unknown".to_string());
-            return format!(
-                "active worktree\nrepo: {repo}\nbranch: {}\npath: {}\nbase: {}",
-                info.branch,
-                info.path.display(),
-                info.base_ref,
+    /// Ensure this session has a Yolop-owned worktree and make it active.
+    ///
+    /// The operation is idempotent. Auto mode is explicit: callers decide when
+    /// repository mutation requires isolation, rather than inferring intent from text.
+    pub fn ensure_initialized(&self, slug_hint: Option<&str>) -> Result<bool> {
+        let _initialize = self
+            .initialize_lock
+            .lock()
+            .expect("worktree init lock poisoned");
+        if self
+            .worktree
+            .read()
+            .expect("worktree lock poisoned")
+            .is_some()
+        {
+            return Ok(false);
+        }
+        if self.mode == WorktreesMode::Off {
+            anyhow::bail!(
+                "worktrees mode is off; change it through the config subsystem before initializing"
             );
         }
-        if self.repo_root.is_none() {
-            return "worktrees: not in a git repository".to_string();
-        }
-        if self.auto_disabled() {
-            return "worktrees: auto activation disabled for this session (already-active \
-                    worktrees are unchanged)"
-                .to_string();
-        }
-        format!(
-            "worktrees: {} (inactive — activates on implementation prompts)",
-            self.mode.as_str()
-        )
-    }
-
-    /// Returns `true` when the active root changed (worktree was created or restored).
-    pub fn ensure_before_turn(&self, prompt: &str) -> Result<bool> {
-        if self.worktree.read().map(|g| g.is_some()).unwrap_or(false) {
-            return Ok(false);
-        }
-        if !self.should_activate(prompt) {
-            return Ok(false);
-        }
-        self.activate(Some(prompt))?;
-        Ok(true)
-    }
-
-    pub fn ensure_always(&self) -> Result<bool> {
-        if self.worktree.read().map(|g| g.is_some()).unwrap_or(false) {
-            return Ok(false);
-        }
         if !self.can_use_worktrees() {
-            return Ok(false);
+            anyhow::bail!("session worktrees are unavailable for this checkout");
         }
-        self.activate(None)?;
+        self.activate(slug_hint)?;
         Ok(true)
     }
 
-    fn should_activate(&self, prompt: &str) -> bool {
-        if self.auto_disabled.load(Ordering::SeqCst) {
-            return false;
-        }
-        match self.mode {
-            WorktreesMode::Off => false,
-            WorktreesMode::Always => self.can_use_worktrees(),
-            WorktreesMode::Auto => {
-                self.can_use_worktrees() && looks_like_implementation_intent(prompt)
-            }
-        }
+    pub fn mode(&self) -> WorktreesMode {
+        self.mode
+    }
+
+    pub fn needs_explicit_init(&self) -> bool {
+        self.mode == WorktreesMode::Auto
+            && self
+                .worktree
+                .read()
+                .expect("worktree lock poisoned")
+                .is_none()
+            && self.can_use_worktrees()
     }
 
     fn can_use_worktrees(&self) -> bool {
@@ -357,20 +297,6 @@ pub fn detect_repo_root(path: &Path) -> Option<PathBuf> {
     } else {
         std::fs::canonicalize(&text).ok()
     }
-}
-
-pub fn looks_like_implementation_intent(prompt: &str) -> bool {
-    let trimmed = prompt.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-    if trimmed.starts_with("/ship") {
-        return true;
-    }
-    let lower = format!(" {lower} ", lower = trimmed.to_ascii_lowercase());
-    IMPLEMENT_VERBS
-        .iter()
-        .any(|verb| lower.contains(&format!(" {verb} ")))
 }
 
 pub fn slug_from_prompt(prompt: &str) -> String {
@@ -995,14 +921,6 @@ mod tests {
     }
 
     #[test]
-    fn implementation_intent_matches_common_verbs() {
-        assert!(looks_like_implementation_intent("fix the auth bug"));
-        assert!(looks_like_implementation_intent("/ship this change"));
-        assert!(!looks_like_implementation_intent("how does auth work?"));
-        assert!(!looks_like_implementation_intent("explain the module"));
-    }
-
-    #[test]
     fn branch_name_uses_slug_and_session_suffix() {
         let id = SessionId::default();
         let branch = branch_name("fix-auth", id);
@@ -1093,7 +1011,7 @@ mod tests {
         );
 
         manager
-            .ensure_before_turn("fix the readme typo")
+            .ensure_initialized(Some("fix the readme typo"))
             .expect("activate worktree");
         let info = manager.worktree_info().expect("worktree info");
         assert!(info.path.exists());
@@ -1181,7 +1099,7 @@ mod tests {
     }
 
     #[test]
-    fn disable_auto_and_status_message() {
+    fn auto_mode_requires_explicit_initialization() {
         let manager = WorktreeManager::new(
             WorktreesMode::Auto,
             Some(PathBuf::from("/tmp/repo")),
@@ -1190,10 +1108,8 @@ mod tests {
             PathBuf::from("/tmp/session"),
             None,
         );
-        assert!(manager.status_message().contains("auto"));
-        manager.disable_auto();
-        assert!(manager.auto_disabled());
-        assert!(manager.status_message().contains("disabled"));
+        assert_eq!(manager.mode(), WorktreesMode::Auto);
+        assert!(manager.worktree_info().is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,8 +224,6 @@ enum Commands {
     Version,
     /// Add yolop into supported editors.
     Into(IntoCommand),
-    /// Git worktree maintenance.
-    Worktree(WorktreeArgs),
     /// Manage MCP servers in global settings or workspace `.mcp.json`.
     Mcp(McpArgs),
     /// Manage downloaded weights for the `local` provider.
@@ -372,27 +370,6 @@ fn parse_key_value(value: &str) -> Result<(String, String), String> {
         return Err("header key cannot be empty".to_string());
     }
     Ok((key.trim().to_string(), val.to_string()))
-}
-
-#[derive(Args, Debug)]
-struct WorktreeArgs {
-    #[command(subcommand)]
-    command: WorktreeCommand,
-}
-
-#[derive(Subcommand, Debug)]
-enum WorktreeCommand {
-    /// List session worktree directories on disk.
-    List,
-    /// Remove worktrees not referenced by any saved session.
-    Prune {
-        /// Print what would be removed without deleting anything.
-        #[arg(long)]
-        dry_run: bool,
-        /// Session storage parent directory (default: platform data dir).
-        #[arg(long)]
-        session_dir: Option<PathBuf>,
-    },
 }
 
 #[derive(Args, Debug)]
@@ -1303,60 +1280,12 @@ fn parse_mcp_auth_mode(value: &str) -> Result<everruns_core::McpServerAuthMode> 
     }
 }
 
-fn run_worktree_command(command: WorktreeCommand) -> Result<()> {
-    match command {
-        WorktreeCommand::List => {
-            let paths = exec::worktree::list_worktree_paths_on_disk()?;
-            if paths.is_empty() {
-                println!("no yolop worktrees found on disk");
-            } else {
-                for path in paths {
-                    println!("{}", path.display());
-                }
-            }
-            Ok(())
-        }
-        WorktreeCommand::Prune {
-            dry_run,
-            session_dir,
-        } => {
-            let sessions_dir = match session_dir {
-                Some(path) => path,
-                None => runtime::session_log::default_sessions_dir()?,
-            };
-            let report = exec::worktree::prune_orphan_worktrees(&sessions_dir, dry_run)?;
-            let action = if dry_run { "would remove" } else { "removed" };
-            for path in &report.removed {
-                println!("{action}: {}", path.display());
-            }
-            let ref_action = if dry_run { "would detach" } else { "detached" };
-            for reference in &report.checkpoint_refs {
-                println!("{ref_action} checkpoint ref: {reference}");
-            }
-            println!(
-                "kept {} referenced worktree(s); {} orphan(s) {action}",
-                report.kept,
-                report.removed.len()
-            );
-            for err in &report.errors {
-                eprintln!("error: {err}");
-            }
-            if report.errors.is_empty() {
-                Ok(())
-            } else {
-                std::process::exit(1);
-            }
-        }
-    }
-}
-
 async fn run_command(command: Commands) -> Result<()> {
     match command {
         Commands::Version => {
             println!("{}", version::VERSION_LINE);
             Ok(())
         }
-        Commands::Worktree(args) => run_worktree_command(args.command),
         Commands::Mcp(args) => run_mcp_command(args.command),
         Commands::Weights(args) => run_weights_command(args.command).await,
         Commands::TuikaGallery => run_tuika_gallery(),
@@ -1510,6 +1439,7 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
         catalog: Arc::new(catalog),
         model_list,
     }))?;
+    registry.register(Arc::new(capabilities::WorktreeCapability::detached()))?;
     let coordination_store = match runtime::session_log::default_sessions_dir()
         .ok()
         .and_then(|dir| capabilities::CoordinationStore::open(&dir).ok())
@@ -2117,9 +2047,6 @@ async fn run_print_mode(
         ..
     } = runtime;
     let color = io::stdout().is_terminal();
-    if let Err(err) = worktree.ensure_before_turn(prompt.trim()) {
-        eprintln!("worktree: {err}");
-    }
     let _ = (&startup.session_dir, &startup.session_log_path);
 
     let trimmed = prompt.trim();
@@ -2334,15 +2261,12 @@ struct PrintTurn {
 
 async fn collect_print_turn(
     handles: &runtime::RuntimeHandles,
-    worktree: &crate::exec::worktree::WorktreeManager,
+    _worktree: &crate::exec::worktree::WorktreeManager,
     model: &runtime::ModelState,
     prompt: &str,
     images: Vec<ContentPart>,
     automatic: bool,
 ) -> Result<PrintTurn> {
-    if let Err(err) = worktree.ensure_before_turn(prompt) {
-        eprintln!("worktree: {err}");
-    }
     let before_msgs = handles
         .runtime
         .messages(handles.session_id)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3531,7 +3531,7 @@ pub async fn build_with_options(
         Some(metadata)
     };
     if worktrees_mode == crate::config::WorktreesMode::Always {
-        let _ = worktree.ensure_always();
+        let _ = worktree.ensure_initialized(None);
     }
 
     let shared_workspace_root = worktree.shared_active_root();
@@ -3910,6 +3910,9 @@ pub async fn build_with_options(
     session_control_registry.register(model_list.clone())?;
     // ConfigCapability owns the attached `config` CLI; the model list remains
     // registered only as the `models` control route it delegates to.
+    let worktree_capability = Arc::new(WorktreeCapability::new(worktree.clone()));
+    session_control_registry.register(worktree_capability.clone())?;
+    capabilities.register_arc(worktree_capability);
     // Per-extension secrets ride the shared credential store (`connections.toml`,
     // 0600), keyed `ext:<name>` — never `settings.toml`. Injected as env at
     // spawn; never surfaced to the agent.
@@ -4102,9 +4105,6 @@ pub async fn build_with_options(
     capabilities.register(UserAskCapability {
         store: user_ask_store.clone(),
         session_id,
-    });
-    capabilities.register(WorktreeCapability {
-        manager: worktree.clone(),
     });
     capabilities.register(CheckpointCapability {
         manager: checkpoints.clone(),
@@ -9159,7 +9159,8 @@ mod tests {
     /// stable composition components so prompt/tool budget changes are explicit.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cold_start_prompt_composition_is_measured_by_component() {
-        const BASELINE_PROMPT_BYTES: usize = 14_138;
+        // Auto mode teaches the model to initialize its session worktree before mutation.
+        const BASELINE_PROMPT_BYTES: usize = 14_204;
         // The tool baselines model what today's surface would cost undeferred,
         // so enabling a capability raises them by exactly that capability's
         // undeferred cost — otherwise the ratio guards below would read a

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4167,18 +4167,10 @@ impl App {
         self.begin_turn(handle, None);
     }
 
-    fn prepare_turn(&mut self, prompt: &str) {
-        match self.worktree.ensure_before_turn(prompt) {
-            Ok(true) => {
-                self.startup.workspace_root = self.worktree.active_root();
-                if let Some(notice) = self.worktree.switch_notice() {
-                    self.push_system(notice);
-                }
-            }
-            Ok(false) => {
-                self.startup.workspace_root = self.worktree.active_root();
-            }
-            Err(err) => self.push_system(format!("worktree: {err}")),
+    fn prepare_turn(&mut self, _prompt: &str) {
+        self.startup.workspace_root = self.worktree.active_root();
+        if let Some(notice) = self.worktree.switch_notice() {
+            self.push_system(notice);
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace auto-mode prompt keyword heuristics with an explicit model-driven session worktree initializer
- add attached `yolop worktree init` and `status`, with `/worktree` using the same idempotent operation
- keep `list` and `prune` in the unified command while routing persistent mode changes through config

## Motivation

The old implementation inferred implementation intent from a fixed verb list before every turn. That produced false positives and false negatives, and hid the workspace transition from the model. Auto mode now makes the policy explicit: investigate in the starting checkout, then initialize the session-owned worktree before the first repository mutation.

## Before / After

Before:

```text
$ yolop worktree --help
Commands:
  list
  prune
```

Auto mode scanned prompt tokens such as `fix`, `add`, and `change` before model execution.

After:

```text
$ yolop worktree --help
Commands:
  init    Ensure this session has a Yolop-owned worktree and make it active
  status  Show this session's worktree policy and active workspace
  list    List Yolop worktree directories on disk
  prune   Remove worktrees no longer referenced by saved sessions
```

In auto mode, the capability prompt directs the model to run `yolop worktree init` before its first repository mutation. Initialization is serialized, idempotent, and performed by the running session through the control plane.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run --quiet -- worktree --help`
- `cargo run --quiet -- worktree list`
- `cargo run --quiet -- --provider llmsim -p 'explain the worktree mode without changing files'`

One known timing-sensitive test failed during a concurrent full-suite run and passed immediately in isolation. A subsequent complete suite passed.

## Security

- **TM-FS:** initialization continues to use `WorktreeManager`'s existing managed paths and Git invocation. No new user-controlled path concatenation was introduced.
- **TM-BASH:** no shell execution changes; timeout and output bounds are unchanged.
- **TM-LLM:** the new prompt contribution contains static instructions only, with no secrets or untrusted interpolation.
- **TM-TOOL:** `init` is consequential in the control plane, while `status` and `list` are marked read-only. The operation is serialized and idempotent.
- **TM-DEP:** no dependencies added.

## Knowledge

Updated `knowledge/specs/worktrees.md` and `knowledge/log.md` to record explicit model-driven auto initialization and the unified command surface.

## Follow-ups

- A read-only starting checkout until initialization remains a possible defense-in-depth improvement. This change removes the heuristic and centralizes initialization without changing sandbox write-root behavior.

Produced by [yolop](https://everruns.com/yolop)
