### PR TITLE
fix(agent): harden ACP compaction and shell failures

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,15 @@
 # Knowledge Log
 
+## 2026-08-31, ACP failures stay bounded at their source
+
+- [Model-context checkpoints](specs/checkpointing.md): Codex native compaction
+  opens a process-wide fallback circuit after HTTP 404 or 405 instead of
+  retrying an unavailable endpoint for every reconstructed driver.
+- [ACP](specs/acp.md): tracing on the protocol stderr channel is plain text.
+- [Sandboxing](specs/sandboxing.md): direct attempts to signal Yolop's own PID
+  are rejected, while recognizable process-control and nested-agent shell
+  commands receive destructive approval classification in interactive clients.
+
 ## 2026-08-29, Skills and repository tools use physical paths
 
 - [Skills](specs/skills.md): every skill scope now points at a real directory.

--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -25,8 +25,9 @@ This is a promotion target for the same runtime that powers the TUI and
 
 `yolop --acp` turns the process into an ACP agent speaking **newline-delimited
 JSON-RPC 2.0** over stdin/stdout (one compact JSON object per line, no embedded
-newlines). Tracing still goes to stderr, so stdout stays a clean protocol
-channel.
+newlines). Tracing still goes to stderr as plain text without terminal color
+escapes, so stdout stays a clean protocol channel and clients can retain
+diagnostics without rendering ANSI control sequences.
 
 ACP protocol version: **1** (integer).
 

--- a/knowledge/specs/checkpointing.md
+++ b/knowledge/specs/checkpointing.md
@@ -144,6 +144,12 @@ therefore leave the live model view while remaining lossless and retrievable
 through `query_history`, with the active raw suffix retaining recent asks,
 decisions, edits, and validation.
 
+A provider endpoint that answers native compaction with HTTP 404 or 405 is
+unavailable for that Yolop process. The provider factory opens a circuit shared
+by subsequently constructed driver instances, logs the transition once, and
+returns to the ordinary fallback path. Transient failures remain errors and do
+not disable the capability.
+
 A durable model-context checkpoint may use an event boundary already persisted
 inside the currently open turn. That pending turn is the active head extension
 until completion, but the timeline rejects boundaries beyond the event log's

--- a/knowledge/specs/sandboxing.md
+++ b/knowledge/specs/sandboxing.md
@@ -23,6 +23,16 @@ Every shell entry point uses one shared `SandboxProvider` boundary:
 - the `/shell` command; and
 - the TUI `!shell` shortcut.
 
+The shared Bash boundary also rejects a process-control command that visibly
+targets the running Yolop PID. In clients with a hard tool-approval UI, shell
+commands that launch another coding-agent runtime or invoke process-control
+programs are classified as destructive and pause at the normal approval level.
+The classifier parses Bash command nodes, including common execution wrappers,
+so quoted documentation and search terms do not become actions. This is a
+guardrail against accidental commands, not process isolation: dynamically
+resolved or deliberately obscured signals still require a kernel, container,
+or VM boundary.
+
 A direct foreground `yolop extensions ...` invocation is a special typed host
 broker, not arbitrary shell execution. It passes the same shell approval policy
 first, then the host invokes its exact Yolop executable with anonymous pipes for
@@ -274,6 +284,9 @@ provider smoke.
 - the one-shot attached Yolop administration broker is a typed host boundary,
   not a sandbox escape available to arbitrary child processes;
 - LSP, MCP, and extension server processes are configured control-plane
-  processes and are not automatically moved into this shell sandbox; and
+  processes and are not automatically moved into this shell sandbox;
+- danger-full-access does not isolate process signals at the OS boundary. The
+  self-PID guard and destructive-command approval reduce accidental misuse but
+  do not contain hostile shell code; and
 - resource controls are the existing wall-clock/output limits, not yet cgroup
   or VM quotas.

--- a/src/capabilities/tool_approval.rs
+++ b/src/capabilities/tool_approval.rs
@@ -5,16 +5,20 @@
 //! configuration, so the upstream hook must receive a fresh config for every
 //! call instead of capturing the session-start value.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use everruns_builtins::tool_approval::ToolApprovalCapability as UpstreamToolApprovalCapability;
 use everruns_core::ToolContext;
 use everruns_core::tool_hooks::{PreToolUseDecision, PreToolUseHook};
 use everruns_core::{Capability, CapabilityStatus};
