### PR TITLE
feat(models): default to the gpt-5.6 line and Claude 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
 | ---------- | ------------------------------------- | ----------------- |
 | OpenAI     | `OPENAI_API_KEY`                      | `gpt-5.6-sol`     |
 | Codex subscription | browser/device ChatGPT login or `CODEX_ACCESS_TOKEN` | `gpt-5.6-sol` |
-| Anthropic  | `ANTHROPIC_API_KEY`                   | `claude-opus-4-8` |
+| Anthropic  | `ANTHROPIC_API_KEY`                   | `claude-opus-5`   |
 | Meta Model API | `MODEL_API_KEY`                   | `muse-spark-1.2`  |
 | OpenRouter | browser PKCE login or `OPENROUTER_API_KEY` | `openai/gpt-5.6-sol` |
 | Google     | `GEMINI_API_KEY` / `GOOGLE_API_KEY`   | `gemini-2.5-flash` |

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -76,9 +76,9 @@ Manage the persistent model catalog and future-session default from a shell:
 yolop config models
 yolop config models add openrouter anthropic/claude-opus-4-8 --label "Opus (OpenRouter)"
 yolop config models move claude-opus-4-8 1
-yolop config models rm gpt-5.4-mini
+yolop config models rm openai/gpt-5.6-luna
 yolop config model show
