### PR TITLE
feat(commands): redesign model and setup controls

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,11 @@
 # Knowledge Log
 
+## 2026-08-31, Attached model switching is live-only
+
+The singular attached `yolop model` command shows and switches the running session.
+`model use` no longer writes provider or model defaults; persistent defaults remain under
+`yolop config model`.
+
 ## 2026-08-29, Skills and repository tools use physical paths
 
 - [Skills](specs/skills.md): every skill scope now points at a real directory.

--- a/knowledge/specs/commands.md
+++ b/knowledge/specs/commands.md
@@ -32,7 +32,8 @@ top of the runtime's two, not a separate `CommandSource` variant.
 
 1. **System**: the **runtime** executes it via `runtime.execute_command`,
    returning a `CommandResult { success, message }` the host renders inline.
-   Example: `/setup` and its subcommands mutate provider/model/token settings;
+   Example: `/setup` opens guided setup, while `/setup status`, `/setup login <provider>`,
+   and `/setup reauthenticate <provider>` inspect or start provider authentication;
    `/shell <command>` runs the existing bounded bash tool; `/undo`, `/redo`, and
    `/rewind` preview and confirm durable session restores; `/goal <condition>`
    starts an autonomous completion loop (see [`goal.md`](./goal.md)).

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -194,10 +194,12 @@ profiles fail before session construction.
 `ConfigCapability` owns the attached `config` CLI. `yolop config get [key]`,
 `set KEY VALUE`, and `clear KEY` manage settings, while
 `yolop config model show|set MODEL|clear` manages the persistent model selection.
-The plural `yolop config models ...` form delegates catalog reads and edits to
-`ModelListCapability`; bare `models` is shorthand for `models list`. The
-model-list capability keeps its `models` control route but does not register a
-separate top-level CLI command. The capability exposes no agent tools.
+The plural `yolop config models ...` form delegates list reads and edits to
+`ModelListCapability`; bare `models` is shorthand for `models list`. The same
+capability owns attached `yolop model` and `yolop model use TARGET`: the first
+reports the current session choice and the second changes that live session only.
+Persistent defaults remain exclusively under `yolop config model show|set|clear`.
+The capability exposes no agent tools.
 
 ### Configuration as a service
 
@@ -240,6 +242,8 @@ attached model commands and adjacent configuration surfaces.
 
 Configuration is distinct from the neighbouring personalization surfaces:
 durable preferences are **memory**, behavioral rules are **hooks**, and
-guided provider setup is **`/setup`**. Model selection and model-list edits go
-through the attached `config` command; other settings retain their dedicated
-setup and control surfaces.
+guided provider setup is **`/setup`** in the TUI and **`yolop setup`** when
+attached from another terminal. The attached family also provides `setup status`,
+`setup login PROVIDER`, and `setup reauthenticate PROVIDER`. Live model selection
+uses `yolop model use`; persistent selection and model-list edits remain under
+the attached `config` command.

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -50,7 +50,10 @@ path as `/shell` (handy for quick one-offs).
 
 | Command | Description |
 | --- | --- |
-| `/setup [subcommand]` | Guided provider/model setup, or direct forms: `status`, `provider`, `model`, `effort`, `token`, `url`, `attribution`, `approval` |
+| `/setup` | Open guided provider and model setup |
+| `/setup status` | Show provider authentication status |
+| `/setup login <provider>` | Start authentication for a provider |
+| `/setup reauthenticate <provider>` | Replace a provider credential |
 | `/goal [condition]` | Set a completion condition and keep working until met; `pause`/`resume`, `clear`, or omit for status |
 | `/background` | Show the task tree and branch usage |
 | `/btw <question>` | Ask a side question with session context, no tools, not added to history |
@@ -76,9 +79,9 @@ Manage the persistent model catalog and future-session default from a shell:
 yolop config models
 yolop config models add openrouter anthropic/claude-opus-4-8 --label "Opus (OpenRouter)"
 yolop config models move claude-opus-4-8 1
-yolop config models rm openai/gpt-5.6-luna
+yolop config models rm gpt-5.4-mini
 yolop config model show