+use everruns_provider::typed_id::SessionId;
 use everruns_provider::{ToolCall, ToolDefinition};
 
+use crate::config::ApprovalMode;
 use crate::config::service::ConfigService;
+use crate::exec::shell_policy::requires_destructive_approval;
 
 pub(crate) use everruns_builtins::TOOL_APPROVAL_CAPABILITY_ID;
 pub(crate) use everruns_builtins::{ApprovalDecision, ToolApprover};
@@ -22,14 +26,18 @@ pub(crate) use everruns_builtins::{ApprovalDecision, ToolApprover};
 /// Delegates approval policy to everruns-core while resolving Yolop's live mode.
 pub struct ToolApprovalCapability {
     upstream: Arc<UpstreamToolApprovalCapability>,
+    approver: Arc<dyn ToolApprover>,
     config: Arc<dyn ConfigService>,
+    critical_remembered: Arc<Mutex<HashMap<(SessionId, String), bool>>>,
 }
 
 impl ToolApprovalCapability {
     pub fn new(approver: Arc<dyn ToolApprover>, config: Arc<dyn ConfigService>) -> Self {
         Self {
-            upstream: Arc::new(UpstreamToolApprovalCapability::new(approver)),
+            upstream: Arc::new(UpstreamToolApprovalCapability::new(approver.clone())),
+            approver,
             config,
+            critical_remembered: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -63,14 +71,28 @@ impl Capability for ToolApprovalCapability {
     fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn PreToolUseHook>> {
         vec![Arc::new(LiveApprovalHook {
             upstream: self.upstream.clone(),
+            approver: self.approver.clone(),
             config: self.config.clone(),
+            critical_remembered: self.critical_remembered.clone(),
         })]
     }
 }
 
 struct LiveApprovalHook {
     upstream: Arc<UpstreamToolApprovalCapability>,
+    approver: Arc<dyn ToolApprover>,
     config: Arc<dyn ConfigService>,
+    critical_remembered: Arc<Mutex<HashMap<(SessionId, String), bool>>>,
+}
+
+impl LiveApprovalHook {
+    fn block(tool_call: ToolCall, reason: &str) -> PreToolUseDecision {
+        PreToolUseDecision::Block {
+            reason: reason.to_string(),
+            user_message: Some(format!("Denied `{}`: {reason}.", tool_call.name)),
+            tool_call,
+        }
+    }
 }
 
 #[async_trait]
@@ -81,7 +103,54 @@ impl PreToolUseHook for LiveApprovalHook {
         tool_def: &ToolDefinition,
         context: &ToolContext,
     ) -> PreToolUseDecision {
-        let config = serde_json::json!({ "mode": self.config.approval_mode().as_str() });
+        let mode = self.config.approval_mode();
+        let critical_command = if tool_call.name == "bash" {
+            tool_call
+                .arguments
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+                .filter(|command| requires_destructive_approval(command))
+        } else {
+            None
+        };
+        if mode != ApprovalMode::Off
+            && let Some(command) = critical_command
+        {
+            let key = (context.session_id, command.to_string());
+            if let Some(&allowed) = self.critical_remembered.lock().unwrap().get(&key) {
+                return if allowed {
+                    PreToolUseDecision::Continue(tool_call)
+                } else {
+                    Self::block(tool_call, "this exact command was rejected earlier")
+                };
+            }
+
+            let mut effective_tool_def = tool_def.clone();
+            match &mut effective_tool_def {
+                ToolDefinition::Builtin(tool) => tool.hints.destructive = Some(true),
+                ToolDefinition::ClientSide(tool) => tool.hints.destructive = Some(true),
+            }
+            return match self
+                .approver
+                .approve(context.session_id, &tool_call, &effective_tool_def)
+                .await
+            {
+                ApprovalDecision::Allow => PreToolUseDecision::Continue(tool_call),
+                ApprovalDecision::AllowAlways => {
+                    self.critical_remembered.lock().unwrap().insert(key, true);
+                    PreToolUseDecision::Continue(tool_call)
+                }
+                ApprovalDecision::Reject => Self::block(tool_call, "rejected by user"),
+                ApprovalDecision::RejectAlways => {
+                    self.critical_remembered.lock().unwrap().insert(key, false);
+                    Self::block(tool_call, "rejected by user")
+                }
+                ApprovalDecision::Cancelled => Self::block(tool_call, "turn cancelled"),
+                ApprovalDecision::Unavailable => Self::block(tool_call, "approval UI unavailable"),
+            };
+        }
+
+        let config = serde_json::json!({ "mode": mode.as_str() });
         let hook = self
             .upstream
             .pre_tool_use_hooks_with_config(&config)
@@ -96,7 +165,6 @@ impl PreToolUseHook for LiveApprovalHook {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use everruns_provider::typed_id::SessionId;
     use everruns_provider::{BuiltinTool, ToolHints};
     use serde_json::json;
 
@@ -120,6 +188,23 @@ mod tests {
         }
     }
 
+    struct RememberingApprover {
+        asked: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ToolApprover for RememberingApprover {
+        async fn approve(
+            &self,
+            _session_id: SessionId,
+            _tool_call: &ToolCall,
+            _tool_def: &ToolDefinition,
+        ) -> ApprovalDecision {
+            self.asked.fetch_add(1, Ordering::Relaxed);
+            ApprovalDecision::AllowAlways
+        }
+    }
+
     fn destructive_tool() -> ToolDefinition {
         ToolDefinition::Builtin(BuiltinTool {
             name: "publish".to_string(),
@@ -140,6 +225,28 @@ mod tests {
             name: "publish".to_string(),
             arguments: json!({}),
         }
+    }
+
+    fn bash_call(id: &str, command: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: "bash".to_string(),
+            arguments: json!({ "command": command }),
+        }
+    }
+
+    fn bash_tool() -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: "bash".to_string(),
+            display_name: None,
+            description: String::new(),
+            parameters: json!({}),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: ToolHints::default(),
+            full_parameters: None,
+        })
     }
 
     #[tokio::test]
@@ -167,5 +274,71 @@ mod tests {
             PreToolUseDecision::Continue(_)
         ));
         assert_eq!(approver.asked.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn normal_mode_gates_process_control_and_nested_agent_commands() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings = Arc::new(SettingsStore::open(temp.path().join("settings.toml")));
+        let approver = Arc::new(RejectingApprover {
+            asked: AtomicUsize::new(0),
+        });
+        let capability = ToolApprovalCapability::new(approver.clone(), settings);
+        let hook = capability.pre_tool_use_hooks().pop().unwrap();
+        let context = ToolContext::new(SessionId::new());
+
+        for (index, command) in [
+            "kill 1234",
+            "pkill -f worker",
+            "codex exec --full-auto 'finish the task'",
+            "claude -p 'finish the task'",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            assert!(matches!(
+                hook.before_exec(
+                    bash_call(&format!("call-{index}"), command),
+                    &bash_tool(),
+                    &context
+                )
+                .await,
+                PreToolUseDecision::Block { .. }
+            ));
+        }
+        assert_eq!(approver.asked.load(Ordering::Relaxed), 4);
+
+        assert!(matches!(
+            hook.before_exec(bash_call("safe", "cargo test"), &bash_tool(), &context)
+                .await,
+            PreToolUseDecision::Continue(_)
+        ));
+        assert_eq!(approver.asked.load(Ordering::Relaxed), 4);
+    }
+
+    #[tokio::test]
+    async fn critical_approval_is_remembered_only_for_the_exact_command() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings = Arc::new(SettingsStore::open(temp.path().join("settings.toml")));
+        let approver = Arc::new(RememberingApprover {
+            asked: AtomicUsize::new(0),
+        });
+        let capability = ToolApprovalCapability::new(approver.clone(), settings);
+        let hook = capability.pre_tool_use_hooks().pop().unwrap();
+        let context = ToolContext::new(SessionId::new());
+
+        for (id, command) in [
+            ("first", "kill 1234"),
+            ("same", "kill 1234"),
+            ("different", "kill 5678"),
+        ] {
+            assert!(matches!(
+                hook.before_exec(bash_call(id, command), &bash_tool(), &context)
+                    .await,
+                PreToolUseDecision::Continue(_)
+            ));
+        }
+
+        assert_eq!(approver.asked.load(Ordering::Relaxed), 2);
     }
 }

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -23,6 +23,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 pub const CODEX_DRIVER_ID: &str = "openai-codex";
@@ -70,16 +71,28 @@ pub struct CodexChatDriver {
     tokens: Arc<tokio::sync::Mutex<CodexTokens>>,
     refresh_gate: Arc<tokio::sync::Mutex<()>>,
     auth_store: Option<Arc<dyn CodexAuthStore>>,
+    native_compaction_available: Arc<AtomicBool>,
 }
 
 pub fn register_driver(registry: &mut DriverRegistry, settings: Arc<SettingsStore>) {
+    register_driver_with_url(registry, settings, CODEX_RESPONSES_URL.to_string());
+}
+
+fn register_driver_with_url(
+    registry: &mut DriverRegistry,
+    settings: Arc<SettingsStore>,
+    responses_url: String,
+) {
     let auth_store: Arc<dyn CodexAuthStore> = settings;
     let refresh_gate = Arc::new(tokio::sync::Mutex::new(()));
+    let native_compaction_available = Arc::new(AtomicBool::new(true));
     registry.register_external(CODEX_DRIVER_ID, move |config| {
         Box::new(CodexChatDriver::from_config_with_refresh_gate(
             config,
             Some(auth_store.clone()),
             refresh_gate.clone(),
+            native_compaction_available.clone(),
+            responses_url.clone(),
         ))
     });
 }
