### PR TITLE
refactor(filesystem): use physical repository paths

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,16 @@
 # Knowledge Log
 
+## 2026-08-29, Skills and repository tools use physical paths
+
+- [Skills](specs/skills.md): every skill scope now points at a real directory.
+  Built-in skills remain materialized under the data directory, extension skills
+  use their installed package directories, and generated environment skills are
+  materialized beneath the session directory.
+- File tools read physical skill directories through an explicit read-only route.
+  Yolop no longer creates virtual skill mounts or a `/workspace` repository alias.
+- Host-backed repository scanners accept repository-relative paths and contained
+  real absolute paths. Unrelated or synthetic absolute paths are rejected.
+
 ## 2026-08-28, Auto worktrees are model-initialized
 
 - [Git worktrees](specs/worktrees.md): `auto` no longer classifies prompt text

--- a/knowledge/specs/skills.md
+++ b/knowledge/specs/skills.md
@@ -19,17 +19,14 @@ substitution, all driven strictly through the session `SessionFileSystem`. yolop
 supplies only the embedder-specific glue (`crate::capabilities::skills`):
 
 1. **The scope set and writability**: workspace, profile, global, environment,
-   and system (below), passed as `SkillScope`s with labeled **VFS roots** (never
-   host paths).
-2. **A host-path `SkillDirResolver`**: so `${SKILL_DIR}` and the displayed paths
-   expand to real on-disk paths the host `bash` tool can read. (The core default
-   keeps them in the VFS, which is correct only when the shell shares that
-   namespace; yolop's `bash` runs on the host.)
+   extension, and system (below), passed as `SkillScope`s with their physical
+   directory paths.
+2. **A host-path `SkillDirResolver`**: so `${SKILL_DIR}` and displayed paths stay
+   usable by the host `bash` tool.
 3. **Bundled system skills**: pre-packed in the binary and materialized once.
-4. **File-store routing**: `CodingCliSessionFileStore` maps each scope's VFS root
-   onto the real directory or ephemeral store below, so the capability reaches
-   global/environment/system skills through the VFS without ever being handed a
-   host path.
+4. **File-store routing**: `CodingCliSessionFileStore` permits reads from physical
+   skill directories outside the workspace while rejecting normal file-tool
+   writes to them.
 
 This spec owns the scope set and the yolop wiring; the capability contract and
 `SKILL.md` format are owned upstream (see `everruns` `specs/skills-registry.md`).
@@ -43,28 +40,28 @@ This spec owns the scope set and the yolop wiring; the capability contract and
 ## Scopes
 
 A skill is a directory named for the skill, containing `SKILL.md`. Each scope is
-a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
+a labeled **real on-disk directory**:
 
-1. **Workspace**: `<workspace>/.agents/skills/<name>/` (VFS `/.agents/skills`).
+1. **Workspace**: `<workspace>/.agents/skills/<name>/`.
    Lives in the project under version control; ships with the repo it belongs to.
    Writable.
 2. **Profile**: the active `--profile`'s skills directory, `skills_dir` or the
-   conventional `<config_dir>/yolop/profiles/<name>/skills/` (VFS
-   `/.yolop/profile-skills`). Present only while that profile is selected.
+   conventional `<config_dir>/yolop/profiles/<name>/skills/`. Present only while that profile is selected.
    Writable. A profile is chosen per run, so it outranks the user's global
    skills and never the repository's own; see
    [configuration](configuration.md).
-3. **Global**: `~/.agents/skills/<name>/` (VFS
-   `/.yolop/global-skills`), installed once per user and shared across every
+3. **Global**: `~/.agents/skills/<name>/`, installed once per user and shared across every
    workspace. Writable. Overridable with `YOLOP_GLOBAL_SKILLS_DIR`. The prior
    `<config_dir>/yolop/skills/` root is imported temporarily for compatibility;
    existing primary entries are never overwritten.
-4. **Environment**: optional, integration-owned skills mounted into the
-   session-only VFS (VFS `/.yolop/environment-skills`). Always read-only and
-   never materialized on disk. Herdr currently contributes this scope when its
-   inherited environment contract is valid.
-5. **System**: pre-packed inside the yolop binary and materialized once to
-   `<data_dir>/yolop/system-skills/<name>/` (VFS `/.yolop/system-skills`). Always
+4. **Environment**: optional, integration-owned skills materialized under the
+   session directory. Always read-only through normal file tools. Herdr currently
+   contributes this scope when its inherited environment contract is valid.
+5. **Extension**: skills already installed inside enabled extension packages.
+   Their declared skill directories are injected directly and are read-only
+   through normal file tools.
+6. **System**: pre-packed inside the yolop binary and materialized once to
+   `<data_dir>/yolop/system-skills/<name>/`. Always
    available, **read-only**. Overridable with `YOLOP_SYSTEM_SKILLS_DIR` (used
    verbatim, no materialization).
 
@@ -77,9 +74,8 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
    global, which shadows environment, which shadows system.
    Discovery de-duplicates by directory name in that order; `activate_skill`
    resolves the same way.
-3. **Usable paths.** Disk-backed scopes expand `${SKILL_DIR}` to paths the host
-   `bash` tool can read, so bundled files work. Environment skills remain
-   VFS-only and must not advertise shell-side assets.
+3. **Usable paths.** Every scope expands `${SKILL_DIR}` to a real path the host
+   `bash` tool can read, so bundled and generated files work consistently.
 4. **No command execution on activation.** The `!`cmd`` substitution is never
    expanded, activating a skill must not spawn a shell on the host (mirrors the
    upstream trust gate; see `everruns-core` skills / EVE-388).
@@ -126,11 +122,10 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
     keyboard shortcuts, CLI flags, and session controls. `/help` in the TUI
     summarizes the live command registry and shortcuts; the skill carries the
     full guide for conversational help.
-14. **Environment skills are ephemeral.** An environment integration may mount
-    a read-only, VFS-only skill scope for the current session. Herdr does this
-    only when its inherited pane/socket contract is present. Precedence is
-    workspace, profile, global, environment, then system; the mount never writes any
-    skill directory.
+14. **Environment skills are session-owned.** An environment integration may
+    materialize a read-only skill scope beneath the current session directory.
+    Herdr does this only when its inherited pane/socket contract is present.
+    Precedence is workspace, profile, global, environment, then system.
 
 ## Ownership Boundary
 
@@ -138,15 +133,15 @@ a labeled VFS root that yolop's file store maps to a **real on-disk directory**:
   precedence, the skills tools, validation, and substitution, all through the
   session `SessionFileSystem`.
 - `crate::capabilities::skills` owns the yolop wiring: the scope set, the
-  host-path `SkillDirResolver`, the embedded system skills + materialization, the
-  VFS-root constants the file store routes on, and the `SkillManagementCapability`
+  host-path `SkillDirResolver`, embedded and generated skill materialization, and
+  the `SkillManagementCapability`
   that contributes `search_skills`, `install_skill`, and `delete_skill`. That
   capability must be both registered *and* enabled in the default coding
   harness; registering it alone leaves its tools out of every session while the
   skill-management skill still instructs the model to call them.
 - `crate::capabilities::skill_registry` owns the skills.sh HTTP client used by
   `search_skills` / `install_skill`.
-- `crate::runtime` (`CodingCliSessionFileStore`) owns mapping the scope VFS roots
-  to real on-disk directories.
+- `crate::runtime` (`CodingCliSessionFileStore`) owns read-only access to physical
+  skill directories outside the workspace.
 - `everruns_core::skill` owns the `SKILL.md` format, parsing, validation, and
   substitution.

--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -1257,9 +1257,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ast_grep_tool_accepts_workspace_alias_scope() {
-        // Like repo_map, ast_grep resolves its `path` through resolve_host_scope,
-        // so the `/workspace` display alias must scope correctly here too.
+    async fn ast_grep_tool_accepts_repository_relative_path_scope() {
+        // Like repo_map, ast_grep resolves repository-relative paths through
+        // resolve_host_scope.
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("src/lib.rs"), "fn target() {}\n");
         write(&dir.path().join("other/lib.rs"), "fn other() {}\n");
@@ -1274,7 +1274,7 @@ mod tests {
             .execute(json!({
                 "pattern": "fn $NAME() {}",
                 "language": "rust",
-                "path": "/workspace/src",
+                "path": "src",
                 "limit": 10
             }))
             .await;

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -2008,10 +2008,8 @@ trait Named {
     }
 
     #[tokio::test]
-    async fn repo_map_tool_accepts_workspace_alias_scope() {
-        // The model often passes the `/workspace` display alias as `path`; the
-        // file tools honor it via MountFs, so repo_map must resolve it to the
-        // workspace root instead of erroring with "path not found: /workspace".
+    async fn repo_map_tool_accepts_repository_relative_path_scope() {
+        // Repository-relative paths resolve from the active repository root.
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("pkg/inside.rs"), "pub fn pkg_fn() {}\n");
         write(
@@ -2026,21 +2024,21 @@ trait Named {
             .find(|tool| tool.name() == "repo_map")
             .expect("repo_map tool");
 
-        // Alias root scans the whole workspace.
+        // Repository root scans the whole workspace.
         let ToolExecutionResult::Success(root) = tool
-            .execute(json!({ "path": "/workspace", "language": "rust" }))
+            .execute(json!({ "path": ".", "language": "rust" }))
             .await
         else {
-            panic!("expected success scanning /workspace");
+            panic!("expected success scanning repository root");
         };
         assert_eq!(root["count"], json!(2));
 
-        // Alias subpath scopes to just that directory.
+        // Repository-relative subpath scopes to just that directory.
         let ToolExecutionResult::Success(sub) = tool
-            .execute(json!({ "path": "/workspace/pkg", "language": "rust" }))
+            .execute(json!({ "path": "pkg", "language": "rust" }))
             .await
         else {
-            panic!("expected success scanning /workspace/pkg");
+            panic!("expected success scanning pkg");
         };
         assert_eq!(sub["count"], json!(1));
         assert_eq!(sub["files"][0]["symbols"][0]["name"], json!("pkg_fn"));
@@ -2051,7 +2049,7 @@ trait Named {
         let dir = tempfile::tempdir().expect("tempdir");
         // A linked Git worktree identifies its repository with a .git file,
         // not a .git directory. The scanner must treat that as metadata while
-        // still accepting the model-facing alias for a nested repository.
+        // still accepting a repository-relative nested path.
         write(
             &dir.path().join(".git"),
             "gitdir: /tmp/repo/.git/worktrees/fixture\n",
@@ -2072,20 +2070,19 @@ trait Named {
             .find(|tool| tool.name() == "repo_map")
             .expect("repo_map tool");
 
-        for path in ["/workspace/REPOS/nested", "REPOS/nested"] {
-            let ToolExecutionResult::Success(result) = tool
-                .execute(json!({ "path": path, "language": "rust" }))
-                .await
-            else {
-                panic!("expected success scanning {path}");
-            };
-            assert_eq!(result["count"], json!(1), "scope {path}");
-            assert_eq!(
-                result["files"][0]["symbols"][0]["name"],
-                json!("nested_owner"),
-                "scope {path}"
-            );
-        }
+        let path = "REPOS/nested";
+        let ToolExecutionResult::Success(result) = tool
+            .execute(json!({ "path": path, "language": "rust" }))
+            .await
+        else {
+            panic!("expected success scanning {path}");
+        };
+        assert_eq!(result["count"], json!(1), "scope {path}");
+        assert_eq!(
+            result["files"][0]["symbols"][0]["name"],
+            json!("nested_owner"),
+            "scope {path}"
+        );
     }
 
     #[test]

--- a/src/capabilities/skill_registry.rs
+++ b/src/capabilities/skill_registry.rs
@@ -989,6 +989,7 @@ mod tests {
                 global: None,
                 profile: None,
                 system: None,
+                environment: None,
             },
             registry,
         );
@@ -1019,6 +1020,7 @@ mod tests {
             global: None,
             profile: None,
             system: None,
+            environment: None,
         };
         let registry = SkillRegistryClient::with_base_url("http://127.0.0.1:9".into());
         assert_eq!(
@@ -1061,6 +1063,7 @@ mod tests {
                 global: None,
                 profile: None,
                 system: None,
+                environment: None,
             },
             registry,
         );

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -8,14 +8,11 @@
 //
 //   * the scope set and where each maps on the *host* disk,
 //   * a `SkillDirResolver` so `${SKILL_DIR}` expands to a real host path the
-//     `bash` tool can read (the core default keeps it in the VFS),
+//     `bash` tool can read,
 //   * the system skills pre-packed in the binary and materialized once.
 //
-// The capability discovers/reads/writes strictly through the session
-// `SessionFileSystem`. yolop's file store (`CodingCliSessionFileStore`) maps the
-// disk-backed scope VFS roots onto the real directories below, so the capability never
-// touches a host path directly — the host mapping lives behind the file store,
-// not in the capability's configuration.
+// The capability discovers and reads through the session `SessionFileSystem`.
+// Yolop registers each physical skill directory as a read-only file-tool root.
 //
 // Scopes (precedence: workspace > profile > global > system; the core capability
 // de-dups by skill directory name, so a nearer scope shadows a farther one):
@@ -43,32 +40,6 @@ const LEGACY_GLOBAL_SKILLS_DIR_ENV: &str = "YOLOP_LEGACY_GLOBAL_SKILLS_DIR";
 /// Env override for the system skills directory (skips materialization).
 const SYSTEM_SKILLS_DIR_ENV: &str = "YOLOP_SYSTEM_SKILLS_DIR";
 
-/// VFS root for the workspace scope. Routes through the workspace file store to
-/// `<workspace>/.agents/skills` like any other workspace path.
-pub const WORKSPACE_SKILLS_VFS: &str = "/.agents/skills";
-/// Synthetic VFS root for the global scope, routed by the file store to the
-/// user's global skills directory (outside the workspace).
-pub const GLOBAL_SKILLS_VFS: &str = "/.yolop/global-skills";
-/// Synthetic VFS root for the active profile's skills directory, routed by the
-/// file store to `profiles/<name>/skills` (or the profile's `skills_dir`).
-pub const PROFILE_SKILLS_VFS: &str = "/.yolop/profile-skills";
-/// Synthetic VFS root for the system scope, routed by the file store to the
-/// materialized system skills directory.
-pub const SYSTEM_SKILLS_VFS: &str = "/.yolop/system-skills";
-/// Read-only, session-local skills contributed by the active host environment.
-/// Unlike global/system skills this root has no disk backing; a capability
-/// mount (currently Herdr) serves it through `MountFs`.
-pub const ENVIRONMENT_SKILLS_VFS: &str = "/.yolop/environment-skills";
-/// VFS prefix for read-only skills contributed by installed extensions. Each
-/// enabled extension declaring `skills` mounts its `skills/` dir at
-/// `<prefix>/<name>`, served from real disk (like global/system).
-pub const EXTENSION_SKILLS_VFS_PREFIX: &str = "/.yolop/extension-skills";
-
-/// VFS root for one extension's contributed skills.
-pub fn extension_skills_vfs(name: &str) -> String {
-    format!("{EXTENSION_SKILLS_VFS_PREFIX}/{name}")
-}
-
 /// Scope label for one extension's contributed skills.
 pub fn extension_skills_label(name: &str) -> String {
     format!("ext:{name}")
@@ -90,6 +61,8 @@ pub struct SkillDirs {
     pub profile: Option<PathBuf>,
     /// Materialized system skills directory, or `None` when unavailable.
     pub system: Option<PathBuf>,
+    /// Materialized environment skills directory for this session.
+    pub environment: Option<PathBuf>,
 }
 
 impl SkillDirs {
@@ -113,12 +86,13 @@ impl SkillDirs {
             global,
             profile,
             system: system_skills_dir(),
+            environment: None,
         }
     }
 }
 
-/// Strip a VFS root prefix, returning the remainder as an absolute path under
-/// that root (`/` for the root itself). Shared with the file-store router.
+/// Strip a physical root prefix, returning the remainder as an absolute path
+/// under that root (`/` for the root itself). Shared with the file-store router.
 pub fn relative_under(path: &str, root: &str) -> Option<String> {
     if path == root {
         return Some("/".to_string());
@@ -131,35 +105,35 @@ pub fn relative_under(path: &str, root: &str) -> Option<String> {
 /// Only disk-backed scopes whose directory resolved are included. System and
 /// environment scopes are read-only; workspace/global are writable.
 /// `${SKILL_DIR}` and display paths resolve through [`HostSkillDirResolver`].
-pub fn skills_config(
-    dirs: &SkillDirs,
-    environment_active: bool,
-    extensions: &[(String, PathBuf)],
-) -> SkillsConfig {
-    let mut scopes = vec![SkillScope::new("workspace", WORKSPACE_SKILLS_VFS, true)];
+pub fn skills_config(dirs: &SkillDirs, extensions: &[(String, PathBuf)]) -> SkillsConfig {
+    let mut scopes = vec![SkillScope::new(
+        "workspace",
+        dirs.workspace.display().to_string(),
+        true,
+    )];
     // Between workspace and global: a profile is chosen per run, so its skills
     // should win over the user's global set but never over the repo's own.
-    if dirs.profile.is_some() {
-        scopes.push(SkillScope::new("profile", PROFILE_SKILLS_VFS, true));
+    if let Some(path) = &dirs.profile {
+        scopes.push(SkillScope::new("profile", path.display().to_string(), true));
     }
-    if dirs.global.is_some() {
-        scopes.push(SkillScope::new("global", GLOBAL_SKILLS_VFS, true));
+    if let Some(path) = &dirs.global {
+        scopes.push(SkillScope::new("global", path.display().to_string(), true));
     }
-    if environment_active {
+    if let Some(path) = &dirs.environment {
         scopes.push(SkillScope::new(
             "environment",
-            ENVIRONMENT_SKILLS_VFS,
+            path.display().to_string(),
             false,
         ));
     }
-    if dirs.system.is_some() {
-        scopes.push(SkillScope::new("system", SYSTEM_SKILLS_VFS, false));
+    if let Some(path) = &dirs.system {
+        scopes.push(SkillScope::new("system", path.display().to_string(), false));
     }
     // Read-only skills contributed by enabled extensions.
     for (name, _dir) in extensions {
         scopes.push(SkillScope::new(
             extension_skills_label(name),
-            extension_skills_vfs(name),
+            _dir.display().to_string(),
             false,
         ));
     }
@@ -194,10 +168,7 @@ impl HostSkillDirResolver {
         match label {
             "global" => self.dirs.global.clone(),
             "profile" => self.dirs.profile.clone(),
-            // Environment skills are VFS-only and contain no shell-side assets.
-            // Keep their display/substitution path honest instead of pretending
-            // they exist in a writable workspace or global directory.
-            "environment" => Some(PathBuf::from(ENVIRONMENT_SKILLS_VFS)),
+            "environment" => self.dirs.environment.clone(),
             "system" => self.dirs.system.clone(),
             _ => Some(self.dirs.workspace.clone()),
         }
@@ -306,6 +277,18 @@ pub fn system_skills_dir() -> Option<PathBuf> {
 fn materialize_system_skills(dest: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dest)?;
     extract_dir(&SYSTEM_SKILLS, dest)
+}
+
+pub fn materialize_environment_skill(
+    session_dir: &Path,
+    name: &str,
+    source: &str,
+) -> std::io::Result<PathBuf> {
+    let root = session_dir.join("skills").join("environment");
+    let skill_dir = root.join(name);
+    std::fs::create_dir_all(&skill_dir)?;
+    write_if_changed(&skill_dir.join("SKILL.md"), source.as_bytes())?;
+    Ok(root)
 }
 
 /// Recursively write an embedded `Dir` under `dest`. `include_dir` entry paths
@@ -577,19 +560,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn relative_under_strips_vfs_roots() {
+    fn relative_under_strips_physical_roots() {
         assert_eq!(
-            relative_under("/.yolop/global-skills/foo/SKILL.md", GLOBAL_SKILLS_VFS),
+            relative_under(
+                "/home/me/.agents/skills/foo/SKILL.md",
+                "/home/me/.agents/skills"
+            ),
             Some("/foo/SKILL.md".to_string())
         );
         assert_eq!(
-            relative_under("/.yolop/system-skills", SYSTEM_SKILLS_VFS),
+            relative_under("/data/system-skills", "/data/system-skills"),
             Some("/".to_string())
         );
-        assert_eq!(relative_under("/src/main.rs", GLOBAL_SKILLS_VFS), None);
-        // A different root must not match.
         assert_eq!(
-            relative_under("/.agents/skills/foo", GLOBAL_SKILLS_VFS),
+            relative_under("/src/main.rs", "/home/me/.agents/skills"),
             None
         );
     }
@@ -632,8 +616,9 @@ mod tests {
             global: None,
             profile: None,
             system: Some(PathBuf::from("/data/sys")),
+            environment: None,
         };
-        let cfg = skills_config(&dirs, false, &[]);
+        let cfg = skills_config(&dirs, &[]);
         let labels: Vec<&str> = cfg.scopes.iter().map(|s| s.label.as_str()).collect();
         assert_eq!(labels, vec!["workspace", "system"]);
         assert!(cfg.manage_tools);
@@ -661,8 +646,9 @@ mod tests {
             global: Some(PathBuf::from("/home/.agents/skills")),
             profile: Some(PathBuf::from("/cfg/yolop/profiles/triage/skills")),
             system: Some(PathBuf::from("/data/sys")),
+            environment: None,
         };
-        let cfg = skills_config(&dirs, false, &[]);
+        let cfg = skills_config(&dirs, &[]);
         let labels: Vec<&str> = cfg.scopes.iter().map(|s| s.label.as_str()).collect();
         assert_eq!(labels, vec!["workspace", "profile", "global", "system"]);
         let scope = cfg
@@ -671,7 +657,7 @@ mod tests {
             .find(|s| s.label == "profile")
             .expect("profile scope");
         assert!(scope.writable, "a profile owns its skills");
-        assert_eq!(scope.vfs_root, PROFILE_SKILLS_VFS);
+        assert_eq!(scope.vfs_root, "/cfg/yolop/profiles/triage/skills");
         assert_eq!(
             PathBuf::from(cfg.resolver.skill_dir(scope, "triage-intake")),
             PathBuf::from("/cfg/yolop/profiles/triage/skills").join("triage-intake")
@@ -685,19 +671,20 @@ mod tests {
             global: None,
             profile: None,
             system: None,
+            environment: None,
         };
         let ext = vec![(
             "git-guard".to_string(),
             PathBuf::from("/ext/git-guard/skills"),
         )];
-        let cfg = skills_config(&dirs, false, &ext);
+        let cfg = skills_config(&dirs, &ext);
         let scope = cfg
             .scopes
             .iter()
             .find(|s| s.label == "ext:git-guard")
             .expect("extension scope present");
         assert!(!scope.writable, "extension skills are read-only");
-        assert_eq!(scope.vfs_root, extension_skills_vfs("git-guard"));
+        assert_eq!(scope.vfs_root, "/ext/git-guard/skills");
         // The resolver maps the scope back to the real on-disk dir.
         assert_eq!(
             cfg.resolver.skill_dir(scope, "my-skill"),
@@ -712,6 +699,7 @@ mod tests {
             global: Some(PathBuf::from("/cfg/yolop/skills")),
             profile: None,
             system: Some(PathBuf::from("/data/sys")),
+            environment: None,
         };
         let r = HostSkillDirResolver {
             dirs,
@@ -719,12 +707,14 @@ mod tests {
         };
         // Compare as paths so separators are platform-correct.
         assert_eq!(
-            PathBuf::from(r.skill_dir(&SkillScope::new("global", GLOBAL_SKILLS_VFS, true), "foo")),
+            PathBuf::from(
+                r.skill_dir(&SkillScope::new("global", "/cfg/yolop/skills", true), "foo")
+            ),
             PathBuf::from("/cfg/yolop/skills").join("foo")
         );
         assert_eq!(
             PathBuf::from(r.skill_dir(
-                &SkillScope::new("workspace", WORKSPACE_SKILLS_VFS, true),
+                &SkillScope::new("workspace", "/ws/.agents/skills", true),
                 "bar"
             )),
             PathBuf::from("/ws/.agents/skills").join("bar")
@@ -823,6 +813,7 @@ mod tests {
             global: None,
             profile: None,
             system: None,
+            environment: None,
         };
         let capability = SkillManagementCapability::new(dirs);
         let names: Vec<String> = capability
@@ -864,6 +855,7 @@ mod tests {
                 global: global.map(Path::to_path_buf),
                 profile: None,
                 system: None,
+                environment: None,
             },
         }
     }

--- a/src/exec/workspace_host.rs
+++ b/src/exec/workspace_host.rs
@@ -1,11 +1,10 @@
 // Shared workspace host for yolop tools that shell out against disk.
 //
-// Everruns centralizes path presentation and containment in `MountFs` and
-// `RealDiskFileStore`. File tools and host-backed capabilities share one
+// Everruns centralizes path presentation and containment in `RealDiskFileStore`.
+// File tools and host-backed capabilities share one
 // repointable disk handle synced from the worktree's active-root lock.
 
 use anyhow::{Context, Result, bail};
-use everruns_core::session_path::to_session_path;
 use everruns_host::RealDiskFileStore;
 use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
@@ -32,6 +31,13 @@ impl WorkspaceHost {
 
     pub fn disk(&self) -> Arc<RealDiskFileStore> {
         self.disk.clone()
+    }
+
+    pub fn active_root(&self) -> Result<PathBuf, String> {
+        self.active_root
+            .read()
+            .map(|root| root.clone())
+            .map_err(|_| "workspace lock poisoned".to_string())
     }
 
     /// Repoint the host disk when the worktree active root changed.
@@ -81,7 +87,7 @@ impl WorkspaceHost {
 /// A disk path proven to live inside the workspace root.
 ///
 /// The only way to obtain one from model-supplied input is [`resolve_host_scope`],
-/// which normalizes the `/workspace` display alias and enforces containment. The
+/// which resolves repository-relative or real absolute paths and enforces containment. The
 /// disk-scanning capabilities (`repo_map`, `repo_symbols`, `ast_grep`, `lsp`)
 /// resolve model paths through it, so a resolved scope is a *distinct type* from
 /// a bare `PathBuf` a tool might build by hand — a new tool that skips
@@ -118,40 +124,27 @@ impl AsRef<Path> for HostPath {
 
 /// Map a model-facing path to a canonical host directory under `root`.
 ///
-/// yolop presents the model its **real** host checkout path (#258), yet models
-/// still emit the `/workspace` alias from cloud-agent priors — so both spellings
-/// must resolve, on every path surface, forever. A real host-absolute path is
-/// honored directly (with a containment check); everything else — the
-/// `/workspace` alias, a session-absolute `/src`, a bare relative `src` — is
-/// funneled through everruns' `to_session_path`, the *same* normalizer the file
-/// tools reach via `MountFs`. That shared normalizer is the point: `repo_map` /
-/// `repo_symbols` / `ast_grep` / `lsp` now accept exactly what `read` / `grep` /
-/// `edit` accept, and the two can't drift because there is one algorithm.
+/// Real absolute paths are accepted only when they resolve inside the repository.
+/// Relative paths resolve from the repository root. Other absolute paths are not
+/// aliases and are rejected.
 pub fn resolve_host_scope(root: &Path, path: Option<&str>) -> Result<HostPath> {
     let Some(path) = path else {
         return Ok(HostPath(root.to_path_buf()));
     };
     let trimmed = path.trim();
 
-    // A real host-absolute path (what yolop actually shows the model): accept it
-    // when it resolves inside the workspace, reject it when it resolves outside.
-    // If it does not resolve as a real path it is almost certainly a session
-    // spelling (`/workspace/...`, `/src`), so fall through to the normalizer.
     let candidate = Path::new(trimmed);
-    if candidate.is_absolute()
-        && let Ok(canonical) = candidate.canonicalize()
-    {
+    if candidate.is_absolute() {
+        let canonical = candidate
+            .canonicalize()
+            .with_context(|| format!("path not found: {path}"))?;
         if canonical.starts_with(root) {
             return Ok(HostPath(canonical));
         }
         bail!("`path` must stay inside the workspace");
     }
 
-    // Alias / session-absolute / relative all normalize through the one shared
-    // normalizer (which strips `/workspace`, collapses slashes, and canonicalizes
-    // the spelling), then resolve relative to the real root.
-    let session = to_session_path(trimmed);
-    resolve_relative_scope(root, session.trim_start_matches('/'), path).map(HostPath)
+    resolve_relative_scope(root, trimmed, path).map(HostPath)
 }
 
 /// Resolve a workspace-relative scope (already normalized to a session path and
@@ -203,57 +196,19 @@ mod tests {
         assert_eq!(relative, HostPath(root.join("pkg")));
     }
 
-    // Every spelling a model might reach for — the `/workspace` alias, a
-    // session-absolute `/pkg`, the real host-absolute path, a bare relative, and
-    // their slash/​trailing-slash variants — must resolve to the *same* host path
-    // as the file tools' MountFs route. This table is the cross-cutting guard the
-    // per-tool suites never had: it fails the moment any spelling drifts.
     #[test]
-    fn resolve_host_scope_spelling_table_is_consistent() {
+    fn resolve_host_scope_rejects_virtual_and_unrelated_absolute_paths() {
         let dir = tempfile::tempdir().expect("tempdir");
         fs::create_dir_all(dir.path().join("pkg")).expect("pkg dir");
         let root = fs::canonicalize(dir.path()).expect("canonical root");
 
-        let root_spellings = [
-            None,
-            Some(".".to_string()),
-            Some("/workspace".to_string()),
-            Some("/workspace/".to_string()),
-            Some("//workspace//".to_string()),
-            Some(root.to_str().expect("root utf8").to_string()),
-        ];
-        for spelling in root_spellings {
-            let scope = resolve_host_scope(&root, spelling.as_deref())
-                .unwrap_or_else(|e| panic!("root spelling {spelling:?}: {e}"));
-            assert_eq!(scope.as_path(), root, "root spelling {spelling:?}");
-        }
-
-        let pkg = root.join("pkg");
-        let pkg_spellings = [
-            "pkg",
-            "/pkg",                          // session-absolute
-            "/workspace/pkg",                // display alias
-            "//workspace//pkg",              // alias with redundant slashes
-            pkg.to_str().expect("pkg utf8"), // real host-absolute
-        ];
-        for spelling in pkg_spellings {
-            let scope = resolve_host_scope(&root, Some(spelling))
-                .unwrap_or_else(|e| panic!("pkg spelling {spelling:?}: {e}"));
-            assert_eq!(scope.as_path(), pkg, "pkg spelling {spelling:?}");
-        }
-
-        // Escapes are rejected no matter how they are dressed up.
-        for escape in ["/workspace/../outside", "../outside", "//workspace//../x"] {
-            assert!(
-                resolve_host_scope(&root, Some(escape)).is_err(),
-                "escape {escape:?} must be rejected"
-            );
-        }
-
-        // `/workspacefoo` shares the prefix but is not the `/workspace` segment,
-        // so it is a real absolute path that does not exist here — not the alias.
-        let err = resolve_host_scope(&root, Some("/workspacefoo")).expect_err("near miss");
-        assert!(err.to_string().contains("path not found"));
+        assert_eq!(
+            resolve_host_scope(&root, Some("pkg")).expect("relative path"),
+            HostPath(root.join("pkg"))
+        );
+        assert!(resolve_host_scope(&root, Some("/workspace/pkg")).is_err());
+        assert!(resolve_host_scope(&root, Some("/pkg")).is_err());
+        assert!(resolve_host_scope(&root, Some("../outside")).is_err());
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -75,7 +75,7 @@ use everruns_core::command::{CommandDescriptor, CommandResult, ExecuteCommandReq
 use everruns_core::session_file::build_grep_search_result;
 use everruns_core::session_path::GrepPathPattern;
 use everruns_core::{
-    CapabilityRegistry, Controls, InputMessage, MountFs, ReasoningConfig, ScopedMcpServers,
+    CapabilityRegistry, Controls, InputMessage, ReasoningConfig, ScopedMcpServers,
     SessionFileSystem,
 };
 use everruns_core::{ContentPart, MessageRole};
@@ -84,9 +84,9 @@ use everruns_core::{
 };
 use everruns_host::RuntimeProviderStore;
 use everruns_host::{
-    AgentBuilder, CapabilityDelta, HarnessBuilder, HostBackends, InMemorySessionFileStore,
-    InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeSessionStore,
-    SessionBuilder, WriteBlocklistFileStore,
+    AgentBuilder, CapabilityDelta, HarnessBuilder, HostBackends, InProcessRuntime,
+    InProcessRuntimeBuilder, RealDiskFileStore, RuntimeSessionStore, SessionBuilder,
+    WriteBlocklistFileStore,
 };
 use everruns_host::{SessionFileSystemFactory, SessionFileSystemFactoryContext};
 use everruns_integrations_daytona::DaytonaCapability;
@@ -119,7 +119,7 @@ use crate::runtime::session_log::{
     session_log_path, update_session_workspace_title,
 };
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex as StdMutex, RwLock};
 use std::time::Duration;
 use tokio::sync::{RwLock as AsyncRwLock, mpsc};
@@ -360,14 +360,11 @@ const AGENT_PROMPT: &str = "Follow the system and repository instructions.";
 struct CodingCliSessionFileSystemFactory {
     workspace: Arc<WorkspaceHost>,
     session_dir: PathBuf,
-    session_id: SessionId,
     materializer: Arc<session_log::SessionMaterializer>,
     skill_global: Option<PathBuf>,
     skill_profile: Option<PathBuf>,
     skill_system: Option<PathBuf>,
-    environment_skill: Option<&'static str>,
-    /// `(name, skills_dir)` for enabled extensions contributing skills; each is
-    /// mounted read-only at its `extension_skills_vfs(name)` root.
+    skill_environment: Option<PathBuf>,
     extension_skills: Vec<(String, PathBuf)>,
 }
 
@@ -388,6 +385,7 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
             self.skill_global.as_ref(),
             self.skill_profile.as_ref(),
             self.skill_system.as_ref(),
+            self.skill_environment.as_ref(),
         ]
         .into_iter()
         .flatten()
@@ -396,65 +394,29 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
                 AgentLoopError::config(format!("create skills dir {}: {e}", dir.display()))
             })?;
         }
+        let mut skill_roots = [
+            self.skill_global.clone(),
+            self.skill_profile.clone(),
+            self.skill_system.clone(),
+            self.skill_environment.clone(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        skill_roots.extend(self.extension_skills.iter().map(|(_, path)| path.clone()));
         let composite: Arc<dyn SessionFileSystem> =
             Arc::new(CodingCliSessionFileStore::new_with_materializer(
                 self.workspace.clone(),
                 self.session_dir.clone(),
-                self.skill_global.clone(),
-                self.skill_profile.clone(),
-                self.skill_system.clone(),
+                skill_roots,
                 self.materializer.clone(),
             )?);
-        // Present the real host checkout path to the model, not the `/workspace`
-        // alias (#258): yolop runs on the user's own machine, so the shell, file
-        // tools, and narration must all name the repo the same way. everruns
-        // 0.17.12's `scoped_prompt_file_store` preserves this backend-native
-        // policy into the system prompt too (via `wrap_if_needed`).
-        let mut mounted = MountFs::new(composite).with_backend_display();
-        if let Some(skill) = self.environment_skill {
-            let environment = Arc::new(InMemorySessionFileStore::new());
-            environment
-                .seed_initial_file(
-                    self.session_id,
-                    &InitialFile {
-                        path: "/herdr/SKILL.md".to_string(),
-                        content: skill.to_string(),
-                        encoding: "text".to_string(),
-                        is_readonly: true,
-                    },
-                )
-                .await?;
-            mounted = mounted.with_mount(
-                crate::capabilities::skills::ENVIRONMENT_SKILLS_VFS,
-                environment,
-                "/",
-            );
-        }
-        // Mount each contributing extension's `skills/` dir read-only. Seeded
-        // into an in-memory store (which honors `is_readonly`) rather than a
-        // live-disk mount, so an installed extension's skills can't be mutated
-        // through the VFS — the same read-only guarantee as environment skills.
-        for (name, dir) in &self.extension_skills {
-            let store = InMemorySessionFileStore::new();
-            if let Err(err) = seed_readonly_dir(&store, self.session_id, dir).await {
-                tracing::warn!(
-                    target: "yolop::ext",
-                    "skipping skills for extension `{name}`: {err}"
-                );
-                continue;
-            }
-            mounted = mounted.with_mount(
-                crate::capabilities::skills::extension_skills_vfs(name),
-                Arc::new(store),
-                "/",
-            );
-        }
-        let mounted: Arc<dyn SessionFileSystem> = Arc::new(mounted);
         let write_blocklist: Arc<dyn SessionFileSystem> =
-            Arc::new(WriteBlocklistFileStore::new(mounted.clone()));
+            Arc::new(WriteBlocklistFileStore::new(composite.clone()));
         Ok(Arc::new(GrepOptionsForwardingFileStore::new(
             write_blocklist,
-            mounted,
+            composite.clone(),
+            composite,
         )))
     }
 }
@@ -463,9 +425,10 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
 // everruns-runtime release containing https://github.com/everruns/everruns/pull/2830.
 // Version 0.17.12's write-blocklist decorator drops `grep_files_with_options`;
 // all mutations must still pass through that decorator while contextual grep
-// can safely use the same mounted read backend directly.
+// can safely use the same read backend directly.
 struct GrepOptionsForwardingFileStore {
     policy: Arc<dyn SessionFileSystem>,
+    display: Arc<dyn SessionFileSystem>,
     grep_backend: Arc<dyn SessionFileSystem>,
 }
 
@@ -530,14 +493,7 @@ async fn grep_workspace_with_options(
                 if !entry.file_type().is_some_and(|kind| kind.is_file()) {
                     continue;
                 }
-                let Ok(relative) = entry.path().strip_prefix(&root) else {
-                    continue;
-                };
-                let Some(relative) = relative.to_str() else {
-                    continue;
-                };
-                let canonical_path =
-                    format!("/{}", relative.replace(std::path::MAIN_SEPARATOR, "/"));
+                let canonical_path = entry.path().display().to_string();
                 if path_matcher
                     .as_ref()
                     .is_some_and(|matcher| !matcher.is_match(&canonical_path))
@@ -607,9 +563,14 @@ async fn grep_workspace_with_options(
 }
 
 impl GrepOptionsForwardingFileStore {
-    fn new(policy: Arc<dyn SessionFileSystem>, grep_backend: Arc<dyn SessionFileSystem>) -> Self {
+    fn new(
+        policy: Arc<dyn SessionFileSystem>,
+        display: Arc<dyn SessionFileSystem>,
+        grep_backend: Arc<dyn SessionFileSystem>,
+    ) -> Self {
         Self {
             policy,
+            display,
             grep_backend,
         }
     }
@@ -618,19 +579,19 @@ impl GrepOptionsForwardingFileStore {
 #[async_trait]
 impl SessionFileSystem for GrepOptionsForwardingFileStore {
     fn display_root(&self) -> String {
-        self.policy.display_root()
+        self.display.display_root()
     }
 
     fn display_path(&self, path: &str) -> String {
-        self.policy.display_path(path)
+        self.display.display_path(path)
     }
 
     fn resolve_path(&self, input: &str) -> String {
-        self.policy.resolve_path(input)
+        self.display.resolve_path(input)
     }
 
     fn is_mount_resolver(&self) -> bool {
-        self.policy.is_mount_resolver()
+        self.display.is_mount_resolver()
     }
 
     async fn read_file(
@@ -738,52 +699,11 @@ impl SessionFileSystem for GrepOptionsForwardingFileStore {
     }
 }
 
-/// Seed every UTF-8 file under `root` into `store` read-only, keyed by its path
-/// relative to `root`. Used to mount an extension's on-disk `skills/` dir as a
-/// read-only VFS source. Non-UTF-8 files (rare in skills) are skipped.
-async fn seed_readonly_dir(
-    store: &InMemorySessionFileStore,
-    session_id: SessionId,
-    root: &std::path::Path,
-) -> everruns_provider::error::Result<()> {
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        let entries = std::fs::read_dir(&dir)
-            .map_err(|e| AgentLoopError::config(format!("read {}: {e}", dir.display())))?;
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                stack.push(path);
-            } else if let Ok(text) = std::fs::read_to_string(&path)
-                && let Ok(rel) = path.strip_prefix(root)
-            {
-                let vfs = format!("/{}", rel.to_string_lossy().replace('\\', "/"));
-                store
-                    .seed_initial_file(
-                        session_id,
-                        &InitialFile {
-                            path: vfs,
-                            content: text,
-                            encoding: "text".to_string(),
-                            is_readonly: true,
-                        },
-                    )
-                    .await?;
-            }
-        }
-    }
-    Ok(())
-}
-
 struct CodingCliSessionFileStore {
     workspace: Arc<WorkspaceHost>,
     workspace_disk: RealDiskFileStore,
     session: StdMutex<Option<RealDiskFileStore>>,
-    // Backing stores for the global/system skill scope VFS roots, served from
-    // real directories outside the workspace (see `capabilities::skills`).
-    skill_global: Option<RealDiskFileStore>,
-    skill_profile: Option<RealDiskFileStore>,
-    skill_system: Option<RealDiskFileStore>,
+    skill_roots: Vec<(PathBuf, RealDiskFileStore)>,
     session_dir: PathBuf,
     materializer: Arc<session_log::SessionMaterializer>,
 }
@@ -804,9 +724,10 @@ impl CodingCliSessionFileStore {
         Self::new_with_materializer(
             workspace,
             session_dir,
-            skill_global,
-            skill_profile,
-            skill_system,
+            [skill_global, skill_profile, skill_system]
+                .into_iter()
+                .flatten()
+                .collect(),
             materializer,
         )
     }
@@ -814,22 +735,18 @@ impl CodingCliSessionFileStore {
     fn new_with_materializer(
         workspace: Arc<WorkspaceHost>,
         session_dir: PathBuf,
-        skill_global: Option<PathBuf>,
-        skill_profile: Option<PathBuf>,
-        skill_system: Option<PathBuf>,
+        skill_roots: Vec<PathBuf>,
         materializer: Arc<session_log::SessionMaterializer>,
     ) -> everruns_provider::error::Result<Self> {
-        let skill_store =
-            |dir: Option<PathBuf>| -> everruns_provider::error::Result<Option<RealDiskFileStore>> {
-                dir.map(RealDiskFileStore::new).transpose()
-            };
+        let skill_roots = skill_roots
+            .into_iter()
+            .map(|path| Ok((path.clone(), RealDiskFileStore::new(path)?)))
+            .collect::<everruns_provider::error::Result<Vec<_>>>()?;
         Ok(Self {
             workspace: workspace.clone(),
             workspace_disk: workspace.disk().as_ref().clone(),
             session: StdMutex::new(None),
-            skill_global: skill_store(skill_global)?,
-            skill_profile: skill_store(skill_profile)?,
-            skill_system: skill_store(skill_system)?,
+            skill_roots,
             session_dir,
             materializer,
         })
@@ -843,25 +760,15 @@ impl CodingCliSessionFileStore {
     }
 
     fn skill_route(&self, path: &str) -> Option<(&RealDiskFileStore, String)> {
-        use crate::capabilities::skills::{
-            GLOBAL_SKILLS_VFS, PROFILE_SKILLS_VFS, SYSTEM_SKILLS_VFS, relative_under,
-        };
-        if let Some(store) = &self.skill_global
-            && let Some(rest) = relative_under(path, GLOBAL_SKILLS_VFS)
-        {
-            return Some((store, rest));
-        }
-        if let Some(store) = &self.skill_profile
-            && let Some(rest) = relative_under(path, PROFILE_SKILLS_VFS)
-        {
-            return Some((store, rest));
-        }
-        if let Some(store) = &self.skill_system
-            && let Some(rest) = relative_under(path, SYSTEM_SKILLS_VFS)
-        {
-            return Some((store, rest));
-        }
-        None
+        use crate::capabilities::skills::relative_under;
+
+        self.skill_roots.iter().find_map(|(root, store)| {
+            relative_under(path, root.to_string_lossy().as_ref()).map(|rest| (store, rest))
+        })
+    }
+
+    fn readonly_skill_error(path: &str) -> AgentLoopError {
+        AgentLoopError::config(format!("skill files are read-only: {path}"))
     }
 
     // Keep project files rooted at the user's workspace, but route generated
@@ -981,13 +888,27 @@ impl SessionFileSystem for CodingCliSessionFileStore {
             .unwrap_or_else(|_| self.workspace_disk.display_root())
     }
 
+    fn resolve_path(&self, input: &str) -> String {
+        self.display_path(input)
+    }
+
     fn display_path(&self, path: &str) -> String {
-        if self.skill_route(path).is_some() || Self::session_artifact_path(path).is_some() {
-            return everruns_core::session_path::to_session_path(path);
+        if self.skill_route(path).is_some() {
+            return path.to_string();
         }
-        self.workspace_store()
-            .map(|store| store.display_path(path))
-            .unwrap_or_else(|_| path.to_string())
+        if let Some(relative) = Self::session_artifact_path(path) {
+            return self.session_dir.join(relative).display().to_string();
+        }
+        let Ok(root) = self.workspace.active_root() else {
+            return path.to_string();
+        };
+        let root = root.canonicalize().unwrap_or(root);
+        let candidate = Path::new(path);
+        if candidate.is_absolute() {
+            path.to_string()
+        } else {
+            root.join(candidate).display().to_string()
+        }
     }
 
     async fn read_file(
@@ -1014,8 +935,8 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         content: &str,
         encoding: &str,
     ) -> everruns_provider::error::Result<SessionFile> {
-        if let Some((store, path)) = self.skill_route(path) {
-            return store.write_file(session_id, &path, content, encoding).await;
+        if self.skill_route(path).is_some() {
+            return Err(Self::readonly_skill_error(path));
         }
         if let Some(path) = Self::session_artifact_path(path) {
             let file = self
@@ -1042,17 +963,8 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         content: &str,
         encoding: &str,
     ) -> everruns_provider::error::Result<Option<SessionFile>> {
-        if let Some((store, path)) = self.skill_route(path) {
-            return store
-                .write_file_if_content_matches(
-                    session_id,
-                    &path,
-                    expected_content,
-                    expected_encoding,
-                    content,
-                    encoding,
-                )
-                .await;
+        if self.skill_route(path).is_some() {
+            return Err(Self::readonly_skill_error(path));
         }
         if let Some(path) = Self::session_artifact_path(path) {
             return self
@@ -1086,8 +998,8 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         path: &str,
         recursive: bool,
     ) -> everruns_provider::error::Result<bool> {
-        if let Some((store, path)) = self.skill_route(path) {
-            return store.delete_file(session_id, &path, recursive).await;
+        if self.skill_route(path).is_some() {
+            return Err(Self::readonly_skill_error(path));
         }
         if let Some(path) = Self::session_artifact_path(path) {
             return match self.session_store(false)? {
@@ -1205,8 +1117,8 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         path: &str,
     ) -> everruns_provider::error::Result<FileInfo> {
-        if let Some((store, path)) = self.skill_route(path) {
-            return store.create_directory(session_id, &path).await;
+        if self.skill_route(path).is_some() {
+            return Err(Self::readonly_skill_error(path));
         }
         if let Some(path) = Self::session_artifact_path(path) {
             return self
@@ -1225,10 +1137,8 @@ impl SessionFileSystem for CodingCliSessionFileStore {
         session_id: SessionId,
         file: &InitialFile,
     ) -> everruns_provider::error::Result<()> {
-        if let Some((store, path)) = self.skill_route(&file.path) {
-            let mut routed = file.clone();
-            routed.path = path;
-            return store.seed_initial_file(session_id, &routed).await;
+        if self.skill_route(&file.path).is_some() {
+            return Err(Self::readonly_skill_error(&file.path));
         }
         if let Some(path) = Self::session_artifact_path(&file.path) {
             let mut routed = file.clone();
@@ -3552,10 +3462,21 @@ pub async fn build_with_options(
     // materializes the embedded system skills). Shared by the skills capability
     // config and the file-store factory's scope routing.
     // The active profile may contribute a fourth, profile-scoped directory.
-    let skill_dirs = crate::capabilities::skills::SkillDirs::resolve(
+    let mut skill_dirs = crate::capabilities::skills::SkillDirs::resolve(
         &effective_root,
         settings.snapshot().skills_dir.clone(),
     );
+    if herdr.is_active() {
+        skill_dirs.environment = Some(
+            crate::capabilities::skills::materialize_environment_skill(
+                &session_dir,
+                "herdr",
+                crate::capabilities::herdr::HerdrCapability::skill_content(true)
+                    .expect("active Herdr skill content"),
+            )
+            .context("materialize Herdr environment skill")?,
+        );
+    }
 
     // Read-only skills contributed by enabled extensions (D4: only a declaring,
     // enabled extension's `skills/` loads). Computed here so it feeds both the
@@ -3792,15 +3713,10 @@ pub async fn build_with_options(
     capabilities.register(AgentInstructionsCapability);
     capabilities.register(FileSystemCapability);
     // Upstream multi-scope skills capability (everruns-core 0.12.0+),
-    // configured with yolop's workspace/global/environment/system scopes and a host-path
-    // resolver so `${SKILL_DIR}` reaches real files. The file store maps the
-    // scope VFS roots onto disk (see `capabilities::skills`).
+    // configured with yolop's physical workspace/global/environment/system
+    // directories so `${SKILL_DIR}` reaches real files.
     capabilities.register(ScopedSkillsCapability::new(
-        crate::capabilities::skills::skills_config(
-            &skill_dirs,
-            herdr.is_active(),
-            &extension_skill_scopes,
-        ),
+        crate::capabilities::skills::skills_config(&skill_dirs, &extension_skill_scopes),
     ));
     // Herdr contributes a conditional, read-only skill mount. Outside a Herdr
     // pane it has no mounts and the reporter is inert.
@@ -4332,12 +4248,11 @@ pub async fn build_with_options(
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
             workspace: workspace_host.clone(),
             session_dir: session_dir.clone(),
-            session_id,
             materializer: materializer.clone(),
             skill_global: skill_dirs.global.clone(),
             skill_profile: skill_dirs.profile.clone(),
             skill_system: skill_dirs.system.clone(),
-            environment_skill: HerdrCapability::skill_content(herdr.is_active()),
+            skill_environment: skill_dirs.environment.clone(),
             extension_skills: extension_skill_scopes.clone(),
         }))
         .build();
@@ -4820,13 +4735,10 @@ mod tests {
             )
             .expect("workspace host"),
         );
-        let composite: Arc<dyn SessionFileSystem> = Arc::new(
+        Arc::new(
             CodingCliSessionFileStore::new(host, session.to_path_buf(), None, None, None)
                 .expect("store"),
-        );
-        // Match production (`build`): backend-native display so tests exercise the
-        // real host-path presentation (#258), not the `/workspace` alias.
-        Arc::new(MountFs::new(composite).with_backend_display())
+        )
     }
 
     #[test]
@@ -7919,17 +7831,8 @@ mod tests {
             WorkspaceHost::new(active_root.clone(), first.path().to_path_buf()).expect("host"),
         );
         let store: Arc<dyn SessionFileSystem> = Arc::new(
-            MountFs::new(Arc::new(
-                CodingCliSessionFileStore::new(
-                    host,
-                    session.path().to_path_buf(),
-                    None,
-                    None,
-                    None,
-                )
+            CodingCliSessionFileStore::new(host, session.path().to_path_buf(), None, None, None)
                 .expect("store"),
-            ))
-            .with_backend_display(),
         );
         let session_id = SessionId::from_seed(7);
         let first_root = std::fs::canonicalize(first.path()).expect("canonical first");
@@ -8139,7 +8042,6 @@ mod tests {
         let factory = CodingCliSessionFileSystemFactory {
             workspace: host,
             session_dir: session.path().to_path_buf(),
-            session_id,
             materializer: Arc::new(session_log::SessionMaterializer::new(
                 session.path().to_path_buf(),
                 None,
@@ -8147,7 +8049,7 @@ mod tests {
             skill_global: None,
             skill_profile: None,
             skill_system: None,
-            environment_skill: None,
+            skill_environment: None,
             extension_skills: Vec::new(),
         };
         let store = factory
@@ -8220,7 +8122,6 @@ mod tests {
         let factory = CodingCliSessionFileSystemFactory {
             workspace: host,
             session_dir: session.path().to_path_buf(),
-            session_id,
             materializer: Arc::new(session_log::SessionMaterializer::new(
                 session.path().to_path_buf(),
                 None,
@@ -8228,7 +8129,7 @@ mod tests {
             skill_global: None,
             skill_profile: None,
             skill_system: None,
-            environment_skill: None,
+            skill_environment: None,
             extension_skills: Vec::new(),
         };
         let store = factory
@@ -8269,7 +8170,14 @@ mod tests {
         };
 
         assert_eq!(result["total_matches"], 2);
-        assert_eq!(result["matches"][0]["path"], "/workspace/source_10.rs");
+        assert_eq!(
+            result["matches"][0]["path"],
+            std::fs::canonicalize(workspace.path())
+                .expect("canonical workspace")
+                .join("source_10.rs")
+                .display()
+                .to_string()
+        );
         assert_eq!(result["matches"][0]["line_number"], 2);
         assert_eq!(result["truncation"]["next_offset"], 1);
     }
@@ -8283,7 +8191,7 @@ mod tests {
 
         assert_eq!(store.display_root(), workspace_root.display().to_string());
         assert_eq!(
-            store.display_path("/src/lib.rs"),
+            store.display_path("src/lib.rs"),
             workspace_root.join("src/lib.rs").display().to_string()
         );
         assert_eq!(
@@ -8300,10 +8208,10 @@ mod tests {
 
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
-        let store = MountFs::wrap_if_needed(test_file_store(workspace.path(), session.path()));
+        let store = test_file_store(workspace.path(), session.path());
         let workspace_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
         let narration = narrate_list_directory(
-            &serde_json::json!({ "path": "/workspace/src" }),
+            &serde_json::json!({ "path": workspace_root.join("src") }),
             ToolNarrationPhase::Completed,
             None,
             ToolNarrationContext::new(Some(store.as_ref())),
@@ -8318,7 +8226,6 @@ mod tests {
 
     #[tokio::test]
     async fn yolop_file_store_routes_skill_scope_roots_outside_workspace() {
-        use crate::capabilities::skills::{GLOBAL_SKILLS_VFS, SYSTEM_SKILLS_VFS};
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
         let global = tempfile::tempdir().expect("global");
@@ -8340,32 +8247,32 @@ mod tests {
         .expect("store");
         let session_id = SessionId::from_seed(7);
 
-        // write_skill into the global scope lands in the global dir, not the workspace.
-        store
-            .write_file(
-                session_id,
-                &format!("{GLOBAL_SKILLS_VFS}/greeter/SKILL.md"),
-                "global skill",
-                "text",
-            )
-            .await
-            .expect("write global skill");
-        assert_eq!(
-            std::fs::read_to_string(global.path().join("greeter/SKILL.md")).expect("global skill"),
-            "global skill"
+        let global_skill = global.path().join("greeter/SKILL.md");
+        assert!(
+            store
+                .write_file(
+                    session_id,
+                    &global_skill.display().to_string(),
+                    "global skill",
+                    "text",
+                )
+                .await
+                .is_err()
         );
-        assert!(!workspace.path().join(".yolop").exists());
 
-        // A skill placed in the system dir is discoverable via the system VFS root.
+        // A skill placed in the system dir is discoverable through its physical root.
         std::fs::create_dir_all(system.path().join("joke")).unwrap();
         std::fs::write(system.path().join("joke/SKILL.md"), "system skill").unwrap();
         let listed = store
-            .list_directory(session_id, SYSTEM_SKILLS_VFS)
+            .list_directory(session_id, &system.path().display().to_string())
             .await
             .expect("list system skills");
         assert!(listed.iter().any(|e| e.is_directory && e.name == "joke"));
         let read = store
-            .read_file(session_id, &format!("{SYSTEM_SKILLS_VFS}/joke/SKILL.md"))
+            .read_file(
+                session_id,
+                &system.path().join("joke/SKILL.md").display().to_string(),
+            )
             .await
             .expect("read system skill")
             .expect("system skill exists");
@@ -8397,6 +8304,7 @@ mod tests {
             global: None,
             profile: None,
             system: Some(system.path().to_path_buf()),
+            environment: None,
         };
         let host = Arc::new(
             WorkspaceHost::new(
@@ -8415,7 +8323,7 @@ mod tests {
             )
             .expect("store"),
         );
-        let cap = ScopedSkillsCapability::new(skills_config(&dirs, false, &[]));
+        let cap = ScopedSkillsCapability::new(skills_config(&dirs, &[]));
         let tools = cap.tools();
         let list = tools
             .iter()
@@ -8432,7 +8340,7 @@ mod tests {
                     .expect("joke discovered");
                 assert_eq!(joke["scope"], "system");
                 // The reported path is a real host path under the system dir,
-                // not a VFS path — that is what `${SKILL_DIR}`/bash needs.
+                // which is what `${SKILL_DIR}` and bash need.
                 // Compare as paths so separators are platform-correct.
                 let path = joke["path"].as_str().unwrap();
                 assert_eq!(
@@ -8448,8 +8356,6 @@ mod tests {
     #[tokio::test]
     async fn herdr_skill_is_visible_from_the_ephemeral_environment_scope() {
         use crate::capabilities::herdr::HerdrCapability;
-        use crate::capabilities::skills::ENVIRONMENT_SKILLS_VFS;
-
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
         let session_id = SessionId::from_seed(81);
@@ -8460,10 +8366,15 @@ mod tests {
             )
             .expect("host"),
         );
+        let environment_dir = crate::capabilities::skills::materialize_environment_skill(
+            session.path(),
+            "herdr",
+            HerdrCapability::skill_content(true).expect("Herdr skill"),
+        )
+        .expect("materialize environment skill");
         let factory = CodingCliSessionFileSystemFactory {
             workspace: host,
             session_dir: session.path().to_path_buf(),
-            session_id,
             materializer: Arc::new(session_log::SessionMaterializer::new(
                 session.path().to_path_buf(),
                 None,
@@ -8471,7 +8382,7 @@ mod tests {
             skill_global: None,
             skill_profile: None,
             skill_system: None,
-            environment_skill: HerdrCapability::skill_content(true),
+            skill_environment: Some(environment_dir.clone()),
             extension_skills: Vec::new(),
         };
 
@@ -8480,7 +8391,7 @@ mod tests {
             .await
             .expect("session file system");
         let entries = store
-            .list_directory(session_id, ENVIRONMENT_SKILLS_VFS)
+            .list_directory(session_id, &environment_dir.display().to_string())
             .await
             .expect("list environment skills");
         assert!(
@@ -8491,7 +8402,7 @@ mod tests {
         let skill = store
             .read_file(
                 session_id,
-                &format!("{ENVIRONMENT_SKILLS_VFS}/herdr/SKILL.md"),
+                &environment_dir.join("herdr/SKILL.md").display().to_string(),
             )
             .await
             .expect("read environment skill")
@@ -8501,7 +8412,7 @@ mod tests {
             store
                 .write_file(
                     session_id,
-                    &format!("{ENVIRONMENT_SKILLS_VFS}/herdr/SKILL.md"),
+                    &environment_dir.join("herdr/SKILL.md").display().to_string(),
                     "changed",
                     "text",
                 )
@@ -8513,8 +8424,6 @@ mod tests {
 
     #[tokio::test]
     async fn extension_contributed_skill_is_visible_and_read_only() {
-        use crate::capabilities::skills::extension_skills_vfs;
-
         let workspace = tempfile::tempdir().expect("workspace");
         let session = tempfile::tempdir().expect("session");
         let ext = tempfile::tempdir().expect("extension");
@@ -8539,7 +8448,6 @@ mod tests {
         let factory = CodingCliSessionFileSystemFactory {
             workspace: host,
             session_dir: session.path().to_path_buf(),
-            session_id,
             materializer: Arc::new(session_log::SessionMaterializer::new(
                 session.path().to_path_buf(),
                 None,
@@ -8547,7 +8455,7 @@ mod tests {
             skill_global: None,
             skill_profile: None,
             skill_system: None,
-            environment_skill: None,
+            skill_environment: None,
             extension_skills: vec![("demo".to_string(), skills_dir.clone())],
         };
         let store = factory
@@ -8555,7 +8463,7 @@ mod tests {
             .await
             .expect("session file system");
 
-        let vfs = extension_skills_vfs("demo");
+        let vfs = skills_dir.display().to_string();
         let entries = store
             .list_directory(session_id, &vfs)
             .await
@@ -9163,7 +9071,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cold_start_prompt_composition_is_measured_by_component() {
         // Auto mode teaches the model to initialize its session worktree before mutation.
-        const BASELINE_PROMPT_BYTES: usize = 14_204;
+        // Skill scopes now advertise physical directories instead of synthetic roots.
+        const BASELINE_PROMPT_BYTES: usize = 14_273;
         // The tool baselines model what today's surface would cost undeferred,
         // so enabling a capability raises them by exactly that capability's
         // undeferred cost — otherwise the ratio guards below would read a


### PR DESCRIPTION
## What

- remove the `/workspace` repository alias and virtual skill mounts
- expose repository-relative and contained physical paths consistently across file tools, repo scanners, grep output, and ACP narration
- use physical directories for workspace, profile, global, system, extension, and generated environment skills
- materialize Herdr's environment skill beneath the session directory and keep non-workspace skill roots read-only through file capabilities

## Why

Yolop runs directly on the user's filesystem. A parallel virtual namespace made tool narration disagree with shell paths and required special handling in every host-backed capability.

## How

`CodingCliSessionFileStore` is now the direct filesystem boundary. It resolves repository files against the active physical worktree, registers physical skill directories as explicit read-only roots, and preserves physical display paths through policy decorators. Host scanners accept repository-relative paths or contained physical absolute paths and reject synthetic absolute aliases.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- focused filesystem, narration, grep, scanner, environment-skill, extension-skill, and read-only tests
- `cargo run -- --provider llmsim -p 'Read Cargo.toml and reply with only the package name.'`
- `python3 scripts/validate_okf.py knowledge --check-links`
- full workspace suite passes all change-related tests; the existing order-dependent `cold_start_prompt_composition_is_measured_by_component` ratio guard can fail when run after capability-registration tests, while passing in isolation

## Before / After

Before:

```text
Read /workspace/src/capabilities/config.rs
```

After:

```text
Read <physical-worktree>/src/capabilities/config.rs
```

The same physical path is now used by file tools, shell commands, grep results, and ACP narration.

## Risk

Medium. This intentionally removes compatibility for model-generated `/workspace/...` paths and changes resumed-session path expectations. Relative repository paths remain supported.

## Security

- **TM-FS:** reviewed traversal, symlink containment, and write policy. Repository-relative paths remain contained by the active worktree. Physical skill roots are registered explicitly and all mutation operations reject them.
- **TM-BASH:** no execution, timeout, or output-cap changes.
- **TM-LLM:** no key handling changes. Physical skill paths add only expected local directory names already available to file and shell tools.
- **TM-TOOL:** existing file capability policy decorators remain in place; no new capabilities.
- **TM-DEP:** no dependency changes.

## Knowledge

Updated `knowledge/specs/skills.md` and `knowledge/log.md` for physical skill directories, environment-skill materialization, read-only external roots, and removal of the `/workspace` alias.

## Follow-ups

- Fix the existing order-dependent cold-start schema ratio test separately; it passes in isolation and is unrelated to this filesystem change.

Produced by [yolop](https://everruns.com/yolop)