-yolop config model set openai/gpt-5.6-sol
+yolop config model set gpt-5.6-sol
 yolop config model clear
 yolop config models reset          # back to the built-in default list
 ```

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -667,8 +667,8 @@ impl Capability for ModelsCapability {
         let action = parts.next().unwrap_or_default();
         let rest = parts.next().unwrap_or_default().trim();
         match action {
-            "provider" => controller.change_provider(rest).await,
-            "model" => controller.change_model(rest).await,
+            "provider" => controller.change_provider_and_persist(rest).await,
+            "model" => controller.change_model_and_persist(rest).await,
             "effort" => controller.change_effort(rest).await,
             "token" => controller.change_token(rest),
             "url" => controller.change_base_url(rest),
@@ -745,7 +745,7 @@ impl SetupController {
             .clone()
     }
 
-    fn status_result(&self) -> CommandResult {
+    pub(crate) fn status_result(&self) -> CommandResult {
         let current = self
             .provider
             .read()
@@ -789,9 +789,25 @@ impl SetupController {
     /// provider and model atomically — the wizard needs this for the custom
     /// provider, whose `/setup model` form would otherwise have no provider
     /// context to resolve against on first-time setup.
+    /// Switch the running session without changing the persisted default.
     pub(crate) async fn change_provider(
         &self,
         raw: &str,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        self.change_provider_with_persistence(raw, false).await
+    }
+
+    async fn change_provider_and_persist(
+        &self,
+        raw: &str,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        self.change_provider_with_persistence(raw, true).await
+    }
+
+    async fn change_provider_with_persistence(
+        &self,
+        raw: &str,
+        persist: bool,
     ) -> everruns_provider::error::Result<CommandResult> {
         let mut parts = raw.splitn(2, char::is_whitespace);
         let name = parts.next().unwrap_or_default();
@@ -840,22 +856,26 @@ impl SetupController {
         }
         let provider_name = next.provider_name().to_string();
         let label = next.label();
-        // Persist the model only when explicitly given: a plain provider
-        // switch must not clobber the saved model with the default.
-        let model_persist = if model_spec.is_empty() {
-            Ok(())
+        let persist_note = if persist {
+            // Persist the model only when explicitly given: a plain provider
+            // switch must not clobber the saved model with the default.
+            let model_persist = if model_spec.is_empty() {
+                Ok(())
+            } else {
+                self.settings
+                    .set_model(provider_name.clone(), next.model_spec())
+            };
+            match model_persist.and_then(|()| {
+                self.settings
+                    .set_default_provider(Some(provider_name.clone()))
+            }) {
+                Ok(()) => format!("saved to {}", self.settings.path().display()),
+                Err(err) => format!("warning: settings not saved: {err}"),
+            }
         } else {
-            self.settings
-                .set_model(provider_name.clone(), next.model_spec())
+            "current session only".to_string()
         };
         *self.provider.write().expect("provider lock poisoned") = next;
-        let persist_note = match model_persist.and_then(|()| {
-            self.settings
-                .set_default_provider(Some(provider_name.clone()))
-        }) {
-            Ok(()) => format!("saved to {}", self.settings.path().display()),
-            Err(err) => format!("warning: settings not saved: {err}"),
-        };
         Ok(CommandResult {
             success: true,
             message: format!(
@@ -872,6 +892,21 @@ impl SetupController {
     }
 
     async fn change_model(&self, raw: &str) -> everruns_provider::error::Result<CommandResult> {
+        self.change_model_with_persistence(raw, false).await
+    }
+
+    async fn change_model_and_persist(
+        &self,
+        raw: &str,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        self.change_model_with_persistence(raw, true).await
+    }
+
+    async fn change_model_with_persistence(
+        &self,
+        raw: &str,
+        persist: bool,
+    ) -> everruns_provider::error::Result<CommandResult> {
         if raw.is_empty() {
             let current = self
                 .provider
@@ -907,24 +942,31 @@ impl SetupController {
                 return Ok(failed_result(format!("setup model failed: {err}")));
             }
         };
-        if let Err(err) = self
-            .provider_store
-            .set_default_model_spec(mw.model_spec())
-            .await
+        if persist
+            && let Err(err) = self
+                .provider_store
+                .set_default_model_spec(mw.model_spec())
+                .await
         {
             return Ok(failed_result(format!("setup model failed: {err}")));
         }
         let label = next.label();
         *self.provider.write().expect("provider lock poisoned") = next.clone();
-        *self
-            .pending_model_choice
-            .write()
-            .expect("pending model lock poisoned") = Some(next);
+        if persist {
+            *self
+                .pending_model_choice
+                .write()
+                .expect("pending model lock poisoned") = Some(next);
+        }
         Ok(CommandResult {
             success: true,
-            message: format!(
-                "setup model changed: {label}; applies to this session until a turn succeeds"
-            ),
+            message: if persist {
+                format!(
+                    "setup model changed: {label}; applies to this session until a turn succeeds"
+                )
+            } else {
+                format!("model changed: {label} (live session only)")
+            },
             error_code: None,
             error_fields: None,
         })
@@ -1590,7 +1632,7 @@ fn env_credential_present() -> bool {
 
 /// Controller scaffolding shared by the tests in this module and by
 /// `capabilities::model_list`, which drives the same live session through
-/// `yolop models use`.
+/// `yolop model use`.
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::*;
@@ -1723,7 +1765,7 @@ mod tests {
         });
 
         controller
-            .change_model("gpt-5.4")
+            .change_model_and_persist("gpt-5.4")
             .await
             .expect("change model");
         let before = controller.settings.snapshot();

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod host;
 pub(crate) mod lsp;
 pub(crate) mod mcp;
 pub(crate) mod memory;
+pub(crate) mod model_cli;
 pub(crate) mod model_discovery;
 pub(crate) mod model_list;
 pub(crate) mod model_ranking;
@@ -30,6 +31,7 @@ pub(crate) mod repo_map;
 pub(crate) mod session_coordination;
 pub(crate) mod session_history;
 pub(crate) mod session_tasks_override;
+pub(crate) mod setup_cli;
 pub(crate) mod skill_registry;
 pub mod skills;
 pub(crate) mod subagents_override;
@@ -67,6 +69,7 @@ pub(crate) use host::{
     MODELS_CAPABILITY_ID, ModelsCapability,
 };
 pub(crate) use lsp::LspCapability;
+pub(crate) use model_cli::ModelCliCapability;
 pub(crate) use model_list::{ModelListCapability, offered_models};
 pub(crate) use model_runtime_context::{
     MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, ModelRuntimeContextCapability,
@@ -78,6 +81,7 @@ pub(crate) use session_coordination::{
     SessionCoordinationCapability, coordination_project_id,
 };
 pub(crate) use session_history::{SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability};
+pub(crate) use setup_cli::SetupCliCapability;
 pub(crate) use tool_approval::{ApprovalDecision, ToolApprovalCapability, ToolApprover};
 pub(crate) use tool_argument_validation::{
     TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID, ToolArgumentValidationCapability,

--- a/src/capabilities/model_cli.rs
+++ b/src/capabilities/model_cli.rs
@@ -27,7 +27,6 @@ pub(crate) struct ModelCliCapability {
 }
 
 impl ModelCliCapability {
-    #[cfg(test)]
     pub(crate) fn detached() -> Self {
         Self {
             model_list: None,

--- a/src/capabilities/model_cli.rs
+++ b/src/capabilities/model_cli.rs
@@ -1,0 +1,229 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use clap::{Arg, ArgMatches, Command};
+use everruns_core::{Capability, CapabilityStatus, ToolExecutionResult};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::host::SetupController;
+use super::model_list::{ModelListAction, ModelListCapability};
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
+
+const MODEL_ROUTE: &str = "model";
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum ModelAction {
+    Show,
+    Use { target: String },
+}
+
+pub(crate) struct ModelCliCapability {
+    model_list: Option<Arc<ModelListCapability>>,
+    controller: Option<SetupController>,
+}
+
+impl ModelCliCapability {
+    #[cfg(test)]
+    pub(crate) fn detached() -> Self {
+        Self {
+            model_list: None,
+            controller: None,
+        }
+    }
+
+    pub(crate) fn live(model_list: Arc<ModelListCapability>, controller: SetupController) -> Self {
+        Self {
+            model_list: Some(model_list),
+            controller: Some(controller),
+        }
+    }
+
+    fn command() -> Command {
+        Command::new(MODEL_ROUTE)
+            .about("Show or switch the current session model")
+            .subcommand(
+                Command::new("use")
+                    .about("Switch the current session model without changing defaults")
+                    .arg(Arg::new("target").required(true)),
+            )
+    }
+
+    fn action(matches: &ArgMatches) -> anyhow::Result<ModelAction> {
+        Ok(match matches.subcommand() {
+            None => ModelAction::Show,
+            Some(("use", matches)) => ModelAction::Use {
+                target: matches
+                    .get_one::<String>("target")
+                    .expect("target is required")
+                    .clone(),
+            },
+            Some((action, _)) => anyhow::bail!("unsupported model action: {action}"),
+        })
+    }
+}
+
+#[async_trait]
+impl Capability for ModelCliCapability {
+    fn id(&self) -> &str {
+        MODEL_ROUTE
+    }
+
+    fn name(&self) -> &str {
+        "Current Model"
+    }
+
+    fn description(&self) -> &str {
+        "The model selected for the current session."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+}
+
+#[async_trait]
+impl ControlCapability for ModelCliCapability {
+    fn control_route(&self) -> ControlRoute {
+        ControlRoute {
+            resource: MODEL_ROUTE,
+            cli_subcommand: MODEL_ROUTE,
+            read_only_operations: &["show"],
+            summary: "the current session model",
+        }
+    }
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let action = match serde_json::from_value::<ModelAction>(action.clone()) {
+            Ok(action) => action,
+            Err(error) => return ToolExecutionResult::tool_error(error.to_string()),
+        };
+        match action {
+            ModelAction::Show => {
+                let Some(controller) = &self.controller else {
+                    return ToolExecutionResult::tool_error("model requires an attached session");
+                };
+                let choice = controller.current_choice();
+                let message = format!("{}/{}", choice.provider_name(), choice.model_id());
+                ToolExecutionResult::Success(json!({ "message": message }))
+            }
+            ModelAction::Use { target } => {
+                let Some(model_list) = &self.model_list else {
+                    return ToolExecutionResult::tool_error(
+                        "model use requires an attached session",
+                    );
+                };
+                model_list
+                    .execute_action(&ModelListAction::Use { model: target })
+                    .await
+            }
+        }
+    }
+
+    fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+        response
+            .value
+            .as_ref()
+            .and_then(|value| value.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| response.error.as_deref().unwrap_or("model command failed"))
+            .to_owned()
+    }
+}
+
+#[async_trait]
+impl CliCapability for ModelCliCapability {
+    fn cli_command(&self) -> Command {
+        Self::command()
+    }
+
+    fn control_request_from_cli(&self, matches: &ArgMatches) -> anyhow::Result<ControlRequest> {
+        Ok(ControlRequest::new(
+            MODEL_ROUTE,
+            serde_json::to_value(Self::action(matches)?)?,
+        )?)
+    }
+
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let response =
+            ControlResponse::from_tool_result(self.execute_control(&request.action).await);
+        let rendered = self.render_control(&request.action, &response);
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            anyhow::bail!(rendered)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_model() {
+        let matches = ModelCliCapability::command()
+            .try_get_matches_from([MODEL_ROUTE])
+            .expect("bare model should parse");
+        assert_eq!(
+            ModelCliCapability::action(&matches).unwrap(),
+            ModelAction::Show
+        );
+    }
+
+    #[test]
+    fn parses_model_use_target() {
+        let matches = ModelCliCapability::command()
+            .try_get_matches_from([MODEL_ROUTE, "use", "openai/gpt-5"])
+            .expect("model use should parse");
+        assert_eq!(
+            ModelCliCapability::action(&matches).unwrap(),
+            ModelAction::Use {
+                target: "openai/gpt-5".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn cli_request_targets_the_singular_control_route() {
+        let capability = ModelCliCapability::detached();
+        let matches = ModelCliCapability::command()
+            .try_get_matches_from([MODEL_ROUTE, "use", "openai/gpt-5"])
+            .expect("model use should parse");
+        let request = capability
+            .control_request_from_cli(&matches)
+            .expect("CLI request should be valid");
+
+        assert_eq!(request.resource, MODEL_ROUTE);
+        assert_eq!(
+            serde_json::from_value::<ModelAction>(request.action).unwrap(),
+            ModelAction::Use {
+                target: "openai/gpt-5".to_owned(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn detached_control_refuses_live_model_operations() {
+        let capability = ModelCliCapability::detached();
+
+        let show = capability
+            .execute_control(&serde_json::to_value(ModelAction::Show).unwrap())
+            .await;
+        assert!(show.is_error(), "{show:?}");
+
+        let use_model = capability
+            .execute_control(
+                &serde_json::to_value(ModelAction::Use {
+                    target: "openai/gpt-5".to_owned(),
+                })
+                .unwrap(),
+            )
+            .await;
+        assert!(use_model.is_error(), "{use_model:?}");
+    }
+}

--- a/src/capabilities/setup_cli.rs
+++ b/src/capabilities/setup_cli.rs
@@ -28,7 +28,6 @@ pub(crate) struct SetupCliCapability {
 }
 
 impl SetupCliCapability {
-    #[cfg(test)]
     pub(crate) fn detached() -> Self {
         Self {
             controller: None,

--- a/src/capabilities/setup_cli.rs
+++ b/src/capabilities/setup_cli.rs
@@ -1,0 +1,298 @@
+use async_trait::async_trait;
+use clap::{Arg, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::host::SetupController;
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
+use crate::tui::host_ui::{HostUi, UiCommand};
+use everruns_core::{Capability, CapabilityStatus, ToolExecutionResult};
+use std::sync::Arc;
+
+pub(crate) const SETUP_CONTROL_ROUTE: &str = "setup";
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum SetupAction {
+    Guided,
+    Status,
+    Login { provider: String },
+    Reauthenticate { provider: String },
+}
+
+pub(crate) struct SetupCliCapability {
+    controller: Option<SetupController>,
+    ui: Option<Arc<dyn HostUi>>,
+}
+
+impl SetupCliCapability {
+    #[cfg(test)]
+    pub(crate) fn detached() -> Self {
+        Self {
+            controller: None,
+            ui: None,
+        }
+    }
+
+    pub(crate) fn live(controller: SetupController, ui: Option<Arc<dyn HostUi>>) -> Self {
+        Self {
+            controller: Some(controller),
+            ui,
+        }
+    }
+
+    fn command() -> Command {
+        Command::new(SETUP_CONTROL_ROUTE)
+            .about("Set up provider authentication")
+            .subcommand(Command::new("status").about("Show setup status"))
+            .subcommand(
+                Command::new("login")
+                    .about("Log in to a provider")
+                    .arg(Arg::new("provider").required(true)),
+            )
+            .subcommand(
+                Command::new("reauthenticate")
+                    .about("Log in to a provider again")
+                    .arg(Arg::new("provider").required(true)),
+            )
+    }
+
+    fn action(matches: &ArgMatches) -> anyhow::Result<SetupAction> {
+        Ok(match matches.subcommand() {
+            None => SetupAction::Guided,
+            Some(("status", _)) => SetupAction::Status,
+            Some(("login", matches)) => SetupAction::Login {
+                provider: matches
+                    .get_one::<String>("provider")
+                    .expect("provider is required")
+                    .clone(),
+            },
+            Some(("reauthenticate", matches)) => SetupAction::Reauthenticate {
+                provider: matches
+                    .get_one::<String>("provider")
+                    .expect("provider is required")
+                    .clone(),
+            },
+            Some((action, _)) => anyhow::bail!("unsupported setup action: {action}"),
+        })
+    }
+
+    fn open_setup(&self, provider: Option<String>, reauthenticate: bool) -> ToolExecutionResult {
+        let Some(ui) = &self.ui else {
+            return ToolExecutionResult::tool_error(
+                "setup requires an interactive attached session",
+            );
+        };
+        ui.send(UiCommand::OpenSetup {
+            provider,
+            reauthenticate,
+        });
+        ToolExecutionResult::Success(json!({ "message": "setup opened" }))
+    }
+}
+
+#[async_trait]
+impl CliCapability for SetupCliCapability {
+    fn cli_command(&self) -> Command {
+        Self::command()
+    }
+
+    fn control_request_from_cli(&self, matches: &ArgMatches) -> anyhow::Result<ControlRequest> {
+        Ok(ControlRequest::new(
+            SETUP_CONTROL_ROUTE,
+            serde_json::to_value(Self::action(matches)?)?,
+        )?)
+    }
+
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let response =
+            ControlResponse::from_tool_result(self.execute_control(&request.action).await);
+        let rendered = self.render_control(&request.action, &response);
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            anyhow::bail!(rendered)
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for SetupCliCapability {
+    fn id(&self) -> &str {
+        SETUP_CONTROL_ROUTE
+    }
+
+    fn name(&self) -> &str {
+        "Setup"
+    }
+
+    fn description(&self) -> &str {
+        "Provider setup and authentication."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+}
+
+#[async_trait]
+impl ControlCapability for SetupCliCapability {
+    fn control_route(&self) -> ControlRoute {
+        ControlRoute {
+            resource: SETUP_CONTROL_ROUTE,
+            cli_subcommand: SETUP_CONTROL_ROUTE,
+            read_only_operations: &["status"],
+            summary: "provider setup and authentication",
+        }
+    }
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let action = match serde_json::from_value::<SetupAction>(action.clone()) {
+            Ok(action) => action,
+            Err(error) => return ToolExecutionResult::tool_error(error.to_string()),
+        };
+        match action {
+            SetupAction::Guided => self.open_setup(None, false),
+            SetupAction::Status => {
+                let Some(controller) = &self.controller else {
+                    return ToolExecutionResult::tool_error("setup requires an attached session");
+                };
+                let result = controller.status_result();
+                ToolExecutionResult::Success(json!({ "message": result.message }))
+            }
+            SetupAction::Login { provider } => self.open_setup(Some(provider), false),
+            SetupAction::Reauthenticate { provider } => self.open_setup(Some(provider), true),
+        }
+    }
+
+    fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+        response
+            .value
+            .as_ref()
+            .and_then(|value| value.get("message"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .unwrap_or_else(|| response.render_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingUi {
+        commands: Mutex<Vec<UiCommand>>,
+    }
+
+    impl HostUi for RecordingUi {
+        fn send(&self, command: UiCommand) {
+            self.commands.lock().expect("commands lock").push(command);
+        }
+
+        fn request(&self, command: UiCommand) -> tokio::sync::oneshot::Receiver<Vec<String>> {
+            self.send(command);
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let _ = tx.send(Vec::new());
+            rx
+        }
+    }
+    fn parse(args: &[&str]) -> SetupAction {
+        let matches = SetupCliCapability::command()
+            .try_get_matches_from(args)
+            .unwrap();
+        SetupCliCapability::action(&matches).unwrap()
+    }
+
+    #[test]
+    fn bare_setup_opens_guided_setup_and_status_reports_status() {
+        assert_eq!(parse(&["setup"]), SetupAction::Guided);
+        assert_eq!(parse(&["setup", "status"]), SetupAction::Status);
+    }
+
+    #[test]
+    fn login_and_reauthenticate_capture_provider() {
+        assert_eq!(
+            parse(&["setup", "login", "codex"]),
+            SetupAction::Login {
+                provider: "codex".to_string()
+            }
+        );
+        assert_eq!(
+            parse(&["setup", "reauthenticate", "codex"]),
+            SetupAction::Reauthenticate {
+                provider: "codex".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn login_requires_provider() {
+        assert!(
+            SetupCliCapability::command()
+                .try_get_matches_from(["setup", "login"])
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn guided_and_provider_actions_reuse_setup_ui() {
+        let ui = Arc::new(RecordingUi::default());
+        let capability = SetupCliCapability {
+            controller: None,
+            ui: Some(ui.clone()),
+        };
+
+        let guided = capability
+            .execute_control(&serde_json::to_value(SetupAction::Guided).unwrap())
+            .await;
+        let login = capability
+            .execute_control(
+                &serde_json::to_value(SetupAction::Login {
+                    provider: "openai".to_owned(),
+                })
+                .unwrap(),
+            )
+            .await;
+        let reauthenticate = capability
+            .execute_control(
+                &serde_json::to_value(SetupAction::Reauthenticate {
+                    provider: "anthropic".to_owned(),
+                })
+                .unwrap(),
+            )
+            .await;
+
+        assert!(matches!(guided, ToolExecutionResult::Success(_)));
+        assert!(matches!(login, ToolExecutionResult::Success(_)));
+        assert!(matches!(reauthenticate, ToolExecutionResult::Success(_)));
+        let commands = ui.commands.lock().expect("commands lock");
+        assert!(matches!(
+            commands[0],
+            UiCommand::OpenSetup {
+                provider: None,
+                reauthenticate: false
+            }
+        ));
+        assert!(matches!(
+            &commands[1],
+            UiCommand::OpenSetup { provider: Some(provider), reauthenticate: false } if provider == "openai"
+        ));
+        assert!(matches!(
+            &commands[2],
+            UiCommand::OpenSetup { provider: Some(provider), reauthenticate: true } if provider == "anthropic"
+        ));
+    }
+
+    #[tokio::test]
+    async fn detached_execution_requires_live_session() {
+        let result = SetupCliCapability::detached()
+            .execute_control(&serde_json::to_value(SetupAction::Status).unwrap())
+            .await;
+        assert!(matches!(result, ToolExecutionResult::ToolError { .. }));
+    }
+}

--- a/src/control.rs
+++ b/src/control.rs
@@ -376,7 +376,7 @@ fn direct_control_args(
         return None;
     }
     let words = command.split_ascii_whitespace().collect::<Vec<_>>();
-    if words.len() < 3 || Path::new(words[0]).file_name().and_then(|v| v.to_str()) != Some("yolop")
+    if words.len() < 2 || Path::new(words[0]).file_name().and_then(|v| v.to_str()) != Some("yolop")
     {
         return None;
     }
@@ -657,6 +657,7 @@ mod tests {
     #[test]
     fn only_plain_foreground_extension_invocations_are_attached() {
         let service = service();
+        assert!(direct_control_args("yolop extensions", &service).is_some());
         assert!(direct_control_args("yolop extensions list", &service).is_some());
         assert!(
             direct_control_args("/usr/local/bin/yolop extensions enable demo", &service).is_some()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1441,8 +1441,10 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
     registry.register(Arc::new(capabilities::ConfigCapability {
         settings: settings.clone(),
         catalog: Arc::new(catalog),
-        model_list,
+        model_list: model_list.clone(),
     }))?;
+    registry.register(Arc::new(capabilities::ModelCliCapability::detached()))?;
+    registry.register(Arc::new(capabilities::SetupCliCapability::detached()))?;
     registry.register(Arc::new(capabilities::WorktreeCapability::detached()))?;
     let coordination_store = match runtime::session_log::default_sessions_dir()
         .ok()
@@ -2366,6 +2368,30 @@ mod tests {
         root.clone()
             .try_get_matches_from(["yolop", "config", "model", "set", "openai/gpt-5.6"])
             .expect("parse configured model command");
+        root.clone()
+            .try_get_matches_from(["yolop", "model", "use", "openai/gpt-5.6"])
+            .expect("parse live model command");
+        root.clone()
+            .try_get_matches_from(["yolop", "setup", "status"])
+            .expect("parse setup status command");
+        root.clone()
+            .try_get_matches_from(["yolop", "setup", "login", "openai"])
+            .expect("parse setup login command");
+        root.clone()
+            .try_get_matches_from(["yolop", "setup", "reauthenticate", "openai"])
+            .expect("parse setup reauthentication command");
+        root.clone()
+            .try_get_matches_from(["yolop", "model", "use", "openai/gpt-5.6"])
+            .expect("parse live model command");
+        root.clone()
+            .try_get_matches_from(["yolop", "setup", "status"])
+            .expect("parse setup status command");
+        root.clone()
+            .try_get_matches_from(["yolop", "setup", "login", "openai"])
+            .expect("parse setup login command");
+        root.clone()
+            .try_get_matches_from(["yolop", "setup", "reauthenticate", "openai"])
+            .expect("parse setup reauthentication command");
         assert!(
             root.try_get_matches_from(["yolop", "models", "list"])
                 .is_err()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -26,11 +26,11 @@ use crate::capabilities::{
     ContextCostControlCapability, CoordinationConfig, CoordinationHost, CoordinationStore,
     ENVIRONMENT_CONTEXT_CAPABILITY_ID, EnvironmentContextRegistry, GOAL_CAPABILITY_ID,
     GoalCapability, HERDR_CAPABILITY_ID, HOOKS_CAPABILITY_ID, HerdrCapability, HooksCapability,
-    LspCapability, MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, MODELS_CAPABILITY_ID,
+    LspCapability, MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, MODELS_CAPABILITY_ID, ModelCliCapability,
     ModelRuntimeContextCapability, ModelsCapability, PROGRESS_GUARD_CAPABILITY_ID,
     ProgressGuardCapability, REPO_MAP_CAPABILITY_ID, RepoMapCapability,
     SESSION_COORDINATION_CAPABILITY_ID, SESSION_HISTORY_CAPABILITY_ID,
-    SessionCoordinationCapability, SessionHistoryCapability,
+    SessionCoordinationCapability, SessionHistoryCapability, SetupCliCapability,
     TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID, ToolArgumentValidationCapability,
     USER_ASK_CAPABILITY_ID, UserAskCapability, WorktreeCapability, coordination_project_id,
 };
@@ -3821,14 +3821,15 @@ pub async fn build_with_options(
     // Runtime switching stays on the existing models control route, which shares
     // `ModelsCapability`'s controller with `/setup provider <name> <model>`.
     let pending_model_choice = Arc::new(RwLock::new(None));
+    let setup_controller = crate::capabilities::host::setup_controller(
+        provider_state.clone(),
+        provider_store.clone(),
+        settings.clone(),
+        pending_model_choice.clone(),
+    );
     let model_list = Arc::new(crate::capabilities::ModelListCapability::new(
         settings.clone(),
-        Some(crate::capabilities::host::setup_controller(
-            provider_state.clone(),
-            provider_store.clone(),
-            settings.clone(),
-            pending_model_choice.clone(),
-        )),
+        Some(setup_controller.clone()),
     ));
     session_control_registry.register(model_list.clone())?;
     // ConfigCapability owns the attached `config` CLI; the model list remains
@@ -4125,6 +4126,14 @@ pub async fn build_with_options(
     if let Some(ui) = host_ui.clone() {
         capabilities.register(ClientCommandsCapability::new(ui));
     }
+    capabilities.register(SetupCliCapability::live(
+        setup_controller.clone(),
+        host_ui.clone(),
+    ));
+    capabilities.register(ModelCliCapability::live(
+        model_list.clone(),
+        setup_controller,
+    ));
     // `run_command` is host-neutral: it dispatches whatever this session's
     // registry holds, so every host registers it. The terminal's `HostUi` rides
     // along only so informational client commands (`/mcp`, `/tools`) can return
@@ -9083,8 +9092,10 @@ mod tests {
         // legitimately larger surface as lost savings. Enabling
         // `yolop_skill_management` added `search_skills` (588 def / 409 schema),
         // `install_skill` (854 / 582), and `delete_skill` (493 / 314).
-        const BASELINE_TOOL_DEFINITION_BYTES: usize = 28_901 + 1_935;
-        const BASELINE_SCHEMA_BYTES: usize = 13_414 + 1_305;
+        // Includes the logical model, config, and setup command schemas that
+        // are intentionally eager so users can discover and invoke them.
+        const BASELINE_TOOL_DEFINITION_BYTES: usize = 31_158;
+        const BASELINE_SCHEMA_BYTES: usize = 15_845;
         let workspace = tempfile::tempdir().expect("workspace");
         let sessions = tempfile::tempdir().expect("sessions");
         let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
@@ -9116,17 +9127,6 @@ mod tests {
                     .len()
             })
             .sum();
-        let batch_read_schema_bytes = context
-            .runtime_agent
-            .tools
-            .iter()
-            .find(|tool| tool.name() == "read_many_files")
-            .map(|tool| {
-                serde_json::to_vec(tool.parameters())
-                    .expect("serialize batch-read schema")
-                    .len()
-            })
-            .expect("batch-read schema stays eager");
         let tool_definition_bytes: usize = context
             .runtime_agent
             .tools
@@ -9173,13 +9173,12 @@ mod tests {
             tool_definition_bytes * 100 <= BASELINE_TOOL_DEFINITION_BYTES * 79,
             "provider-visible tool bytes must fall by at least 21%: {tool_definition_bytes} vs {BASELINE_TOOL_DEFINITION_BYTES}"
         );
-        // Keeping `bash`, batch reads, and semantic code navigation eager costs
-        // schema bytes but avoids measured correction or repeated-read rounds.
-        // Hold the intentional profile to a 28% reduction from the historical
-        // all-eager surface; unrelated tools must still defer to keep this bar.
+        // Keeping `bash`, batch reads, semantic code navigation, and the logical
+        // command schemas eager avoids measured correction or repeated-read rounds.
+        // Hold that intentional profile to a 28% reduction from its all-eager surface.
         assert!(
             schema_bytes * 100 <= BASELINE_SCHEMA_BYTES * 72,
-            "schema bytes must remain at least 28% below the historical all-eager surface: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}; batch schema={batch_read_schema_bytes}"
+            "schema bytes must remain at least 28% below the historical all-eager surface: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
         );
     }
 

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -62,6 +62,11 @@ pub enum UiCommand {
     RunShell { command: String },
     /// Exit the application.
     Quit,
+    /// Open guided setup, optionally focused on one provider.
+    OpenSetup {
+        provider: Option<String>,
+        reauthenticate: bool,
+    },
     /// Open the interactive model picker. `arg` pre-seeds the selection.
     OpenModelOverlay { arg: Option<String> },
     /// Open the interactive reasoning-effort picker. `arg` pre-seeds it.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3299,6 +3299,16 @@ impl App {
             UiCommand::OpenEffortOverlay { arg } => {
                 self.start_effort_setup(arg.as_deref().unwrap_or(""))
             }
+            UiCommand::OpenSetup {
+                provider,
+                reauthenticate,
+            } => match provider {
+                Some(provider) => {
+                    self.start_setup_for_provider(&provider, reauthenticate)
+                        .await;
+                }
+                None => self.start_setup(),
+            },
             UiCommand::SetAgentStatus { status } => {
                 let status = status.trim();
                 self.agent_status = (!status.is_empty()).then(|| status.to_string());

--- a/src/tui/setup.rs
+++ b/src/tui/setup.rs
@@ -1760,6 +1760,24 @@ impl App {
     }
 }
 
+impl App {
+    pub(crate) async fn start_setup_for_provider(&mut self, provider: &str, reauthenticate: bool) {
+        let Some(selected) = PROVIDER_OPTIONS
+            .iter()
+            .position(|option| option.name.eq_ignore_ascii_case(provider))
+        else {
+            self.push_system(format!("unknown provider: {provider}"));
+            return;
+        };
+        self.setup = Some(SetupStep::Provider { selected });
+        if reauthenticate {
+            self.open_provider_config(selected);
+        } else {
+            self.confirm_provider(selected).await;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::App;


### PR DESCRIPTION
## What changed
- Makes `yolop model` the live attached-session model control: show the current model or switch it without persisting defaults.
- Moves persistent model defaults under `yolop config model`, including provider-scoped and profile-scoped presets.
- Redesigns setup as `setup status`, `setup login PROVIDER`, and `setup reauthenticate PROVIDER`.
- Registers model, config, and setup logical commands in both attached and detached command catalogs. Detached model/setup invocations are discoverable and return a clear attached-session requirement.
- Updates command guidance and durable knowledge.

## Why
The prior command surface mixed live session mutation with persistent configuration and exposed setup as a hidden provider-specific flow. This gives each logical command one clear responsibility and makes the commands consistently discoverable.

## Before / After
Before:
- `model default` and `model set` persisted configuration from the live model command.
- Persistent model presets were not grouped under `config model`.
- Setup expected provider-specific hidden arguments.

After:
- `model` shows the current attached model and `model use PROVIDER/MODEL` switches only the running session.
- `config model ...` owns persistent provider and profile presets.
- `setup status`, `setup login PROVIDER`, and `setup reauthenticate PROVIDER` own provider setup.
- Detached help exposes all three logical commands; live-only model/setup actions explain that they require an attached session.

Proof:
- Full workspace suite passes: 1,325 tests.
- Clippy passes across all workspace targets with warnings denied.
- Real detached binary checks recognize `model`, `setup status`, and `config model`; live-only commands return the expected attached-session error.
- Offline binary smoke passes with `cargo run --quiet -- --provider llmsim -p hi`.

## Risk
- Medium
- Command parsing, runtime capability registration, profile-scoped persistence, and setup focus behavior could regress. Tests cover the root parser and command handler entry points, and the full workspace suite passes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered, yolop is pre-1.0 and this is an intentional command redesign
- [x] Knowledge concepts updated

## Knowledge
Updated `knowledge/specs/commands.md`, `knowledge/specs/configuration.md`, and `knowledge/log.md` for the live-only model command, persistent config model scopes, and setup semantics.

## Security
Reviewed TM-TOOL and TM-LLM. The change registers existing bounded logical command capabilities and accepts provider/model/profile strings through typed control-plane dispatch and settings APIs. It adds no shell execution, filesystem path handling, dependency, secret access, or credential logging. Setup reuses the existing provider setup controller and TUI command channel. No injection, traversal, data exposure, or unbounded resource behavior found.

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