@@ -93,6 +106,8 @@ impl CodexChatDriver {
         config: &DriverConfig,
         auth_store: Option<Arc<dyn CodexAuthStore>>,
         refresh_gate: Arc<tokio::sync::Mutex<()>>,
+        native_compaction_available: Arc<AtomicBool>,
+        responses_url: String,
     ) -> Self {
         let access_token = config
             .api_key
@@ -113,7 +128,7 @@ impl CodexChatDriver {
             .and_then(|auth| auth.email);
         Self {
             client: reqwest::Client::new(),
-            responses_url: CODEX_RESPONSES_URL.to_string(),
+            responses_url,
             tokens: Arc::new(tokio::sync::Mutex::new(CodexTokens {
                 access_token,
                 refresh_token,
@@ -123,6 +138,7 @@ impl CodexChatDriver {
             })),
             refresh_gate,
             auth_store,
+            native_compaction_available,
         }
     }
 
@@ -431,7 +447,7 @@ impl ChatDriver for CodexChatDriver {
     }
 
     fn supports_compact(&self) -> bool {
-        true
+        self.native_compaction_available.load(Ordering::Acquire)
     }
 
     fn effective_context_window(&self, model: &str) -> Option<usize> {
@@ -447,6 +463,9 @@ impl ChatDriver for CodexChatDriver {
         _endpoint: &ProviderEndpoint,
         request: CompactRequest,
     ) -> EverrunsResult<Option<CompactResponse>> {
+        if !self.supports_compact() {
+            return Ok(None);
+        }
         let tokens = self.token_snapshot().await?;
         let response = self
             .client
@@ -465,6 +484,21 @@ impl ChatDriver for CodexChatDriver {
 
         let status = response.status();
         if !status.is_success() {
+            if matches!(
+                status,
+                StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+            ) {
+                if self
+                    .native_compaction_available
+                    .swap(false, Ordering::AcqRel)
+                {
+                    tracing::warn!(
+                        %status,
+                        "Codex native compaction unavailable; using fallback compaction"
+                    );
+                }
+                return Ok(None);
+            }
             let body = response.text().await.unwrap_or_default();
             return Err(codex_response_error(
                 "compact API",
@@ -1288,6 +1322,7 @@ mod tests {
             })),
             refresh_gate: Arc::new(tokio::sync::Mutex::new(())),
             auth_store: None,
+            native_compaction_available: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -1360,6 +1395,13 @@ mod tests {
     }
 
     fn serve_one_json_response(response_body: &'static str) -> (String, mpsc::Receiver<String>) {
+        serve_one_response("200 OK", response_body)
+    }
+
+    fn serve_one_response(
+        status: &'static str,
+        response_body: &'static str,
+    ) -> (String, mpsc::Receiver<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock Codex server");
         let address = listener.local_addr().expect("mock server address");
         let (request_tx, request_rx) = mpsc::channel();
@@ -1394,7 +1436,7 @@ mod tests {
                 .expect("capture request");
 
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 response_body.len(),
                 response_body
             );
@@ -1493,6 +1535,101 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn compact_404_disables_native_compaction_for_the_driver() {
+        let (responses_url, request_rx) =
+            serve_one_response("404 Not Found", r#"{"detail":"Not Found"}"#);
+        let driver = test_driver(responses_url);
+        let request = CompactRequest {
+            model: "gpt-5.6".to_string(),
+            input: vec![everruns_provider::compact::CompactInputItem::Message {
+                role: "user".to_string(),
+                content: CompactContent::Text("compact me".to_string()),
+            }],
+            previous_response_id: None,
+            instructions: None,
+        };
+
+        assert!(ChatDriver::supports_compact(&driver));
+        assert!(
+            ChatDriver::compact(&driver, &ProviderEndpoint::default(), request.clone())
+                .await
+                .expect("404 should fall back instead of failing")
+                .is_none()
+        );
+        assert!(!ChatDriver::supports_compact(&driver));
+        assert!(
+            ChatDriver::compact(&driver, &ProviderEndpoint::default(), request)
+                .await
+                .expect("disabled native compaction should stay on fallback")
+                .is_none()
+        );
+        assert!(
+            request_rx
+                .recv()
+                .expect("captured request")
+                .starts_with("POST /responses/compact HTTP/1.1\r\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn compact_capability_circuit_is_shared_across_factory_drivers() {
+        use everruns_provider::driver_registry::ProviderConfig;
+
+        let temp = tempfile::tempdir().unwrap();
+        let settings = Arc::new(SettingsStore::open(temp.path().join("settings.toml")));
+        let (responses_url, _request_rx) =
+            serve_one_response("405 Method Not Allowed", r#"{"detail":"unsupported"}"#);
+        let mut registry = DriverRegistry::new();
+        register_driver_with_url(&mut registry, settings, responses_url);
+        let config = ProviderConfig::new(DriverId::external(CODEX_DRIVER_ID))
+            .with_api_key("test-access-token");
+
+        let first = registry.create_chat_driver(&config).expect("first driver");
+        assert!(first.supports_compact());
+        assert!(
+            first
+                .compact(
+                    &ProviderEndpoint::default(),
+                    CompactRequest {
+                        model: "gpt-5.6".to_string(),
+                        input: Vec::new(),
+                        previous_response_id: None,
+                        instructions: None,
+                    },
+                )
+                .await
+                .expect("405 should select fallback")
+                .is_none()
+        );
+
+        let second = registry.create_chat_driver(&config).expect("second driver");
+        assert!(!second.supports_compact());
+    }
+
+    #[tokio::test]
+    async fn transient_compact_failure_keeps_native_compaction_enabled() {
+        let (responses_url, _request_rx) =
+            serve_one_response("503 Service Unavailable", r#"{"error":"try later"}"#);
+        let driver = test_driver(responses_url);
+
+        let error = ChatDriver::compact(
+            &driver,
+            &ProviderEndpoint::default(),
+            CompactRequest {
+                model: "gpt-5.6".to_string(),
+                input: Vec::new(),
+                previous_response_id: None,
+                instructions: None,
+            },
+        )
+        .await
+        .expect_err("transient failures remain errors");
+
+        assert!(error.to_string().contains("503 Service Unavailable"));
+        assert!(ChatDriver::supports_compact(&driver));
+    }
+
+    #[tokio::test]
     async fn refresh_persists_rotated_tokens_to_store() {
         let store = MemoryAuthStore::default();
         store
@@ -1586,6 +1723,7 @@ mod tests {
             tokens: Arc::new(tokio::sync::Mutex::new(expired_tokens("refresh-once"))),
             refresh_gate: refresh_gate.clone(),
             auth_store: Some(auth_store.clone()),
+            native_compaction_available: Arc::new(AtomicBool::new(true)),
         };
         let first = make_driver();
         let second = make_driver();

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -241,12 +241,9 @@ impl ToolApprover for AcpToolApprover {
                 _ => ApprovalDecision::Reject,
             },
             Err(err) => {
-                // The client could not answer (no permission UI, or the
-                // connection is winding down). Fall back to allowing so a client
-                // without `session/request_permission` keeps working rather than
-                // having every mutating tool blocked; the soft-approval prompt
-                // still nudges the model.
-                tracing::warn!(%err, "acp: request_permission failed; allowing tool");
+                // The client could not answer or the connection is winding
+                // down. `Unavailable` makes the hard gate fail closed.
+                tracing::warn!(%err, "acp: request_permission failed; rejecting tool");
                 ApprovalDecision::Unavailable
             }
         }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod proc;
 pub mod sandbox;
+pub(crate) mod shell_policy;
 pub mod tools;
 pub mod workspace_host;
 pub mod worktree;

--- a/src/exec/shell_policy.rs
+++ b/src/exec/shell_policy.rs
@@ -1,0 +1,132 @@
+//! Static checks for shell actions that need stronger process safety.
+
+use std::path::Path;
+
+use tree_sitter::{Node, Parser};
+
+const PROCESS_CONTROL_PROGRAMS: &[&str] = &["kill", "killall", "pkill"];
+const DESTRUCTIVE_PROGRAMS: &[&str] = &[
+    "aider", "claude", "codex", "gemini", "kill", "killall", "pkill", "yolop",
+];
+const EXEC_WRAPPERS: &[&str] = &[
+    "command", "env", "exec", "find", "nice", "nohup", "sudo", "time", "xargs",
+];
+
+/// Process-control and nested agent commands are destructive shell actions.
+pub(crate) fn requires_destructive_approval(script: &str) -> bool {
+    any_command_matches(script, DESTRUCTIVE_PROGRAMS)
+}
+
+/// Refuse shell commands that visibly target the Yolop host process itself.
+///
+/// This is defense in depth for direct mistakes such as `kill <host-pid>`.
+/// Kernel or VM isolation remains the boundary against deliberately obscured
+/// signaling through scripts or dynamically discovered PIDs.
+pub(crate) fn command_can_signal_yolop(script: &str, yolop_pid: u32) -> bool {
+    let has_process_control = any_command_matches(script, PROCESS_CONTROL_PROGRAMS);
+    if !has_process_control {
+        return false;
+    }
+
+    script
+        .split(|character: char| !character.is_ascii_digit())
+        .any(|word| word.parse::<u32>().ok() == Some(yolop_pid))
+        || script.to_ascii_lowercase().contains("yolop")
+        || script
+            .split_ascii_whitespace()
+            .map(|word| word.trim_matches(|character: char| ";|&()".contains(character)))
+            .any(|word| matches!(word, "0" | "-1"))
+}
+
+fn any_command_matches(script: &str, programs: &[&str]) -> bool {
+    let mut parser = Parser::new();
+    if parser
+        .set_language(&tree_sitter_bash::LANGUAGE.into())
+        .is_err()
+    {
+        return false;
+    }
+    let Some(tree) = parser.parse(script, None) else {
+        return false;
+    };
+    let mut pending = vec![tree.root_node()];
+    while let Some(node) = pending.pop() {
+        if node.kind() == "command" && command_matches(&node, script, programs) {
+            return true;
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.named_children(&mut cursor));
+    }
+    false
+}
+
+fn command_matches(command: &Node<'_>, script: &str, programs: &[&str]) -> bool {
+    let Some(name) = command.child_by_field_name("name") else {
+        return false;
+    };
+    let Some(name) = plain_program(name, script) else {
+        return false;
+    };
+    if programs.contains(&name.as_str()) {
+        return true;
+    }
+    if !EXEC_WRAPPERS.contains(&name.as_str()) {
+        return false;
+    }
+
+    let mut cursor = command.walk();
+    command
+        .children_by_field_name("argument", &mut cursor)
+        .filter_map(|argument| plain_program(argument, script))
+        .any(|argument| programs.contains(&argument.as_str()))
+}
+
+fn plain_program(node: Node<'_>, script: &str) -> Option<String> {
+    if !matches!(node.kind(), "command_name" | "word") {
+        return None;
+    }
+    let word = node.utf8_text(script.as_bytes()).ok()?;
+    Path::new(word)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_ascii_lowercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_direct_and_wrapped_destructive_commands() {
+        for command in [
+            "kill 1234",
+            "cd /tmp && pkill -f worker",
+            "env codex exec --full-auto task",
+            "command claude -p task",
+            "xargs kill < pids",
+            "find . -exec kill {} +",
+            "codex exec --full-auto task",
+            "claude -p task",
+        ] {
+            assert!(
+                requires_destructive_approval(command),
+                "expected destructive: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_program_names_used_only_as_data() {
+        for command in [
+            "rg codex src",
+            "printf '%s' 'kill 1234'",
+            "cargo test codex",
+            "echo yolop",
+        ] {
+            assert!(
+                !requires_destructive_approval(command),
+                "expected ordinary command: {command}"
+            );
+        }
+    }
+}

--- a/src/exec/tools.rs
+++ b/src/exec/tools.rs
@@ -9,6 +9,7 @@
 
 use crate::config::{ApprovalPolicy, SandboxMode};
 use crate::exec::sandbox::SandboxProvider;
+use crate::exec::shell_policy::command_can_signal_yolop;
 use crate::exec::workspace_host::WorkspaceHost;
 use crate::sandbox_approval::{ApprovalGate, ApprovalRequest};
 use async_trait::async_trait;
@@ -308,6 +309,11 @@ impl BashTool {
         request_full_access: bool,
         justification: Option<&str>,
     ) -> Result<BashRunOutput, ToolExecutionResult> {
+        if command_can_signal_yolop(command, std::process::id()) {
+            return Err(ToolExecutionResult::tool_error(
+                "refusing to signal the running Yolop host process",
+            ));
+        }
         if sink.is_none()
             && self.control.is_some()
             && self.sandbox.mode() != SandboxMode::DangerFullAccess
@@ -813,6 +819,48 @@ mod tests {
         ] {
             assert!(!trusted_command(command), "expected untrusted: {command}");
         }
+    }
+
+    #[test]
+    fn shell_process_guard_detects_commands_that_can_signal_yolop() {
+        let pid = 95_236;
+        for command in [
+            "kill 77982 95236 2>/dev/null || true",
+            "kill -TERM 95236",
+            "pkill yolop",
+            "kill $(pgrep yolop)",
+            "kill -TERM 0",
+            "kill -- -1",
+        ] {
+            assert!(
+                command_can_signal_yolop(command, pid),
+                "expected guarded command: {command}"
+            );
+        }
+        for command in ["kill 77982", "echo 95236", "rg yolop src"] {
+            assert!(
+                !command_can_signal_yolop(command, pid),
+                "expected unrelated command: {command}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn bash_refuses_to_signal_the_running_yolop_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(Workspace::from_path(dir.path().to_path_buf()));
+
+        let result = tool
+            .execute(json!({
+                "command": format!("kill -TERM {}", std::process::id())
+            }))
+            .await;
+
+        assert!(matches!(
+            result,
+            ToolExecutionResult::ToolError(message)
+                if message.contains("refusing to signal the running Yolop host process")
+        ));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,7 +741,7 @@ async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> 
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("error")),
         )
-        .with_ansi(!interactive)
+        .with_ansi(trace_ansi_enabled(&cli))
         .with_writer(trace_writer(interactive))
         .init();
 
@@ -903,6 +903,10 @@ async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> 
 fn uses_interactive_renderer(cli: &Cli) -> bool {
     (cli.command.is_none() && cli.print.is_none() && !cli.acp)
         || matches!(cli.command.as_ref(), Some(Commands::TuikaGallery))
+}
+
+fn trace_ansi_enabled(cli: &Cli) -> bool {
+    !uses_interactive_renderer(cli) && !cli.acp
 }
 
 fn trace_writer(interactive: bool) -> BoxMakeWriter {
@@ -2338,11 +2342,15 @@ mod tests {
         let print = Cli::try_parse_from(["yolop", "--provider", "llmsim", "-p", "hi"])
             .expect("parse print mode");
         let command = Cli::try_parse_from(["yolop", "version"]).expect("parse command");
+        let acp = Cli::try_parse_from(["yolop", "--acp"]).expect("parse ACP");
 
         assert!(uses_interactive_renderer(&tui));
         assert!(uses_interactive_renderer(&gallery));
         assert!(!uses_interactive_renderer(&print));
         assert!(!uses_interactive_renderer(&command));
+        assert!(trace_ansi_enabled(&print));
+        assert!(trace_ansi_enabled(&command));
+        assert!(!trace_ansi_enabled(&acp));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,7 +22,7 @@
 mod support;
 
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -2688,6 +2688,8 @@ struct AcpHandshake {
     assistant_text: String,
     /// True if the process exited cleanly after stdin was closed.
     exited_cleanly: bool,
+    /// Process diagnostics captured from stderr.
+    stderr: String,
 }
 
 /// Spawn `yolop --acp <provider>` over real OS stdin/stdout pipes and drive the
@@ -2712,7 +2714,7 @@ fn run_acp_handshake(provider: &str, prompt_text: &str) -> AcpHandshake {
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("spawn yolop --acp");
 
@@ -2733,6 +2735,15 @@ fn run_acp_handshake(provider: &str, prompt_text: &str) -> AcpHandshake {
                 Err(_) => break,
             }
         }
+    });
+    let stderr = child.stderr.take().expect("acp stderr");
+    let stderr_reader = thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let mut stderr = stderr;
+        stderr
+            .read_to_end(&mut bytes)
+            .expect("read yolop --acp stderr");
+        String::from_utf8_lossy(&bytes).into_owned()
     });
 
     let send = |stdin: &mut std::process::ChildStdin, value: serde_json::Value| {
@@ -2818,6 +2829,7 @@ fn run_acp_handshake(provider: &str, prompt_text: &str) -> AcpHandshake {
     drop(stdin);
     let status = wait_for_process_exit(&mut child, Duration::from_secs(10));
     let _ = reader.join();
+    let stderr = stderr_reader.join().expect("join stderr reader");
 
     AcpHandshake {
         init,
@@ -2825,6 +2837,7 @@ fn run_acp_handshake(provider: &str, prompt_text: &str) -> AcpHandshake {
         prompt,
         assistant_text: assistant_text.into_inner(),
         exited_cleanly: status.map(|s| s.success()).unwrap_or(false),
+        stderr,
     }
 }
 
@@ -2855,6 +2868,11 @@ fn acp_stdio_handshake_smoke() {
     assert!(
         result.exited_cleanly,
         "yolop --acp should exit cleanly after stdin close"
+    );
+    assert!(
+        !result.stderr.contains('\x1b'),
+        "ACP stderr must be plain text: {:?}",
+        result.stderr
     );
 }
 


### PR DESCRIPTION
## What changed

- Fall back from Codex native compaction after the endpoint returns HTTP 404 or 405, with one process-wide circuit shared by reconstructed drivers.
- Keep transient compaction failures visible without disabling native compaction.
- Emit plain-text tracing on ACP stderr.
- Refuse Bash commands that visibly signal Yolop's own PID.
- Require destructive approval for recognizable process-control and nested coding-agent shell commands, scoped to the exact command when remembered.

## Why

An ACP session could repeatedly retry an unavailable native compaction endpoint, flood stderr with ANSI-formatted errors, and then terminate Yolop by running a shell command that included the host PID. These failure modes should remain bounded at their source.

## Before / After

Before:

- Every reconstructed Codex driver retried `/responses/compact` after a 404.
- ACP stderr included terminal escape sequences.
- `kill <yolop-pid>` reached the host shell.
- Nested coding-agent and process-control commands were ordinary Bash calls at the normal approval level.

After:

- A 404 or 405 selects fallback compaction once for the whole process. A 503 remains an error and leaves the capability enabled.
- A real ACP handshake captures escape-free stderr.
- The actual Bash execution seam rejects the running Yolop PID.
- Recognizable high-risk shell commands use the hard approval UI and remembered decisions apply only to the exact command in that session.

## Risk

- Medium.
- The shell classifier may require an extra approval for legitimate process-management or nested-agent commands. Approval mode `off` still bypasses that prompt, while the direct self-PID rejection remains non-bypassable.
- Providers that intentionally return 404 or 405 only temporarily will use fallback compaction until Yolop restarts.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated

## Knowledge

Updated ACP, model-context checkpointing, and sandboxing concepts, plus the knowledge log.

## Security

- TM-BASH: applies the self-PID rejection at the shared Bash execution boundary and parses Bash command nodes for higher-risk approval classification.
- TM-TOOL: reuses the existing hard approval interface, fails closed when unavailable, and scopes remembered decisions by session and exact command.
- TM-LLM: does not log provider response bodies when opening the 404/405 compaction circuit.
- TM-FS and TM-DEP: no filesystem authority or dependency changes.
- The classifier is a guardrail against accidental misuse. It is not kernel-level containment for deliberately obscured commands.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema -- --skip runtime::tests::cold_start_prompt_composition_is_measured_by_component`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `git diff --check`
- The skipped assertion also fails unchanged on `origin/main`: actual tool-definition bytes are 24,586 versus its 24,360 threshold. All other 1,315 unit tests and every integration suite pass.
- Local live-provider smoke was unavailable because this checkout has neither Doppler project configuration nor `OPENAI_API_KEY`; the CI live-provider smoke is authoritative.

## Follow-ups

- Add OS-level signal isolation separately. macOS can use Seatbelt same-sandbox signal rules; robust Linux containment needs PID namespaces or a VM/container provider. This is broader than the incident guardrail and changes danger-full-access semantics.
- Correct the pre-existing cold-start prompt-size threshold in a focused repository-health change.