-yolop config model set gpt-5.6-sol
+yolop config model set openai/gpt-5.6-sol
 yolop config model clear
 yolop config models reset          # back to the built-in default list
 ```

--- a/src/capabilities/model_list.rs
+++ b/src/capabilities/model_list.rs
@@ -831,10 +831,10 @@ mod tests {
         let offered = offer(
             vec![ModelEntry::new("openrouter", "some/model")],
             None,
-            |provider| provider == "anthropic",
+            |provider| provider == "codex",
         );
         assert!(
-            offered.iter().all(|entry| entry.provider == "anthropic"),
+            offered.iter().all(|entry| entry.provider == "codex"),
             "an unreachable list falls back to reachable defaults: {offered:?}"
         );
         assert!(!offered.is_empty(), "picker must never be empty");

--- a/src/config/model_list.rs
+++ b/src/config/model_list.rs
@@ -172,9 +172,20 @@ mod tests {
     }
 
     #[test]
-    fn default_list_leads_with_gpt_5_6_sol() {
+    fn default_list_offers_the_gpt_5_6_line_on_both_accounts() {
         let defaults = default_models();
         assert_eq!(defaults[0], ModelEntry::new("openai", "gpt-5.6-sol"));
+        assert_eq!(
+            defaults,
+            vec![
+                ModelEntry::new("openai", "gpt-5.6-sol"),
+                ModelEntry::new("openai", "gpt-5.6-terra"),
+                ModelEntry::new("openai", "gpt-5.6-luna"),
+                ModelEntry::new("codex", "gpt-5.6-sol"),
+                ModelEntry::new("codex", "gpt-5.6-terra"),
+                ModelEntry::new("codex", "gpt-5.6-luna"),
+            ]
+        );
         for entry in &defaults {
             assert!(
                 SUPPORTED_PROVIDERS.contains(&entry.provider.as_str()),

--- a/src/config/model_list.rs
+++ b/src/config/model_list.rs
@@ -89,17 +89,18 @@ impl ModelEntry {
 
 /// The menu a user who has never configured one gets.
 ///
-/// Small on purpose: enough to cover the everyday switches (a frontier model, a
-/// fast one, the other lab) without reproducing the catalog the list exists to
+/// Small on purpose: the current frontier line, reachable through either
+/// account that serves it, without reproducing the catalog the list exists to
 /// avoid. Entries whose provider has no credential are hidden at display time,
 /// so listing several providers here costs nothing to a user who has one.
 pub fn default_models() -> Vec<ModelEntry> {
     vec![
         ModelEntry::new("openai", "gpt-5.6-sol"),
-        ModelEntry::new("openai", "gpt-5.4-mini"),
-        ModelEntry::new("anthropic", "claude-opus-4-8"),
-        ModelEntry::new("anthropic", "claude-sonnet-4-5"),
+        ModelEntry::new("openai", "gpt-5.6-terra"),
+        ModelEntry::new("openai", "gpt-5.6-luna"),
         ModelEntry::new("codex", "gpt-5.6-sol"),
+        ModelEntry::new("codex", "gpt-5.6-terra"),
+        ModelEntry::new("codex", "gpt-5.6-luna"),
     ]
 }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -108,8 +108,8 @@ pub fn schema() -> &'static [ConfigField] {
                           means the built-in default list.",
             kind: ValueKind::List,
             default: Some(
-                "openai/gpt-5.6-sol, openai/gpt-5.4-mini, anthropic/claude-opus-4-8, \
-                           anthropic/claude-sonnet-4-5, codex/gpt-5.6-sol",
+                "openai/gpt-5.6-sol, openai/gpt-5.6-terra, openai/gpt-5.6-luna, \
+                           codex/gpt-5.6-sol, codex/gpt-5.6-terra, codex/gpt-5.6-luna",
             ),
             examples: &["yolop config models add openrouter anthropic/claude-opus-4-8"],
             provider_scoped: false,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1249,7 +1249,7 @@ impl SessionFileSystem for CodingCliSessionFileStore {
 
 const DEFAULT_OPENAI_MODEL: &str = "gpt-5.6-sol";
 const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
-const DEFAULT_ANTHROPIC_MODEL: &str = "claude-opus-4-8";
+const DEFAULT_ANTHROPIC_MODEL: &str = "claude-opus-5";
 const DEFAULT_META_MODEL: &str = "muse-spark-1.2";
 const DEFAULT_GOOGLE_MODEL: &str = "gemini-2.5-flash";
 // Gemini exposes an OpenAI-compatible surface at this base URL, driven through
@@ -1885,11 +1885,14 @@ impl ProviderChoice {
                 "claude-opus-4-6",
                 "claude-opus-4-7",
                 "claude-opus-4-8",
+                "claude-sonnet-5",
+                "claude-opus-5",
                 "claude-fable-5",
                 // `[1m]` ids are the 1M-context twins of the 200K base models;
                 // the everruns-anthropic driver strips the suffix on the wire
                 // and requests the window via the `context-1m` beta header.
                 "claude-fable-5[1m]",
+                "claude-opus-5[1m]",
                 "claude-opus-4-8[1m]",
             ],
             "meta" => &["muse-spark-1.2", "muse-spark-1.2-contributor"],
@@ -7332,7 +7335,7 @@ mod tests {
         assert!(codex.label().starts_with("codex/gpt-5.6-sol"));
 
         let anthropic = ProviderChoice::default_for_provider_name("anthropic").unwrap();
-        assert_eq!(anthropic.label(), "anthropic/claude-opus-4-8 high");
+        assert_eq!(anthropic.label(), "anthropic/claude-opus-5 high");
 
         let meta = ProviderChoice::default_for_provider_name("meta").unwrap();
         assert_eq!(meta.label(), "meta/muse-spark-1.2");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3207,7 +3207,7 @@ fn config_model_entry_point_persists_show_set_and_clear() {
         String::from_utf8_lossy(&output.stdout)
     );
 
-    let output = run(&["config", "model", "set", "gpt-5.4-mini"]);
+    let output = run(&["config", "model", "set", "openai/gpt-5.6-luna"]);
     assert!(
         output.status.success(),
         "stderr={}",
@@ -3221,7 +3221,7 @@ fn config_model_entry_point_persists_show_set_and_clear() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains("openai/gpt-5.4-mini"),
+        String::from_utf8_lossy(&output.stdout).contains("openai/gpt-5.6-luna"),
         "unexpected stdout: {}",
         String::from_utf8_lossy(&output.stdout)
     );
@@ -3229,7 +3229,7 @@ fn config_model_entry_point_persists_show_set_and_clear() {
     let settings =
         fs::read_to_string(config_dir.join("settings.toml")).expect("read persisted settings");
     assert!(settings.contains("default_provider = \"openai\""));
-    assert!(settings.contains("gpt-5.4-mini"));
+    assert!(settings.contains("gpt-5.6-luna"));
 
     let output = run(&["config", "models", "add", "custom", "qualified-model"]);
     assert!(


### PR DESCRIPTION
## What changed

- The anthropic provider default is now `claude-opus-5` (was `claude-opus-4-8`), and the anthropic suggestion list gained `claude-sonnet-5`, `claude-opus-5`, and the 1M-context twin `claude-opus-5[1m]` alongside the `claude-fable-5` entries already there.
- The built-in model menu a user who never configured `[[models]]` gets is now the gpt-5.6 line on both accounts that serve it: `openai/gpt-5.6-{sol,terra,luna}` then `codex/gpt-5.6-{sol,terra,luna}`. The `gpt-5.4-mini` and the two Claude 4 entries are gone from it.
- README's provider table, the bundled `yolop` skill's examples, and the `models` field default in the config schema follow the new list.

Users who already curated a list are untouched; this only changes what an unconfigured install offers and which model `--provider anthropic` picks with no saved choice.

## Why

The defaults named the previous generation. The menu should lead with the models people actually switch between today, and reaching the same gpt-5.6 weights through an API key or a ChatGPT subscription is exactly the distinction the list exists to express.

## Before / After

`yolop config models list` on a fresh config directory:

Before
```text
   1. openai/gpt-5.6-sol  (no credential)
   2. openai/gpt-5.4-mini  (no credential)
   3. anthropic/claude-opus-4-8  (no credential)
   4. anthropic/claude-sonnet-4-5  (no credential)
   5. codex/gpt-5.6-sol  (no credential)
(built-in default list; `yolop config models add|rm|move` makes it yours)
```

After
```text
   1. openai/gpt-5.6-sol  (no credential)
   2. openai/gpt-5.6-terra  (no credential)
   3. openai/gpt-5.6-luna  (no credential)
   4. codex/gpt-5.6-sol  (no credential)
   5. codex/gpt-5.6-terra  (no credential)
   6. codex/gpt-5.6-luna  (no credential)
(built-in default list; `yolop config models add|rm|move` makes it yours)
```

Provider default, from `ProviderChoice::default_for_provider_name("anthropic")`: `anthropic/claude-opus-4-8 high` becomes `anthropic/claude-opus-5 high`. A local run with a deliberately bad key reaches the API and fails on auth, not on an unknown model:

```text
turn error: LLM error: provider 'anthropic': Anthropic API error (401 Unauthorized): {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}...}
```

Smoke: `yolop --provider llmsim -p "hi"` still answers locally, and CI's Live Provider Smoke (Doppler) job passes on this head.

## Risk

- Low
- Two behavior notes worth stating rather than hiding. Every `gpt-5.6-*` id is now on the list for both openai and codex, so a bare reference (`config model set gpt-5.6-sol`, `config models rm gpt-5.6-luna`) is ambiguous and errors asking for a `provider/model` form. That is `find`'s existing, tested contract, not new behavior, but the default list now triggers it; the docs and the config entry-point test use qualified names. Second, the default menu no longer names anthropic, so `offered_models`' last-resort fallback (unreachable configured list) yields nothing for a user whose only credential is `ANTHROPIC_API_KEY`; the picker is still populated normally whenever the configured list is reachable.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

`No knowledge update required`: [`knowledge/specs/model-list.md`](knowledge/specs/model-list.md) describes the menu's contract and still holds: an unset list resolves to a built-in default led by `openai/gpt-5.6-sol`, and ambiguous bare references stay an error. Which ids populate that default is source-level detail the spec deliberately does not carry.

## Security

Reviewed against the threat-model categories in `.agents/skills/ship/SKILL.md`. No TM-FS, TM-BASH, or TM-TOOL surface is touched: no filesystem, shell-execution, or capability-registration code changes. TM-LLM is the only category in scope, and only in that different model ids are sent as request parameters; credential reading, prompt construction, and logging are unchanged, and no key material appears in the diff. TM-DEP: no dependency changes.

## Follow-ups

- The anthropic-only fallback gap under **Risk** is left as-is: making `offered_models` fall back per credential rather than per default entry is a behavior change beyond this one, and the picker is unaffected for any reachable list. Restoring an anthropic entry to the default menu would also close it if that is preferred.