### PR TITLE
feat(cli): manage hooks and skills with commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
   bodies are recalled on demand, so the prompt stays small however much you
   remember.
 - **Skills**: `SKILL.md` files discovered from workspace (`.agents/skills/`),
-  global, ephemeral environment, and bundled scopes, exposed via `list_skills`,
-  `read_skill`, `write_skill`, `activate_skill`, plus `search_skills` /
-  `install_skill` for the public skills.sh registry and `delete_skill` for
-  uninstall. Skills installed after startup are available immediately. See
+  global, ephemeral environment, and bundled scopes. Model-visible discovery
+  and activation use upstream `list_skills` and `activate_skill`; package
+  management uses `yolop skills`. Skills installed after startup are available
+  immediately. See
   [Registry skills and Mermaid diagrams](./docs/features/show-me/show-me.md).
 - **OKF knowledge**: a bundled `okf` skill for the
   [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md):

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -10,15 +10,14 @@ outside the model.
 
 Yolop uses the upstream `everruns-core` `user_hooks` capability. The local
 Yolop layer only discovers hook files, merges workspace and global scopes, and
-exposes a `hooks` capability to configure those files from natural language.
+exposes `yolop config hooks` plus a host control route for those files.
 
 ## How it works
 
 ```mermaid
 flowchart LR
-  User["User: yolop setup a hook"] --> Hooks["hooks capability"]
-  Hooks --> Tools["validate_hook / upsert_hook"]
-  Tools --> Files["hooks.json"]
+  User["User: yolop config hooks set"] --> Hooks["hooks control route"]
+  Hooks --> Files["hooks.json"]
   Files --> Runtime["user_hooks capability"]
   Runtime --> Decision{"Hook decision"}
   Decision -->|allow| Continue["run action"]
@@ -26,9 +25,8 @@ flowchart LR
   Decision -->|mutate| Rewrite["rewrite action/result"]
 ```
 
-The model interprets the request, but it does not hand-edit hook JSON. The
-embedded `yolop-hooks` skill maps common requests to hook specs, and the
-`hooks` tools validate and write the config atomically.
+The attached CLI validates and writes hook configuration atomically. Hook
+management is not exposed as model tools.
 
 ## Scopes
 
@@ -40,18 +38,15 @@ embedded `yolop-hooks` skill maps common requests to hook specs, and the
 Workspace hooks override global hooks with the same `id`. A workspace file can
 also disable a lower-precedence global hook by listing the id in `disabled`.
 
-## Configure from chat
+## Configure with the CLI
 
-Ask Yolop directly:
-
-```text
-yolop setup a hook to prevent calls to git
+```bash
+yolop config hooks list
+yolop config hooks set hook.json --scope workspace
 ```
 
-Yolop should translate that into a `pre_tool_use` hook and save it through
-`upsert_hook`. If the scope is ambiguous and the hook blocks a broad class
-of normal coding actions, Yolop should ask whether the hook is global or just
-for the current workspace.
+Use `get` to inspect one effective hook and `remove` to delete or disable a hook
+in a selected scope.
 
 ## Configure by file
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -11,6 +11,17 @@ The singular attached `yolop model` command shows and switches the running sessi
 `model use` no longer writes provider or model defaults; persistent defaults remain under
 `yolop config model`.
 
+## 2026-08-31, Hook and skill management moved to detached CLI
+
+- [Hooks](specs/hooks.md): hook CRUD is available under `yolop config hooks`
+  through the shared hook store, and hook management model tools are removed.
+- [Skills](specs/skills.md): package management and registry operations are
+  available under top-level `yolop skills`; assembled sessions expose only
+  `list_skills` and `activate_skill` to the model.
+- [Conversational control](specs/conversational-control.md) and
+  [configuration](specs/configuration.md) distinguish host administration from
+  the runtime model surface.
+
 ## 2026-08-31, ACP failures stay bounded at their source
 
 - [Model-context checkpoints](specs/checkpointing.md): Codex native compaction

--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -247,3 +247,12 @@ attached from another terminal. The attached family also provides `setup status`
 `setup login PROVIDER`, and `setup reauthenticate PROVIDER`. Live model selection
 uses `yolop model use`; persistent selection and model-list edits remain under
 the attached `config` command.
+guided provider setup is **`/setup`**. Model selection and model-list edits go
+through the attached `config` command; other settings retain their dedicated
+setup and control surfaces.
+
+Hook configuration is managed under the configuration command: `yolop config hooks list|get|set|remove`. Skill packages use the separate top-level `yolop skills ...` management command.
+
+## Detached management commands
+
+`yolop config hooks` manages global and workspace hook files through the same `HooksStore` used at startup. Skill package administration is a separate top-level `yolop skills` command. Neither management surface is registered as model tools.

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -67,10 +67,8 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 | Model list (the menu `/model` and ACP offer) | `yolop config models …` (attached CLI) | `/model` overlay, `[[models]]` in settings |
 | Provider | `set_provider` | `/setup provider` |
 | Skills, list | `list_skills` (upstream) | system-prompt listing |
-| Skills, search (skills.sh) | `search_skills` |, |
-| Skills, install from registry | `install_skill` |, |
-| Skills, install/update by content | `write_skill` (upstream) |, |
-| Skills, uninstall | `delete_skill` |, |
+| Skills, package management | `yolop skills` (attached CLI) | skills control route |
+| Hooks, configuration | `yolop config hooks` (attached CLI) | hooks control route |
 | Model selection and model-list edits | `yolop config model` / `yolop config models` | `/setup`, `yolop-config` skill |
 | Any slash command the host's registry holds (`/setup`, `/background`, `/undo`, `/redo`, `/rewind`, `/goal`, plus the terminal ones in the TUI) | `run_command` (every host) | the slash commands themselves |
 
@@ -111,9 +109,12 @@ Notes:
 
 - This spec owns the conversational-control contract and the inventory above.
 - `crate::capabilities::host` owns `SetupController` and the `set_*` tools.
-- `crate::capabilities::skills` owns `delete_skill`; `crate::capabilities::skill_registry`
-  owns `search_skills` / `install_skill`; the upstream `ScopedSkillsCapability`
-  owns `list_skills` / `write_skill` (see [`skills.md`](./skills.md)).
+- `crate::capabilities::skills` owns attached skill package management;
+  `crate::capabilities::skill_registry` owns its skills.sh client. The upstream
+  `ScopedSkillsCapability` owns model-visible `list_skills` and `activate_skill`
+  (see [`skills.md`](./skills.md)).
+- `crate::capabilities::hooks` owns the hook control route; `config` nests its
+  CLI at `yolop config hooks`.
 - `crate::capabilities::config` owns the attached `config` command and delegates
   model-list actions to `ModelListCapability` (see
   [`configuration.md`](./configuration.md)).
@@ -124,3 +125,9 @@ Notes:
 - [`commands.md`](./commands.md), slash-command surface and natural-language dispatch.
 - [`skills.md`](./skills.md), skill scopes and management tools.
 - [`configuration.md`](./configuration.md), the settings file and its schema.
+
+Hook and skill mutation is intentionally outside conversational control. The model may list and activate installed skills, but operators manage hooks with `yolop config hooks ...` and skill storage with `yolop skills ...`.
+
+## Detached administration
+
+Hook CRUD and skill installation, editing, deletion, and registry operations are host administration. They run under `yolop config hooks` and `yolop skills`, not as model tools. The model skill surface remains limited to discovery and activation.

--- a/knowledge/specs/hooks.md
+++ b/knowledge/specs/hooks.md
@@ -6,8 +6,8 @@ description: Defines the hooks specification contract for Yolop.
 
 # Hooks Specification
 
-Status: v1 implemented for scoped config loading, `hooks` self-configuration,
-and upstream `user_hooks` registration.
+Status: v1 implemented for scoped config loading, detached `yolop config hooks`
+management, and upstream `user_hooks` registration.
 
 ## Why
 
@@ -97,69 +97,13 @@ This matches yolop's existing extension model: workspace scope is most
 specific, global scope is user-wide, and absent or broken optional extension
 files do not sink startup.
 
-## Natural-Language Setup
+## Management CLI
 
-Hook setup is part of yolop self-configuration. A user should be able to say:
-
-> yolop setup a hook to prevent calls to git
-
-and have yolop create a real hook config entry rather than merely remembering a
-preference.
-
-The reliable design is **prompt/skill for interpretation, tools for writes**:
-
-- The `hooks` capability prompt teaches the model that requests like
-  "configure yolop", "set up your hooks", or "prevent yourself from calling X"
-  are self-configuration requests.
-- The embedded `yolop-hooks` skill holds examples that map common intents to
-  hook specs, so the prompt stays short and examples are loaded on demand.
-- Structured `hooks` capability tools perform the actual mutation. They read,
-  validate, merge, and atomically write `hooks.json`, then return the effective
-  hook id and scope. The model should not hand-edit hook JSON through generic
-  file tools for global self-configuration.
-
-Initial tool surface:
-
-- `list_hooks`, show effective hooks, their scope, event, matcher, and
-  source file.
-- `upsert_hook`, create or replace one hook by `id`.
-- `remove_hook`, remove or disable one hook by `id`.
-- `validate_hook`, validate a candidate spec without writing it.
-
-`upsert_hook` accepts an explicit `scope`:
-
-- `global` writes `<config_dir>/yolop/hooks.json`.
-- `workspace` writes `<workspace>/.agents/hooks.json`.
-
-If the user says "yolop", "your", or otherwise frames the request as a
-personal preference, default to `global`. If the user says "this repo",
-"workspace", or "project", use `workspace`. If the requested hook would block a
-broad class of normal coding actions and the scope is ambiguous, ask once for
-scope instead of guessing.
-
-Example generated hook for "prevent calls to git":
-
-```json
-{
-  "id": "block-git",
-  "event": "pre_tool_use",
-  "matcher": {
-    "tool_name": "bash",
-    "args_jsonpath": "$.command",
-    "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
-  },
-  "executor": {
-    "type": "bash",
-    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"git command blocked by hook\",\"user_message\":\"Blocked by your yolop hook: git commands are disabled.\"}'"
-  },
-  "timeout_ms": 1000,
-  "on_error": "block",
-  "description": "Block bash commands that invoke git"
-}
-```
-
-The model may offer to refine the matcher for narrower cases, such as allowing
-read-only `git status` while blocking mutating commands.
+Hook management is detached host administration under `yolop config hooks`.
+The `list`, `get`, `set`, and `remove` commands reuse `HooksStore`, including
+its global/workspace merge and atomic write behavior. Hook management is not a
+model tool surface. The model can still explain hook configuration, but it does
+not receive hook CRUD tools in an assembled session.
 
 ## Events
 
@@ -241,11 +185,9 @@ Implemented:
    and enables it with `AgentCapabilityConfig::with_config("user_hooks", ...)`
    only when hooks are configured.
 3. `StartupInfo` includes effective hook counts; `--print` shows loaded hooks.
-4. `HooksCapability` includes the hook self-configuration tools described in
-   [Natural-Language Setup](#natural-language-setup).
-5. The bundled `yolop-hooks` system skill ships the self-configuration recipes
-   used for natural-language hook setup.
-6. Tests cover merge behavior, `hooks` tools, and a scripted llmsim
+4. `yolop config hooks` manages hooks through the startup `HooksStore`; hook
+   management is not exposed as model tools.
+5. Tests cover merge behavior, hook CLI management, and a scripted llmsim
    `pre_tool_use` hook that blocks a matching `bash` tool call.
 
 Follow-up:
@@ -261,3 +203,7 @@ Follow-up:
 - No TOML format until there is a concrete reason to diverge from upstream's
   JSON schema.
 - No separate yolop-only hook executor.
+
+## Management surface
+
+Hook management is explicit CLI configuration, not a model tool surface. Use `yolop config hooks list`, `get`, `set`, and `remove`. Runtime hook execution remains model-independent.

--- a/knowledge/specs/skills.md
+++ b/knowledge/specs/skills.md
@@ -8,14 +8,14 @@ description: Defines the skills specification contract for Yolop.
 
 ## Abstract
 
-Skills are instruction packages (`SKILL.md` files) the agent can discover,
-activate, and manage at runtime via skills tools, plus a system-prompt listing
-of what's available.
+Skills are instruction packages (`SKILL.md` files) the agent can discover and
+activate at runtime, manage through the detached `yolop skills` CLI, and see in
+the system-prompt listing.
 
 yolop uses the upstream `ScopedSkillsCapability` from `everruns-core` (0.12.0+).
-That capability owns discovery, precedence, the skills tools (`list_skills`,
-`activate_skill`, `read_skill`, `write_skill`), validation, and `SKILL.md`
-substitution, all driven strictly through the session `SessionFileSystem`. yolop
+That capability owns discovery, precedence, the model tools (`list_skills` and
+`activate_skill`), validation, and `SKILL.md` substitution, all driven strictly
+through the session `SessionFileSystem`. yolop
 supplies only the embedder-specific glue (`crate::capabilities::skills`):
 
 1. **The scope set and writability**: workspace, profile, global, environment,
@@ -65,6 +65,14 @@ a labeled **real on-disk directory**:
    available, **read-only**. Overridable with `YOLOP_SYSTEM_SKILLS_DIR` (used
    verbatim, no materialization).
 
+## Management and model surfaces
+
+The detached `yolop skills` command owns list, read, delete, registry search,
+and registry install operations. It reuses the scoped skills,
+yolop skill management, and registry services. The assembled model tool surface
+contains exactly `list_skills` and `activate_skill`; CLI duplication of those two
+operations is intentional.
+
 ## Required Behavior
 
 1. **Merge.** `list_skills` and the system-prompt listing see skills from all
@@ -80,43 +88,32 @@ a labeled **real on-disk directory**:
    expanded, activating a skill must not spawn a shell on the host (mirrors the
    upstream trust gate; see `everruns-core` skills / EVE-388).
 5. **Writes are explicit.** Normal file tools edit only the workspace. The
-   dedicated `write_skill` tool may write workspace or global skills when the
+   `yolop skills write` command may write workspace or global skills when the
    user asks Yolop to install or modify skills. System skills are read-only.
 6. **Hot install.** Workspace and global scope paths are kept even when the
    directories do not exist yet. Discovery reads the filesystem on each
-   `list_skills`, `read_skill`, and `activate_skill` call, so a skill installed
+   `list_skills`, CLI `read`, and `activate_skill` call, so a skill installed
    after Yolop starts is available without restarting.
-7. **Manage workspace/global skills.** `read_skill` returns an installed
-   skill's `SKILL.md` and file manifest. `write_skill` installs or updates a
-   skill in the workspace (`workspace`/`local`) or global (`global`) scope.
-   `write_skill` validates the skill name and `SKILL.md`, requires the
-   frontmatter `name` to match the directory name, bounds extra files, rejects
-   path traversal, and never writes system skills.
-8. **Uninstall.** The yolop-owned `delete_skill` tool removes an installed skill
+7. **Inspect workspace/global skills.** `yolop skills read` returns an installed
+   skill's `SKILL.md` and file manifest. Registry installation validates the
+   skill name and `SKILL.md`, bounds files, rejects path traversal, and never
+   writes system skills.
+8. **Uninstall.** The `yolop skills delete` command removes an installed skill
    from a writable scope (`workspace` or `global`). It validates the name as a
    single path segment (no separators, `.`, or `..`), refuses a directory with no
-   `SKILL.md`, and never touches the read-only system scope. This is the
-   conversational uninstall path (see [`conversational-control.md`](./conversational-control.md));
-   the upstream capability has no removal.
+   `SKILL.md`, and never touches the read-only system scope. The upstream capability has no removal.
 9. **Absent scopes are silent.** A missing workspace/global directory is simply
    empty until a skill is installed. A failure to materialize system skills
    disables that scope without failing the session.
 10. **Materialization is safe.** System-skill materialization is idempotent and
     concurrency-safe (atomic per-file writes, skipped when bytes are unchanged),
     so parallel processes do not race on the shared cache directory.
-11. **Management guidance is bundled.** Yolop ships a `skill-management` system
-    skill that tells the agent how to inspect, install, search for, and upgrade
-    skills. Prefer the yolop-owned `search_skills` / `install_skill` tools for
-    the public skills.sh registry (search → ask which to install → install).
-    Reconstruct `npx skill add ...` style installs that are not on skills.sh by
-    fetching source files directly and writing them with `write_skill`.
-12. **Registry search and install.** `search_skills` queries skills.sh and
-    returns structured matches (id, source, installs, URL). `install_skill`
-    downloads a skills.sh snapshot into a writable scope (`workspace` or
-    `global`), validates `SKILL.md` and relative paths, and makes the skill
-    available immediately. Both are conversational control surfaces (see
-    [`conversational-control.md`](./conversational-control.md)): present search
-    results and ask before installing. System skills remain read-only.
+11. **Management guidance is bundled.** Yolop ships a `skill-management`
+    system skill that directs operators to `yolop skills` for listing, reading,
+    searching, installing, and deleting skills.
+12. **Registry search and install.** `yolop skills search` queries skills.sh and
+    returns structured matches. `yolop skills install` downloads and validates a
+    snapshot into a writable scope. Neither operation is exposed as a model tool.
 13. **User guide is bundled.** Yolop ships a `yolop` system skill from the
     private bundled asset tree as the durable reference for slash commands,
     keyboard shortcuts, CLI flags, and session controls. `/help` in the TUI
@@ -134,14 +131,17 @@ a labeled **real on-disk directory**:
   session `SessionFileSystem`.
 - `crate::capabilities::skills` owns the yolop wiring: the scope set, the
   host-path `SkillDirResolver`, embedded and generated skill materialization, and
-  the `SkillManagementCapability`
-  that contributes `search_skills`, `install_skill`, and `delete_skill`. That
-  capability must be both registered *and* enabled in the default coding
-  harness; registering it alone leaves its tools out of every session while the
-  skill-management skill still instructs the model to call them.
+  the operator-only `SkillManagementCapability` behind `yolop skills`.
 - `crate::capabilities::skill_registry` owns the skills.sh HTTP client used by
-  `search_skills` / `install_skill`.
+  the CLI `search` and `install` operations.
 - `crate::runtime` (`CodingCliSessionFileStore`) owns read-only access to physical
   skill directories outside the workspace.
 - `everruns_core::skill` owns the `SKILL.md` format, parsing, validation, and
   substitution.
+
+## Management surface
+
+The model-visible skill surface is exactly `list_skills` and `activate_skill`.
+Reading, deleting, searching, and installing skills are operator actions exposed
+through top-level `yolop skills list|read|delete|search|install`; they are not
+model tools.

--- a/knowledge/test-scenarios/skill-install-mermaid-render.md
+++ b/knowledge/test-scenarios/skill-install-mermaid-render.md
@@ -14,7 +14,7 @@ rather than as source.
 
 Neither half is reachable from `cargo test`. The install needs the live
 [skills.sh](https://skills.sh) registry over the network, and the answer needs a
-live provider, a simulated one will not choose to call `search_skills`. The
+live provider, a simulated one will not choose to invoke `yolop skills search`. The
 rendering half is asserted in unit tests at fixed widths
 (`markdown_mermaid_fence_renders_as_a_diagram`), but only a real terminal shows
 whether a real model's diagram fits the transcript it actually gets.
@@ -61,10 +61,10 @@ doppler run -- target/debug/yolop -C /tmp/yolop-show-me-orbit --provider anthrop
 
 **Skill installed**
 
-1. The transcript shows a `search_skills` call followed by an `install_skill`
-   call. A `write_skill` call instead means the registry tools were unreachable
-   and the model fell back to fetching files by hand, that is a failure of this
-   scenario even though the skill ends up on disk.
+1. The transcript shows `yolop skills search` followed by `yolop skills
+   install`. A `yolop skills write` command instead means registry installation
+   was unreachable and the model fell back to fetching files by hand, that is a
+   failure of this scenario even though the skill ends up on disk.
 2. `/tmp/yolop-show-me-orbit/.agents/skills/show-me/SKILL.md` exists after the
    first turn.
 3. Its contents match what the registry serves, byte for byte:
@@ -93,7 +93,7 @@ and wording differ run to run, and the diagram may include return arrows one run
 and not the next. None of that fails the scenario, criteria 5 through 7 are
 about the render, not the content.
 
-The registry install count reported by `search_skills` changes over time, and
+The registry install count reported by `yolop skills search` changes over time, and
 other `show-me` skills from other owners appear in the results. Only
 `humanlayer/skills/show-me` matters.
 
@@ -111,7 +111,7 @@ other `show-me` skills from other owners appear in the results. Only
 
 ## Related
 
-- [`skills.md`](../specs/skills.md), scopes, precedence, and the registry tools.
+- [`skills.md`](../specs/skills.md), scopes, precedence, and the registry CLI.
 - [`tuika.md`](../specs/tuika.md), the rendering boundary this exercises.
 - [Registry skills and Mermaid diagrams](../../docs/features/show-me/show-me.md)
 , the public guide, whose recording is this scenario run once.

--- a/src/bundled/system-skills/skill-management/SKILL.md
+++ b/src/bundled/system-skills/skill-management/SKILL.md
@@ -1,122 +1,19 @@
 ---
 name: skill-management
-description: Install, inspect, update, or search for Yolop skills in workspace and global scopes. Use when the user asks to manage skills, find a skill for a task, import a skill from skills.sh or GitHub, or upgrade skills.
-user-invocable: true
+description: Manage installed skills and the public skills.sh registry through yolop's CLI.
 ---
-
 # Skill Management
 
-Use this skill when the user wants to customize Yolop with skills, especially
-when they ask to *find* a skill for a task.
+Use the attached `yolop skills` CLI for package management:
 
-## Ground Rules
+- `yolop skills list`
+- `yolop skills read <name>`
+- `yolop skills search <query>`
+- `yolop skills install <source> [--scope workspace|global]`
+- `yolop skills delete <name> [--scope workspace|global]`
 
-- Installed skills are directories with a `SKILL.md`.
-- Workspace skills live under `.agents/skills/<name>/`.
-- Global skills live under `~/.agents/skills/<name>/`. The former
-  `<config_dir>/yolop/skills/<name>/` location is supported temporarily for
-  compatibility.
-- System skills are built into Yolop and are read-only.
-- Workspace skills shadow global skills; global skills shadow system skills.
-- New or changed workspace/global skills are available immediately through
-  `list_skills` and `activate_skill`; do not ask the user to restart Yolop.
+Search results return canonical sources such as `owner/repo/skillId`. Ask the
+user which result and scope they want before installing or deleting. Workspace
+scope is project-owned; global scope is personal. System skills are read-only.
 
-## Inspect
-
-1. Call `list_skills` to see installed skills and scopes.
-2. Call `read_skill` before modifying an existing skill.
-3. Prefer editing the nearest scope that matches the user's intent:
-   workspace/local for project-specific behavior, global for cross-project
-   behavior.
-
-## Search (conversational)
-
-When the user asks to find a skill for something:
-
-1. Call `search_skills` with a short query (and optional `owner`).
-2. Present the top matches: name, source repo, install count, and skills.sh URL.
-3. **Ask which skill to install** (and whether workspace or global) before
-   writing anything.
-4. Call `install_skill` with the chosen `install_source` / id from the search
-   result (`owner/repo/skillId`).
-5. Confirm with `list_skills` and offer to `activate_skill` when useful.
-
-Do not install on a guess. If search returns nothing useful, say so and offer
-the GitHub / web fallback below.
-
-## Install From Registry
-
-`install_skill` fetches a skills.sh snapshot and writes it into a writable
-scope:
-
-- `source`: `owner/repo/skillId`, `owner/repo@skill`, or a skills.sh URL
-- `scope`: `workspace` (default) or `global`
-- `overwrite`: defaults to true
-
-After install the skill is live, no restart.
-
-## Install Or Modify By Hand
-
-Use `write_skill` when you already have the `SKILL.md` (and optional files), or
-when the source is not on skills.sh:
-
-- `scope`: `workspace`/`local` or `global`
-- `name`: the skill directory name
-- `skill_md`: the full `SKILL.md` contents
-- `files`: optional bundled files keyed by relative path
-
-`write_skill` validates the skill name, parses `SKILL.md`, rejects path
-traversal in bundled files, and writes the skill atomically.
-
-## Import From npx-Style Or GitHub Sources
-
-If the user mentions an `npx skill add ...` command or a GitHub skill that
-`install_skill` cannot resolve:
-
-1. Prefer `install_skill` with `owner/repo@skill` when the package is on
-   skills.sh.
-2. Otherwise identify the repository or files that command would fetch.
-3. Fetch the relevant `SKILL.md` and bundled files (`web_fetch` /
-   `free_web_search`).
-4. Preserve the upstream skill directory name unless the user asks to rename it.
-5. Install with `write_skill`.
-6. Call `list_skills` afterward and report the installed scope/path.
-
-If the source is ambiguous or private and cannot be fetched, ask for the exact
-repository, package, archive, or file contents.
-
-## Search Fallback Order
-
-1. `search_skills` (skills.sh), preferred.
-2. GitHub repositories and paths containing `SKILL.md` via `free_web_search` /
-   `web_fetch`.
-3. General web search for the skill topic plus `SKILL.md`.
-
-Prefer source URLs that expose the actual files. Do not install from a summary
-page unless you can retrieve the real `SKILL.md` and any referenced files.
-
-## Upgrade
-
-For one skill:
-
-1. `read_skill` to capture the current scope, path, and any local changes.
-2. Prefer `install_skill` when the upstream is a known skills.sh source.
-3. Otherwise fetch the current upstream version and `write_skill`.
-4. Compare with the installed version when practical.
-5. `activate_skill` or `list_skills` to verify it loads.
-
-For all skills:
-
-1. `list_skills`.
-2. Upgrade only skills with an identifiable upstream source or enough user
-   context to locate one.
-3. Skip read-only system skills unless Yolop itself is being updated.
-4. Report skipped skills with the reason, especially when no source is known.
-
-Never silently overwrite a clearly user-customized skill with unrelated
-registry content. If the intended upstream is uncertain, ask first.
-
-## Uninstall
-
-Use `delete_skill` with `name` and `scope` (`workspace` or `global`). System
-skills cannot be deleted.
+The model-facing skill tools are only `list_skills` and `activate_skill`.

--- a/src/bundled/system-skills/yolop-hooks/SKILL.md
+++ b/src/bundled/system-skills/yolop-hooks/SKILL.md
@@ -1,131 +1,17 @@
 ---
 name: yolop-hooks
-description: Configure Yolop hooks from natural-language self-configuration requests, especially block, allow, mutate, or audit rules around tool calls.
-user-invocable: false
+description: Configure yolop lifecycle hooks with the attached CLI and scoped JSON manifests.
 ---
-
 # Yolop Hooks
 
-Use this skill when the user asks Yolop to configure its own behavior with
-hooks, for example:
+Manage hooks through `yolop config hooks`:
 
-- "yolop setup a hook to prevent calls to git"
-- "block yourself from running terraform apply in this repo"
-- "add a workspace hook that audits shell commands"
-- "remove the hook that blocks cargo publish"
+- `yolop config hooks list`
+- `yolop config hooks get <id>`
+- `yolop config hooks set <file> [--scope global|workspace]`
+- `yolop config hooks remove <id> [--scope global|workspace]`
 
-Hooks are real configuration. Do not treat these requests as memory or as a
-soft preference. Use the `hooks` capability tools:
-
-1. Build a candidate hook spec.
-2. Call `validate_hook`.
-3. Call `upsert_hook` after validation succeeds.
-4. Use `list_hooks` to inspect current state or confirm effective config.
-5. Use `remove_hook` when the user asks to remove or disable a hook.
-
-## Scope
-
-Choose the narrowest scope that matches the request.
-
-- Use `workspace` when the user says "this repo", "this project",
-  "workspace", or references project policy.
-- Use `global` when the user says "yolop", "your", "always", "everywhere",
-  or frames the rule as a personal preference.
-- Ask once if the rule would block broad normal coding behavior and the scope
-  is ambiguous.
-
-## Common Recipes
-
-Block any Bash command that invokes `git`:
-
-```json
-{
-  "id": "block-git",
-  "event": "pre_tool_use",
-  "matcher": {
-    "tool_name": "bash",
-    "args_jsonpath": "$.command",
-    "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
-  },
-  "executor": {
-    "type": "bash",
-    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"git command blocked by hook\",\"user_message\":\"Blocked by your Yolop hook: git commands are disabled.\"}'"
-  },
-  "timeout_ms": 1000,
-  "on_error": "block",
-  "description": "Block bash commands that invoke git"
-}
-```
-
-Block mutating `git` commands but allow read-only status/log/diff:
-
-```json
-{
-  "id": "block-mutating-git",
-  "event": "pre_tool_use",
-  "matcher": {
-    "tool_name": "bash",
-    "args_jsonpath": "$.command",
-    "match_regex": "(^|[;&|()[:space:]])git[[:space:]]+(add|am|apply|bisect|branch|checkout|cherry-pick|clean|commit|fetch|merge|mv|pull|push|rebase|reset|restore|revert|rm|switch|tag)([[:space:]]|$)"
-  },
-  "executor": {
-    "type": "bash",
-    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"mutating git command blocked by hook\",\"user_message\":\"Blocked by your Yolop hook: mutating git commands are disabled.\"}'"
-  },
-  "timeout_ms": 1000,
-  "on_error": "block",
-  "description": "Block mutating git commands"
-}
-```
-
-Block publishing commands:
-
-```json
-{
-  "id": "block-publish",
-  "event": "pre_tool_use",
-  "matcher": {
-    "tool_name": "bash",
-    "args_jsonpath": "$.command",
-    "match_regex": "(^|[;&|()[:space:]])(cargo publish|npm publish|pnpm publish)([[:space:]]|$)"
-  },
-  "executor": {
-    "type": "bash",
-    "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"publish command blocked by hook\",\"user_message\":\"Blocked by your Yolop hook: publish commands are disabled.\"}'"
-  },
-  "timeout_ms": 1000,
-  "on_error": "block",
-  "description": "Block package publishing commands"
-}
-```
-
-Audit Bash commands without blocking:
-
-```json
-{
-  "id": "audit-bash",
-  "event": "pre_tool_use",
-  "matcher": {
-    "tool_name": "bash"
-  },
-  "executor": {
-    "type": "bash",
-    "command": "printf '%s\\n' \"$EVERRUNS_HOOK_PAYLOAD_JSON\" >> .agents/hook-audit.jsonl && printf '%s\\n' '{\"decision\":\"allow\"}'"
-  },
-  "timeout_ms": 1000,
-  "on_error": "warn",
-  "description": "Append Bash tool calls to .agents/hook-audit.jsonl"
-}
-```
-
-## Rules
-
-- Prefer stable ids such as `block-git`, `block-mutating-git`, or
-  `audit-bash`; stable ids make overrides and removal possible.
-- Prefer `pre_tool_use` for blocking or mutating model-authored tool calls.
-- Use `on_error: "block"` for safety-critical hooks and `on_error: "warn"`
-  for audit hooks.
-- Keep hook commands short. For complex logic, point the executor at a checked
-  in script instead of embedding a large shell program.
-- Do not put secrets in `hooks.json`; hook scripts can read environment
-  variables at runtime.
+Global hooks live in the yolop config directory. Workspace hooks live in
+`.agents/hooks.json` and override global hooks by id. Hook management is host
+administration, not a model tool surface. Runtime execution remains the upstream
+`user_hooks` capability.

--- a/src/bundled/system-skills/yolop/SKILL.md
+++ b/src/bundled/system-skills/yolop/SKILL.md
@@ -149,7 +149,7 @@ yolop is an autonomous coding agent for the workspace it was started in.
 - **Web**: `web_fetch`, `free_web_search`, and `duckduckgo_instant_answer`
 - **Memory**: durable cross-session notes via `remember` / `recall` / `forget`
 - **Skills**: `SKILL.md` packages in workspace, global, and bundled system scopes;
-  find/install from skills.sh via `search_skills` / `install_skill`
+  find/install from skills.sh via `yolop skills search` / `yolop skills install`
 - **MCP**: extra tools from `.mcp.json` / global `mcp.json`
 - **Hooks**: block, allow, or audit tool calls (see `yolop-hooks` skill)
 - **Goal loops**: `/goal` keeps working until an evaluator confirms the condition

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -12,15 +12,16 @@ use crate::config::capability_settings::{
     capability_catalog_json, capability_catalog_list, effective_harness_json, overrides_to_json,
     parse_override_from_json, stored_override_json,
 };
+use crate::config::hooks::{HookScope, HooksStore};
 use crate::config::schema::{KeyTarget, ValueKind, known_keys, parse_key, schema};
 use crate::config::service::{ConfigService, current_value, scoped_current};
-use crate::config::{ApprovalMode, Settings, SettingsStore};
+use crate::config::{ApprovalMode, Settings, SettingsStore, default_settings_path};
 use crate::control::{
     CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
 };
 use crate::runtime::{SUPPORTED_PROVIDERS, coding_harness_defaults, resolve_for_settings};
 use async_trait::async_trait;
-use clap::{Args, Command, FromArgMatches, Subcommand};
+use clap::{Args, Command, FromArgMatches, Subcommand, ValueEnum};
 use everruns_core::tool_narration::ToolNarrationPhase;
 use everruns_core::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::{Tool, ToolExecutionResult};
@@ -56,6 +57,48 @@ enum ConfigCommand {
     Models {
         #[command(subcommand)]
         command: Option<ModelsCliCommand>,
+    },
+    Hooks {
+        #[command(subcommand)]
+        command: HooksCommand,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, ValueEnum)]
+enum HookScopeArg {
+    Global,
+    Workspace,
+}
+impl From<HookScopeArg> for HookScope {
+    fn from(value: HookScopeArg) -> Self {
+        match value {
+            HookScopeArg::Global => Self::Global,
+            HookScopeArg::Workspace => Self::Workspace,
+        }
+    }
+}
+#[derive(Debug, Serialize, Deserialize, Subcommand)]
+enum HooksCommand {
+    List,
+    Get {
+        id: String,
+        #[arg(long, value_enum)]
+        scope: Option<HookScopeArg>,
+    },
+    Set {
+        id: String,
+        event: String,
+        #[arg(long)]
+        command: String,
+        #[arg(long, value_enum, default_value = "global")]
+        scope: HookScopeArg,
+        #[arg(long)]
+        disabled: bool,
+    },
+    Remove {
+        id: String,
+        #[arg(long, value_enum, default_value = "global")]
+        scope: HookScopeArg,
     },
 }
 
@@ -119,6 +162,7 @@ impl ConfigCommandLine {
                     connected: false,
                 },
             })?,
+            ConfigCommand::Hooks { command } => serde_json::json!({ "hooks": command }),
         };
         Ok(ControlRequest::new("models", action)?)
     }
@@ -168,6 +212,12 @@ impl CliCapability for ConfigCapability {
     }
 
     async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        if let Some(value) = request.action.get("hooks") {
+            let command: HooksCommand = serde_json::from_value(value.clone())?;
+            let result = execute_hooks_cli(command)?;
+            println!("{}", tool_result_json(result));
+            return Ok(());
+        }
         if serde_json::from_value::<ConfigAction>(request.action.clone()).is_err() {
             return self.model_list.execute_cli_request(request).await;
         }
@@ -900,6 +950,53 @@ fn on_off(enabled: bool) -> &'static str {
     if enabled { "on" } else { "off" }
 }
 
+fn tool_result_json(result: ToolExecutionResult) -> String {
+    match result {
+        ToolExecutionResult::Success(value) => {
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+        }
+        ToolExecutionResult::ToolError(message) => message,
+        _ => "hook command failed".to_string(),
+    }
+}
+
+fn execute_hooks_cli(command: HooksCommand) -> anyhow::Result<ToolExecutionResult> {
+    let settings_path =
+        default_settings_path().unwrap_or_else(|| std::path::PathBuf::from("settings.toml"));
+    let workspace_root = std::env::current_dir()?;
+    let store = HooksStore::new(settings_path.with_file_name("hooks.json"), workspace_root);
+    let value = match command {
+        HooksCommand::List => serde_json::json!({ "hooks": store.effective().summaries() }),
+        HooksCommand::Get { id, scope } => {
+            let scope = scope.map(HookScope::from);
+            let hook = store.effective().hooks.into_iter().find(|hook| {
+                hook.id.as_deref() == Some(id.as_str())
+                    && scope.is_none_or(|scope| hook.scope == scope)
+            });
+            serde_json::to_value(hook.ok_or_else(|| anyhow::anyhow!("hook `{id}` was not found"))?)?
+        }
+        HooksCommand::Set {
+            id,
+            event,
+            command,
+            scope,
+            disabled,
+        } => {
+            let hook = serde_json::json!({
+                "id": id,
+                "event": event,
+                "executor": { "type": "bash", "command": command },
+                "enabled": !disabled,
+            });
+            serde_json::to_value(store.upsert_hook(scope.into(), hook)?)?
+        }
+        HooksCommand::Remove { id, scope } => {
+            serde_json::json!({ "removed": store.remove_hook(scope.into(), &id)?, "id": id })
+        }
+    };
+    Ok(ToolExecutionResult::success(value))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -924,6 +1021,8 @@ mod tests {
             &["config", "model", "set", "openai/gpt-5.6"][..],
             &["config", "model", "clear"][..],
             &["config", "models"][..],
+            &["config", "hooks", "list"][..],
+            &["config", "hooks", "remove", "example", "--scope", "global"][..],
         ] {
             cli_request(args);
         }
@@ -977,6 +1076,27 @@ mod tests {
                 .is_err(),
             "scalar and JSON forms must be mutually exclusive"
         );
+    }
+
+    #[test]
+    fn hooks_cli_dispatches_management_commands() {
+        for (args, expected) in [
+            (&["config", "hooks", "list"][..], "list"),
+            (&["config", "hooks", "get", "sample"][..], "get"),
+            (&["config", "hooks", "remove", "sample"][..], "remove"),
+        ] {
+            let request = cli_request(args);
+            let command: HooksCommand =
+                serde_json::from_value(request.action.get("hooks").expect("hooks action").clone())
+                    .expect("hooks command");
+            let actual = match command {
+                HooksCommand::List => "list",
+                HooksCommand::Get { .. } => "get",
+                HooksCommand::Remove { .. } => "remove",
+                HooksCommand::Set { .. } => "set",
+            };
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]

--- a/src/capabilities/hooks.rs
+++ b/src/capabilities/hooks.rs
@@ -1,23 +1,20 @@
-// The `hooks` capability — authoring and inspecting Yolop hook config.
-//
-// The hook engine itself is upstream `user_hooks`; this capability is only the
-// natural-language-safe write surface for Yolop's global/workspace `hooks.json`
-// files.
-
-use crate::capabilities::narration::stable_labeled;
-use crate::config::hooks::{HookScope, HooksStore};
 use async_trait::async_trait;
-use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
-use everruns_core::{Capability, CapabilityStatus};
-use everruns_core::{Tool, ToolExecutionResult};
-use everruns_provider::ToolCall;
+use everruns_core::{Capability, CapabilityStatus, Tool, ToolExecutionResult};
 use serde_json::{Value, json};
-use std::sync::Arc;
 
-pub(crate) const HOOKS_CAPABILITY_ID: &str = "hooks";
+use crate::config::hooks::{HookScope, HooksStore};
+use crate::control::{ControlCapability, ControlResponse, ControlRoute};
 
-pub(crate) struct HooksCapability {
-    pub(crate) hooks: Arc<HooksStore>,
+pub const HOOKS_CAPABILITY_ID: &str = "hooks";
+
+pub struct HooksCapability {
+    hooks: HooksStore,
+}
+
+impl HooksCapability {
+    pub fn new(hooks: HooksStore) -> Self {
+        Self { hooks }
+    }
 }
 
 #[async_trait]
@@ -27,11 +24,11 @@ impl Capability for HooksCapability {
     }
 
     fn name(&self) -> &str {
-        "Hooks"
+        "Hook Management"
     }
 
     fn description(&self) -> &str {
-        "Authoring and inspection tools for global and workspace hook configuration."
+        "Manage global and workspace lifecycle hooks through the control plane."
     }
 
     fn status(&self) -> CapabilityStatus {
@@ -39,384 +36,122 @@ impl Capability for HooksCapability {
     }
 
     fn category(&self) -> Option<&str> {
-        Some("Extensibility")
+        Some("Examples")
     }
 
-    // No system-prompt contribution: the four tool descriptions already carry the
-    // workflow (`list_hooks` before changing, `validate_hook` before writing) and
-    // state that hooks are global/workspace configuration.
+    fn system_prompt_addition(&self) -> Option<&str> {
+        None
+    }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(ListHooksTool {
-                hooks: self.hooks.clone(),
-            }),
-            Box::new(ValidateHookTool {
-                hooks: self.hooks.clone(),
-            }),
-            Box::new(UpsertHookTool {
-                hooks: self.hooks.clone(),
-            }),
-            Box::new(RemoveHookTool {
-                hooks: self.hooks.clone(),
-            }),
-        ]
+        Vec::new()
     }
-}
-
-struct ListHooksTool {
-    hooks: Arc<HooksStore>,
 }
 
 #[async_trait]
-impl Tool for ListHooksTool {
-    fn narrate(
-        &self,
-        _tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        Some(stable_labeled("List hooks", None, phase))
-    }
-
-    fn name(&self) -> &str {
-        "list_hooks"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("List hooks")
-    }
-
-    fn description(&self) -> &str {
-        "List Yolop hooks from global and workspace hook config. Use for \
-         \"what hooks are configured?\" or before changing an existing hook."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({ "type": "object", "properties": {}, "additionalProperties": false })
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        let effective = self.hooks.effective();
-        ToolExecutionResult::success(json!({
-            "ok": true,
-            "global_path": effective.global_path.display().to_string(),
-            "workspace_path": effective.workspace_path.display().to_string(),
-            "count": effective.hooks.len(),
-            "scope_counts": effective.scope_counts(),
-            "hooks": effective.summaries(),
-        }))
-    }
-}
-
-struct ValidateHookTool {
-    hooks: Arc<HooksStore>,
-}
-
-#[async_trait]
-impl Tool for ValidateHookTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let id = tool_call
-            .arguments
-            .get("hook")
-            .and_then(|hook| hook.get("id"))
-            .and_then(Value::as_str)
-            .map(|value| truncate(value, 48));
-        Some(stable_labeled("Validate hook", id, phase))
-    }
-
-    fn name(&self) -> &str {
-        "validate_hook"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Validate hook")
-    }
-
-    fn description(&self) -> &str {
-        "Validate a candidate Yolop hook spec without writing it. Use before `upsert_hook`, \
-         especially when translating a natural-language request into hook JSON."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        hook_value_schema()
-    }
-
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let hook = match arguments.get("hook") {
-            Some(hook) => hook.clone(),
-            None => return ToolExecutionResult::tool_error("'hook' is required"),
-        };
-        match self.hooks.validate_hook(&hook) {
-            Ok(entry) => ToolExecutionResult::success(json!({
-                "ok": true,
-                "hook": entry.to_validation_json(),
-            })),
-            Err(error) => ToolExecutionResult::tool_error(format!("invalid hook: {error}")),
+impl ControlCapability for HooksCapability {
+    fn control_route(&self) -> ControlRoute {
+        ControlRoute {
+            resource: HOOKS_CAPABILITY_ID,
+            cli_subcommand: "config hooks",
+            read_only_operations: &["list", "validate"],
+            summary: "global and workspace hook management",
         }
     }
-}
 
-struct UpsertHookTool {
-    hooks: Arc<HooksStore>,
-}
-
-#[async_trait]
-impl Tool for UpsertHookTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let id = tool_call
-            .arguments
-            .get("hook")
-            .and_then(|hook| hook.get("id"))
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let operation = action
+            .get("operation")
             .and_then(Value::as_str)
-            .map(|value| truncate(value, 48));
-        Some(stable_labeled("Save hook", id, phase))
-    }
-
-    fn name(&self) -> &str {
-        "upsert_hook"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Save hook")
-    }
-
-    fn description(&self) -> &str {
-        "Create or replace one Yolop hook by id. Use global scope for personal Yolop behavior \
-         and workspace scope for project-owned hook config. Validates before writing."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": {
-                    "type": "string",
-                    "enum": ["global", "workspace"],
-                    "description": "Where to write the hook. Use global for personal Yolop configuration; workspace for this repo."
-                },
-                "hook": {
-                    "type": "object",
-                    "description": "A UserHookSpec object with a stable id."
-                }
-            },
-            "required": ["scope", "hook"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let scope = match parse_scope_arg(&arguments) {
-            Ok(scope) => scope,
-            Err(error) => return ToolExecutionResult::tool_error(error),
-        };
-        let hook = match arguments.get("hook") {
-            Some(hook) => hook.clone(),
-            None => return ToolExecutionResult::tool_error("'hook' is required"),
-        };
-        match self.hooks.upsert_hook(scope, hook) {
-            Ok(entry) => ToolExecutionResult::success(json!({
-                "ok": true,
-                "message": format!("saved {} hook", scope.as_str()),
-                "hook": entry.to_summary_json(),
-                "path": self.hooks.path_for(scope).display().to_string(),
-            })),
-            Err(error) => ToolExecutionResult::tool_error(format!("could not save hook: {error}")),
-        }
-    }
-}
-
-struct RemoveHookTool {
-    hooks: Arc<HooksStore>,
-}
-
-#[async_trait]
-impl Tool for RemoveHookTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let id = arg_str(&tool_call.arguments, &["id"]).map(|value| truncate(value, 48));
-        Some(stable_labeled("Remove hook", id, phase))
-    }
-
-    fn name(&self) -> &str {
-        "remove_hook"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Remove hook")
-    }
-
-    fn description(&self) -> &str {
-        "Remove one Yolop hook by id from the selected scope. Workspace removal also writes a \
-         disabled marker so a lower-precedence global hook with the same id stays disabled."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": {
-                    "type": "string",
-                    "enum": ["global", "workspace"]
-                },
-                "id": {
-                    "type": "string",
-                    "description": "Stable hook id to remove or disable."
-                }
-            },
-            "required": ["scope", "id"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let scope = match parse_scope_arg(&arguments) {
-            Ok(scope) => scope,
-            Err(error) => return ToolExecutionResult::tool_error(error),
-        };
-        let id = match arguments.get("id").and_then(Value::as_str) {
-            Some(id) if !id.trim().is_empty() => id,
-            _ => return ToolExecutionResult::tool_error("'id' is required"),
-        };
-        match self.hooks.remove_hook(scope, id) {
-            Ok(removed) => ToolExecutionResult::success(json!({
-                "ok": true,
-                "removed": removed,
-                "id": id,
-                "scope": scope.as_str(),
-                "path": self.hooks.path_for(scope).display().to_string(),
-            })),
-            Err(error) => {
-                ToolExecutionResult::tool_error(format!("could not remove hook: {error}"))
+            .unwrap_or_default();
+        match operation {
+            "list" => {
+                let effective = self.hooks.effective();
+                ToolExecutionResult::success(json!({
+                    "hooks": effective.summaries(),
+                    "disabled_contributions": effective.disabled_contributions,
+                    "paths": {
+                        "global": effective.global_path,
+                        "workspace": effective.workspace_path,
+                    }
+                }))
             }
+            "validate" => {
+                let Some(hook) = action.get("hook") else {
+                    return ToolExecutionResult::tool_error("hook is required");
+                };
+                match self.hooks.validate_hook(hook) {
+                    Ok(validated) => ToolExecutionResult::success(json!({
+                        "valid": true,
+                        "hook": validated.to_validation_json(),
+                    })),
+                    Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+                }
+            }
+            "upsert" => {
+                let scope = match parse_scope(action) {
+                    Ok(scope) => scope,
+                    Err(error) => return ToolExecutionResult::tool_error(error),
+                };
+                let Some(hook) = action.get("hook") else {
+                    return ToolExecutionResult::tool_error("hook is required");
+                };
+                match self.hooks.upsert_hook(scope, hook.clone()) {
+                    Ok(saved) => ToolExecutionResult::success(json!({
+                        "ok": true,
+                        "hook": saved.to_summary_json(),
+                    })),
+                    Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+                }
+            }
+            "remove" => {
+                let scope = match parse_scope(action) {
+                    Ok(scope) => scope,
+                    Err(error) => return ToolExecutionResult::tool_error(error),
+                };
+                let id = action.get("id").and_then(Value::as_str).unwrap_or_default();
+                match self.hooks.remove_hook(scope, id) {
+                    Ok(removed) => ToolExecutionResult::success(json!({
+                        "ok": true,
+                        "id": id,
+                        "scope": scope.as_str(),
+                        "removed": removed,
+                    })),
+                    Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+                }
+            }
+            _ => ToolExecutionResult::tool_error(format!(
+                "unsupported hooks operation `{operation}`; expected list, validate, upsert, or remove"
+            )),
         }
+    }
+
+    fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+        response.render_default()
     }
 }
 
-fn parse_scope_arg(arguments: &Value) -> std::result::Result<HookScope, String> {
-    let scope = arguments
+fn parse_scope(action: &Value) -> Result<HookScope, String> {
+    let raw = action
         .get("scope")
         .and_then(Value::as_str)
-        .ok_or_else(|| "'scope' is required".to_string())?;
-    HookScope::parse(scope).map_err(|error| error.to_string())
-}
-
-fn hook_value_schema() -> Value {
-    json!({
-        "type": "object",
-        "properties": {
-            "hook": {
-                "type": "object",
-                "description": "A UserHookSpec object."
-            }
-        },
-        "required": ["hook"],
-        "additionalProperties": false
-    })
+        .unwrap_or("global");
+    HookScope::parse(raw).map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn hooks_in_tmp() -> (tempfile::TempDir, HooksStore) {
-        let tmp = tempfile::tempdir().expect("hooks tmp");
-        let store = HooksStore::new(tmp.path().join("hooks.json"), tmp.path().join("workspace"));
-        (tmp, store)
-    }
+    use std::path::PathBuf;
 
     #[test]
-    fn capability_exposes_unprefixed_hook_tools_without_slash_command() {
-        let (_hooks_tmp, hooks) = hooks_in_tmp();
-        let capability = HooksCapability {
-            hooks: Arc::new(hooks),
-        };
-
-        let names = capability
-            .tools()
-            .iter()
-            .map(|tool| tool.name().to_string())
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            names,
-            vec!["list_hooks", "validate_hook", "upsert_hook", "remove_hook"]
-        );
-        assert!(capability.commands().is_empty());
-    }
-
-    fn block_git_hook() -> Value {
-        json!({
-            "id": "block-git",
-            "event": "pre_tool_use",
-            "matcher": {
-                "tool_name": "bash",
-                "args_jsonpath": "$.command",
-                "match_regex": "(^|[;&|()[:space:]])git([[:space:]]|$)"
-            },
-            "executor": {
-                "type": "bash",
-                "command": "printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"blocked\"}'"
-            },
-            "timeout_ms": 1000,
-            "on_error": "block",
-            "description": "Block git"
-        })
-    }
-
-    #[tokio::test]
-    async fn hook_tools_validate_save_list_and_remove() {
-        let (_tmp, hooks) = hooks_in_tmp();
-        let hooks = Arc::new(hooks);
-        let validate = ValidateHookTool {
-            hooks: hooks.clone(),
-        };
-        let validated = validate.execute(json!({ "hook": block_git_hook() })).await;
-        assert!(validated.is_success());
-
-        let upsert = UpsertHookTool {
-            hooks: hooks.clone(),
-        };
-        let saved = upsert
-            .execute(json!({ "scope": "global", "hook": block_git_hook() }))
-            .await;
-        assert!(saved.is_success());
-
-        let list = ListHooksTool {
-            hooks: hooks.clone(),
-        };
-        let listed = list.execute(json!({})).await;
-        assert!(listed.is_success());
-
-        let remove = RemoveHookTool {
-            hooks: hooks.clone(),
-        };
-        let removed = remove
-            .execute(json!({ "scope": "global", "id": "block-git" }))
-            .await;
-        assert!(removed.is_success());
-        assert!(hooks.effective().hooks.is_empty());
+    fn hooks_capability_exposes_control_not_agent_tools() {
+        let capability = HooksCapability::new(HooksStore::new(
+            PathBuf::from("/tmp/yolop-hooks.json"),
+            PathBuf::from("/tmp/yolop-workspace"),
+        ));
+        assert!(capability.tools().is_empty());
+        assert_eq!(capability.control_route().resource, "hooks");
+        assert_eq!(capability.control_route().cli_subcommand, "config hooks");
     }
 }

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -82,6 +82,7 @@ pub(crate) use session_coordination::{
 };
 pub(crate) use session_history::{SESSION_HISTORY_CAPABILITY_ID, SessionHistoryCapability};
 pub(crate) use setup_cli::SetupCliCapability;
+pub(crate) use skills::{SkillDirs, SkillManagementCapability};
 pub(crate) use tool_approval::{ApprovalDecision, ToolApprovalCapability, ToolApprover};
 pub(crate) use tool_argument_validation::{
     TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID, ToolArgumentValidationCapability,

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -22,6 +22,9 @@
 //   * system    — pre-packed, materialized once          (read-only; override: YOLOP_SYSTEM_SKILLS_DIR)
 
 use crate::capabilities::narration::stable_labeled;
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
 use async_trait::async_trait;
 use everruns_builtins::{SkillDirResolver, SkillScope, SkillsConfig};
 use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
@@ -29,7 +32,9 @@ use everruns_core::{Capability, CapabilityStatus};
 use everruns_core::{Tool, ToolExecutionResult};
 use everruns_provider::ToolCall;
 use include_dir::{Dir, include_dir};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -146,7 +151,7 @@ pub fn skills_config(dirs: &SkillDirs, extensions: &[(String, PathBuf)]) -> Skil
                 .map(|(name, dir)| (extension_skills_label(name), dir.clone()))
                 .collect(),
         }),
-        manage_tools: true,
+        manage_tools: false,
     }
 }
 
@@ -343,12 +348,7 @@ fn write_if_changed(target: &Path, contents: &[u8]) -> std::io::Result<()> {
 
 pub(crate) const SKILL_MANAGEMENT_CAPABILITY_ID: &str = "yolop_skill_management";
 
-/// Skill removal for yolop's writable scopes. The upstream
-/// `ScopedSkillsCapability` owns discovery and `list/activate/read/write_skill`
-/// but has no uninstall, so yolop contributes `delete_skill` here. It operates
-/// on the same workspace/global directories the resolver exposes (system stays
-/// read-only), giving the agent a first-class, conversational uninstall instead
-/// of shelling out to `rm`.
+/// Detached skill package and registry administration.
 pub(crate) struct SkillManagementCapability {
     dirs: SkillDirs,
     registry: crate::capabilities::skill_registry::SkillRegistryClient,
@@ -369,35 +369,301 @@ impl Capability for SkillManagementCapability {
         SKILL_MANAGEMENT_CAPABILITY_ID
     }
     fn name(&self) -> &str {
-        "Skill Management"
+        "Skill management CLI"
     }
     fn description(&self) -> &str {
-        "Search skills.sh, install registry skills, and uninstall workspace/global skills."
+        "Detached skill package and registry administration."
     }
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
     }
-    fn category(&self) -> Option<&str> {
-        Some("Examples")
-    }
-    fn system_prompt_addition(&self) -> Option<&str> {
-        // Tool descriptions already cover search → ask → install, and that
-        // system skills are read-only.
-        None
-    }
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(crate::capabilities::skill_registry::SearchSkillsTool::new(
-                self.registry.clone(),
-            )),
-            Box::new(crate::capabilities::skill_registry::InstallSkillTool::new(
-                self.dirs.clone(),
-                self.registry.clone(),
-            )),
-            Box::new(DeleteSkillTool {
-                dirs: self.dirs.clone(),
-            }),
-        ]
+        Vec::new()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub(crate) enum SkillsAction {
+    List,
+    Read {
+        name: String,
+    },
+    Activate {
+        name: String,
+    },
+    Write {
+        name: String,
+        content: String,
+        scope: Option<String>,
+    },
+    Delete {
+        name: String,
+        scope: Option<String>,
+    },
+    Search {
+        query: String,
+    },
+    Install {
+        source: String,
+        scope: Option<String>,
+    },
+}
+
+#[async_trait]
+impl ControlCapability for SkillManagementCapability {
+    fn control_route(&self) -> ControlRoute {
+        ControlRoute {
+            resource: "skills",
+            cli_subcommand: "skills",
+            read_only_operations: &["list", "read", "search"],
+            summary: "installed skill management",
+        }
+    }
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let Ok(action) = serde_json::from_value::<SkillsAction>(action.clone()) else {
+            return ToolExecutionResult::tool_error("invalid skills action");
+        };
+        match action {
+            SkillsAction::Activate { name } => match self.read_skill(&name) {
+                Ok(value) => ToolExecutionResult::success(value),
+                Err(error) => ToolExecutionResult::tool_error(error),
+            },
+            SkillsAction::Write {
+                name,
+                content,
+                scope,
+            } => match self.write_skill(&name, &content, scope.as_deref()) {
+                Ok(value) => ToolExecutionResult::success(value),
+                Err(error) => ToolExecutionResult::tool_error(error),
+            },
+            SkillsAction::Delete { name, scope } => {
+                DeleteSkillTool {
+                    dirs: self.dirs.clone(),
+                }
+                .execute(
+                    json!({"name": name, "scope": scope.unwrap_or_else(|| "workspace".into())}),
+                )
+                .await
+            }
+            SkillsAction::Search { query } => {
+                crate::capabilities::skill_registry::SearchSkillsTool::new(self.registry.clone())
+                    .execute(json!({"query": query}))
+                    .await
+            }
+            SkillsAction::Install { source, scope } => {
+                crate::capabilities::skill_registry::InstallSkillTool::new(
+                    self.dirs.clone(),
+                    self.registry.clone(),
+                )
+                .execute(
+                    json!({"source": source, "scope": scope.unwrap_or_else(|| "workspace".into())}),
+                )
+                .await
+            }
+            SkillsAction::List => {
+                let mut skills = Vec::new();
+                for (scope, base) in self.readable_scopes() {
+                    let Ok(entries) = std::fs::read_dir(base) else {
+                        continue;
+                    };
+                    for entry in entries.flatten() {
+                        if entry.path().join("SKILL.md").is_file() {
+                            skills.push(json!({"name": entry.file_name().to_string_lossy(), "scope": scope}));
+                        }
+                    }
+                }
+                ToolExecutionResult::success(json!({"skills": skills}))
+            }
+            SkillsAction::Read { name } => match self.read_skill(&name) {
+                Ok(value) => ToolExecutionResult::success(value),
+                Err(error) => ToolExecutionResult::tool_error(error),
+            },
+        }
+    }
+    fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+        response.render_default()
+    }
+}
+
+#[derive(clap::Args)]
+struct SkillsCommandLine {
+    #[command(subcommand)]
+    command: SkillsCommand,
+}
+#[derive(clap::Subcommand)]
+enum SkillsCommand {
+    List,
+    Read {
+        name: String,
+    },
+    Activate {
+        name: String,
+    },
+    Write {
+        name: String,
+        /// Read SKILL.md from this path. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "content")]
+        file: Option<PathBuf>,
+        /// Set short SKILL.md text directly. Prefer `--file` or stdin for substantial files.
+        #[arg(
+            long,
+            value_name = "TEXT",
+            allow_hyphen_values = true,
+            conflicts_with = "file"
+        )]
+        content: Option<String>,
+        #[arg(long, value_parser = ["workspace", "global"])]
+        scope: Option<String>,
+    },
+    Delete {
+        name: String,
+        #[arg(long, value_parser = ["workspace", "global"])]
+        scope: Option<String>,
+    },
+    Search {
+        query: String,
+    },
+    Install {
+        source: String,
+        #[arg(long, value_parser = ["workspace", "global"])]
+        scope: Option<String>,
+    },
+}
+impl SkillsCommandLine {
+    fn action(matches: &clap::ArgMatches) -> anyhow::Result<SkillsAction> {
+        use clap::FromArgMatches;
+        let cli = Self::from_arg_matches(matches)?;
+        Ok(match cli.command {
+            SkillsCommand::List => SkillsAction::List,
+            SkillsCommand::Read { name } => SkillsAction::Read { name },
+            SkillsCommand::Activate { name } => SkillsAction::Activate { name },
+            SkillsCommand::Write {
+                name,
+                file,
+                content,
+                scope,
+            } => SkillsAction::Write {
+                name,
+                content: read_skill_input(file.as_deref(), content)?,
+                scope,
+            },
+            SkillsCommand::Delete { name, scope } => SkillsAction::Delete { name, scope },
+            SkillsCommand::Search { query } => SkillsAction::Search { query },
+            SkillsCommand::Install { source, scope } => SkillsAction::Install { source, scope },
+        })
+    }
+}
+
+#[async_trait]
+impl CliCapability for SkillManagementCapability {
+    fn cli_command(&self) -> clap::Command {
+        use clap::Args;
+        SkillsCommandLine::augment_args(clap::Command::new("skills"))
+    }
+    fn control_request_from_cli(
+        &self,
+        matches: &clap::ArgMatches,
+    ) -> anyhow::Result<ControlRequest> {
+        let action = SkillsCommandLine::action(matches)?;
+        Ok(ControlRequest::new(self.control_route().resource, action)?)
+    }
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let response =
+            ControlResponse::from_tool_result(self.execute_control(&request.action).await);
+        let rendered = response.render_default();
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            anyhow::bail!(rendered)
+        }
+    }
+}
+
+const MAX_SKILL_MD_BYTES: u64 = 1024 * 1024;
+
+fn read_skill_input(file: Option<&Path>, content: Option<String>) -> anyhow::Result<String> {
+    if let Some(content) = content {
+        if content.len() as u64 > MAX_SKILL_MD_BYTES {
+            anyhow::bail!("skill content exceeds the 1 MiB limit");
+        }
+        return Ok(content);
+    }
+
+    if let Some(path) = file.filter(|path| *path != Path::new("-")) {
+        let file = std::fs::File::open(path)
+            .map_err(|error| anyhow::anyhow!("failed to open {}: {error}", path.display()))?;
+        return read_bounded_skill_input(file, &format!("skill file {}", path.display()));
+    }
+
+    let stdin = std::io::stdin();
+    if stdin.is_terminal() {
+        anyhow::bail!(
+            "no skill content provided; pass --file PATH, --content TEXT, or pipe SKILL.md on stdin"
+        );
+    }
+    read_bounded_skill_input(stdin.lock(), "skill content from stdin")
+}
+
+fn read_bounded_skill_input(reader: impl Read, source: &str) -> anyhow::Result<String> {
+    let mut bytes = Vec::new();
+    reader
+        .take(MAX_SKILL_MD_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| anyhow::anyhow!("failed to read {source}: {error}"))?;
+    if bytes.len() as u64 > MAX_SKILL_MD_BYTES {
+        anyhow::bail!("{source} exceeds the 1 MiB limit");
+    }
+    String::from_utf8(bytes).map_err(|error| anyhow::anyhow!("{source} is not UTF-8: {error}"))
+}
+
+impl SkillManagementCapability {
+    fn readable_scopes(&self) -> Vec<(&str, &Path)> {
+        let mut scopes = vec![("workspace", self.dirs.workspace.as_path())];
+        if let Some(path) = &self.dirs.profile {
+            scopes.push(("profile", path.as_path()));
+        }
+        if let Some(path) = &self.dirs.global {
+            scopes.push(("global", path.as_path()));
+        }
+        if let Some(path) = &self.dirs.environment {
+            scopes.push(("environment", path.as_path()));
+        }
+        if let Some(path) = &self.dirs.system {
+            scopes.push(("system", path.as_path()));
+        }
+        scopes
+    }
+    fn write_skill(&self, name: &str, content: &str, scope: Option<&str>) -> Result<Value, String> {
+        validate_skill_name(name)?;
+        let base = match scope.unwrap_or("workspace") {
+            "workspace" => self.dirs.workspace.clone(),
+            "global" => self
+                .dirs
+                .global
+                .clone()
+                .ok_or_else(|| "global skills scope is not configured".to_string())?,
+            other => return Err(format!("unsupported writable scope `{other}`")),
+        };
+        let dir = base.join(name);
+        std::fs::create_dir_all(&dir).map_err(|error| error.to_string())?;
+        std::fs::write(dir.join("SKILL.md"), content).map_err(|error| error.to_string())?;
+        Ok(
+            json!({"name": name, "scope": scope.unwrap_or("workspace"), "path": dir.join("SKILL.md")}),
+        )
+    }
+
+    fn read_skill(&self, name: &str) -> Result<Value, String> {
+        validate_skill_name(name)?;
+        for (scope, base) in self.readable_scopes() {
+            let path = base.join(name).join("SKILL.md");
+            if path.is_file() {
+                let content = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+                return Ok(json!({"name": name, "scope": scope, "path": path, "content": content}));
+            }
+        }
+        Err(format!("skill `{name}` was not found"))
     }
 }
 
@@ -621,7 +887,7 @@ mod tests {
         let cfg = skills_config(&dirs, &[]);
         let labels: Vec<&str> = cfg.scopes.iter().map(|s| s.label.as_str()).collect();
         assert_eq!(labels, vec!["workspace", "system"]);
-        assert!(cfg.manage_tools);
+        assert!(!cfg.manage_tools);
         // System scope is read-only; workspace is writable.
         assert!(
             !cfg.scopes
@@ -807,7 +1073,7 @@ mod tests {
     // ---------- delete_skill ----------
 
     #[test]
-    fn skill_management_capability_exposes_search_install_delete() {
+    fn skill_management_capability_exposes_cli_not_agent_tools() {
         let dirs = SkillDirs {
             workspace: PathBuf::from("/ws/.agents/skills"),
             global: None,
@@ -816,35 +1082,9 @@ mod tests {
             environment: None,
         };
         let capability = SkillManagementCapability::new(dirs);
-        let names: Vec<String> = capability
-            .tools()
-            .iter()
-            .map(|t| t.name().to_string())
-            .collect();
-        for expected in ["search_skills", "install_skill", "delete_skill"] {
-            assert!(
-                names.iter().any(|n| n == expected),
-                "{expected} should be exposed: {names:?}"
-            );
-        }
-        // Guidance belongs to the tools, not to a per-turn prompt block:
-        // the descriptions are already in context whenever the tools are offered.
-        assert!(
-            capability.system_prompt_addition().is_none(),
-            "skill management guidance lives in the tool descriptions"
-        );
-        let description = capability
-            .tools()
-            .into_iter()
-            .find(|t| t.name() == "delete_skill")
-            .expect("delete_skill")
-            .description()
-            .to_string();
-        assert!(description.contains("workspace"));
-        // The read-only system scope is the one thing the schema cannot express;
-        // routing between delete/write lives in the skill-management skill, not
-        // in provider-visible description bytes.
-        assert!(description.contains("System skills cannot be deleted"));
+        assert!(capability.tools().is_empty());
+        assert_eq!(capability.control_route().resource, "skills");
+        assert_eq!(capability.cli_command().get_name(), "skills");
     }
 
     /// Build a tool whose workspace/global scopes point at fresh temp dirs.

--- a/src/config/hooks.rs
+++ b/src/config/hooks.rs
@@ -49,7 +49,7 @@ pub struct HooksFile {
     pub disabled_contributions: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ResolvedHook {
     pub scope: HookScope,
     pub path: PathBuf,
@@ -95,7 +95,7 @@ impl ResolvedHook {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct EffectiveHooks {
     pub global_path: PathBuf,
     pub workspace_path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1422,7 +1422,7 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
     let capability = Arc::new(
         extensions::ExtensionsCapability::new(
             extensions_dir,
-            workspace,
+            workspace.clone(),
             settings.clone(),
             extensions::LiveProcessRegistry::default(),
             None,
@@ -1456,6 +1456,9 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
     registry.register(Arc::new(
         capabilities::SessionCoordinationCapability::detached(coordination_store),
     ))?;
+    registry.register(Arc::new(capabilities::SkillManagementCapability::new(
+        capabilities::SkillDirs::resolve(&workspace, None),
+    )))?;
     Ok(registry)
 }
 
@@ -2353,6 +2356,28 @@ mod tests {
         assert!(trace_ansi_enabled(&print));
         assert!(trace_ansi_enabled(&command));
         assert!(!trace_ansi_enabled(&acp));
+    }
+
+    #[tokio::test]
+    async fn detached_management_commands_dispatch() {
+        let registry = detached_cli_registry().expect("build detached CLI registry");
+        for argv in [
+            vec!["yolop", "config", "hooks", "list"],
+            vec!["yolop", "skills", "list"],
+        ] {
+            let root = registry
+                .augment(Cli::command())
+                .expect("augment root command");
+            let matches = root.try_get_matches_from(argv).expect("parse command");
+            let invocation = registry
+                .invocation(&matches)
+                .expect("route detached command")
+                .expect("management command was not dispatched");
+            invocation
+                .execute()
+                .await
+                .expect("execute detached command");
+        }
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1214,6 +1214,10 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     "ast_grep",
     "write_todos",
     "write_session_title",
+    // Skill discovery and activation are core prompt-routing operations. Keep
+    // their complete schemas eager even though the CLI duplicates them.
+    "list_skills",
+    "activate_skill",
     // The most-called tool in the harness, and the one a deferred stub hurts
     // most: the stub names no parameters while declaring
     // `additionalProperties: true`, so a model fills the gap from other
@@ -2411,11 +2415,6 @@ fn default_coding_harness_capabilities(client_commands: bool) -> Vec<CapabilityR
         ),
         CapabilityRef::new(SESSION_FILE_SYSTEM_CAPABILITY_ID),
         CapabilityRef::new(SKILLS_CAPABILITY_ID),
-        // Registering `SkillManagementCapability` is not enough — a capability
-        // the harness never enables contributes no tools, which left
-        // `search_skills` / `install_skill` / `delete_skill` absent from the
-        // session while the skill-management skill documented them.
-        CapabilityRef::new(crate::capabilities::skills::SKILL_MANAGEMENT_CAPABILITY_ID),
         CapabilityRef::new(HERDR_CAPABILITY_ID),
         CapabilityRef::new(REPO_MAP_CAPABILITY_ID),
         CapabilityRef::new(SESSION_HISTORY_CAPABILITY_ID),
@@ -3685,8 +3684,8 @@ pub async fn build_with_options(
     // Skills (upstream `ScopedSkillsCapability`, wired in `crate::capabilities::skills`):
     //   * skills               — discovers SKILL.md across workspace / global /
     //                            environment / system scopes via the session file store;
-    //                            list_skills + activate_skill + read/write_skill
-    //   * skill_management     — search_skills / install_skill (skills.sh) + delete_skill
+    //                            model-visible tools are list_skills + activate_skill
+    //   * skill_management     — operator-only top-level `yolop skills` CLI
     //
     // Non-filesystem, but useful for a coding agent:
     //   * repo_map            - on-demand multi-language symbol map for broad codebase orientation
@@ -3732,10 +3731,9 @@ pub async fn build_with_options(
     // Herdr contributes a conditional, read-only skill mount. Outside a Herdr
     // pane it has no mounts and the reporter is inert.
     capabilities.register(HerdrCapability::new(herdr.is_active()));
-    // yolop-owned skill registry + uninstall (`search_skills`, `install_skill`,
-    // `delete_skill`); the upstream capability has list/activate/read/write only.
-    // Shares the same resolved scope directories.
-    capabilities.register(crate::capabilities::skills::SkillManagementCapability::new(
+    // Yolop-owned skill lifecycle operations are exposed through `yolop skills`.
+    // The upstream agent capability remains responsible for list/activate/read/write.
+    let skill_management = Arc::new(crate::capabilities::skills::SkillManagementCapability::new(
         skill_dirs.clone(),
     ));
     capabilities.register(RepoMapCapability::new(workspace_host.clone()));
@@ -3823,7 +3821,13 @@ pub async fn build_with_options(
     // iteration) without a yolop restart.
     let live_processes = crate::extensions::LiveProcessRegistry::default();
     let mut session_control_registry = crate::control::ControlRegistry::default();
+    session_control_registry.register(skill_management)?;
     session_control_registry.register(coordination_capability)?;
+    // Hook management is exposed through the control plane and `yolop config hooks`.
+    // Runtime execution is still upstream `user_hooks`, registered above.
+    let hooks_capability = Arc::new(HooksCapability::new((*hooks_store).clone()));
+    session_control_registry.register(hooks_capability.clone())?;
+    capabilities.register_arc(hooks_capability);
     // The persistent config CLI delegates catalog operations to the model list.
     // Runtime switching stays on the existing models control route, which shares
     // `ModelsCapability`'s controller with `/setup provider <name> <model>`.
@@ -4074,9 +4078,6 @@ pub async fn build_with_options(
         )),
         reveals: tool_reveals.clone(),
     });
-    // `hooks` — global/workspace hook self-configuration tools. Runtime
-    // execution is still upstream `user_hooks`, registered above.
-    capabilities.register(HooksCapability { hooks: hooks_store });
     // `yolop` — framing when the user addresses yolop itself, not the project.
     capabilities.register(YolopCapability);
     capabilities.register(YolopMcpCapability {
@@ -6963,22 +6964,8 @@ mod tests {
         assert!(unknown.message.contains("model <id>"));
     }
 
-    // The live-config tools (`set_provider` / `set_model` / `set_reasoning_effort`)
-    // and skill management tools (`search_skills` / `install_skill` / `delete_skill`)
-    // are registered via ModelsCapability / SkillManagementCapability
-    // in `build_with_options`. Because ToolSearchCapability defers the long tail
-    // behind `tool_search`, all three skill-management schemas remain deferred
-    // but discoverable until the model reveals them. Behavior is covered by the
-    // SkillRegistry / DeleteSkillTool unit tests.
-
-    /// Registering a capability is not the same as enabling it: the harness only
-    /// contributes tools for capabilities in its enabled set. Asserting presence
-    /// at the capability level once let `search_skills` / `install_skill` /
-    /// `delete_skill` disappear from real sessions while the skill-management
-    /// skill still told the model to call them, so this pins the assembled
-    /// session tool surface instead.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn skill_management_tools_reach_the_assembled_session() {
+    async fn assembled_session_exposes_only_activation_skill_tools() {
         let workspace = tempfile::tempdir().expect("workspace");
         let sessions = tempfile::tempdir().expect("sessions");
         let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
@@ -6997,17 +6984,26 @@ mod tests {
             .runtime
             .load_context(built.handles.session_id)
             .await
-            .expect("assemble cold-start context");
+            .expect("assemble context");
         let names: Vec<&str> = context
             .runtime_agent
             .tools
             .iter()
             .map(|tool| tool.name())
             .collect();
-        for expected in ["search_skills", "install_skill", "delete_skill"] {
+        assert!(names.contains(&"list_skills"));
+        assert!(names.contains(&"activate_skill"));
+        for removed in [
+            "read_skill",
+            "write_skill",
+            "delete_skill",
+            "search_skills",
+            "install_skill",
+            "list_hooks",
+        ] {
             assert!(
-                names.contains(&expected),
-                "{expected} missing from the assembled session tools: {names:?}"
+                !names.contains(&removed),
+                "{removed} remains exposed: {names:?}"
             );
         }
     }
@@ -8800,6 +8796,8 @@ mod tests {
             "ast_grep",
             "write_todos",
             "write_session_title",
+            "list_skills",
+            "activate_skill",
             "progress_checkpoint",
             // The shell is eager: a stub costs a correction round trip on the
             // most-called tool in the harness.
@@ -8816,9 +8814,6 @@ mod tests {
             "lsp_hover",
             "spawn_background",
             "search_sessions",
-            "activate_skill",
-            "search_skills",
-            "install_skill",
             "run_command",
             "search_models",
         ];
@@ -9095,17 +9090,11 @@ mod tests {
     async fn cold_start_prompt_composition_is_measured_by_component() {
         // Auto mode teaches the model to initialize its session worktree before mutation.
         // Skill scopes now advertise physical directories instead of synthetic roots.
-        const BASELINE_PROMPT_BYTES: usize = 14_402;
-        // The tool baselines model what today's surface would cost undeferred,
-        // so enabling a capability raises them by exactly that capability's
-        // undeferred cost — otherwise the ratio guards below would read a
-        // legitimately larger surface as lost savings. Enabling
-        // `yolop_skill_management` added `search_skills` (588 def / 409 schema),
-        // `install_skill` (854 / 582), and `delete_skill` (493 / 314).
-        // Includes the logical model, config, and setup command schemas that
-        // are intentionally eager so users can discover and invoke them.
-        const BASELINE_TOOL_DEFINITION_BYTES: usize = 31_158;
-        const BASELINE_SCHEMA_BYTES: usize = 15_845;
+        const BASELINE_PROMPT_BYTES: usize = 14_496;
+        // Includes the logical model, config, setup, and mandatory skill
+        // discovery/activation schemas that are intentionally eager.
+        const BASELINE_TOOL_DEFINITION_BYTES: usize = 28_901;
+        const BASELINE_SCHEMA_BYTES: usize = 13_414;
         let workspace = tempfile::tempdir().expect("workspace");
         let sessions = tempfile::tempdir().expect("sessions");
         let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
@@ -9183,13 +9172,13 @@ mod tests {
             tool_definition_bytes * 100 <= BASELINE_TOOL_DEFINITION_BYTES * 89,
             "provider-visible tool bytes must fall by at least 11%: {tool_definition_bytes} vs {BASELINE_TOOL_DEFINITION_BYTES}"
         );
-        // Keeping `bash`, batch reads, semantic code navigation, and the logical
-        // command schemas eager avoids measured correction or repeated-read rounds.
-        // Keep a historical floor while the compact profile evolves with the
-        // intentional eager schemas.
+        // Keeping `bash`, batch reads, semantic code navigation, and mandatory
+        // skill discovery/activation eager avoids measured correction rounds.
+        // This migration intentionally spends almost all prior schema savings
+        // on list_skills and activate_skill while staying below the baseline.
         assert!(
-            schema_bytes * 100 <= BASELINE_SCHEMA_BYTES * 93,
-            "schema bytes must remain at least 7% below the historical all-eager surface: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
+            schema_bytes <= BASELINE_SCHEMA_BYTES,
+            "schema bytes must remain below the historical all-eager surface: {schema_bytes} vs {BASELINE_SCHEMA_BYTES}"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2995,6 +2995,119 @@ fn openai_print_smoke() {
 }
 
 #[test]
+fn skills_cli_write_list_and_activate_uses_compiled_binary() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_dir = tmp.path().join("config");
+    let data_dir = tmp.path().join("data");
+    let workspace = tmp.path().join("workspace");
+    let global_skills = tmp.path().join("global-skills");
+    std::fs::create_dir(&workspace).expect("workspace");
+    let skill_file = tmp.path().join("SKILL.md");
+    let file_content = "---\nname: cli-file\ndescription: Installed from a file through the compiled CLI.\n---\n# CLI file\n\nThis skill proves file input.\n";
+    std::fs::write(&skill_file, file_content).expect("skill fixture");
+    let stdin_content = "---\nname: cli-stdin\ndescription: Installed from stdin through the compiled CLI.\n---\n# CLI stdin\n\nThis skill proves stdin input.\n";
+    let direct_content = "---\nname: cli-direct\ndescription: Installed from direct text through the compiled CLI.\n---\n# CLI direct\n";
+
+    let command = || {
+        let mut command = Command::new(yolop_binary());
+        command
+            .env("YOLOP_GLOBAL_SKILLS_DIR", &global_skills)
+            .args([
+                "--config-dir",
+                config_dir.to_str().unwrap(),
+                "--data-dir",
+                data_dir.to_str().unwrap(),
+                "-C",
+                workspace.to_str().unwrap(),
+            ]);
+        command
+    };
+
+    let file_write = command()
+        .args([
+            "skills",
+            "write",
+            "cli-file",
+            "--scope",
+            "global",
+            "--file",
+            skill_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn yolop skills write --file");
+    assert!(
+        file_write.status.success(),
+        "skills write --file failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&file_write.stdout),
+        String::from_utf8_lossy(&file_write.stderr)
+    );
+
+    let mut stdin_write = command()
+        .args(["skills", "write", "cli-stdin", "--scope", "global"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn yolop skills write on stdin");
+    std::io::Write::write_all(
+        stdin_write.stdin.as_mut().expect("stdin pipe"),
+        stdin_content.as_bytes(),
+    )
+    .expect("write skill stdin");
+    let stdin_write = stdin_write
+        .wait_with_output()
+        .expect("wait for stdin write");
+    assert!(
+        stdin_write.status.success(),
+        "skills write on stdin failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&stdin_write.stdout),
+        String::from_utf8_lossy(&stdin_write.stderr)
+    );
+
+    let direct_write = command()
+        .args([
+            "skills",
+            "write",
+            "cli-direct",
+            "--scope",
+            "global",
+            "--content",
+            direct_content,
+        ])
+        .output()
+        .expect("spawn yolop skills write --content");
+    assert!(direct_write.status.success());
+    assert!(global_skills.join("cli-file/SKILL.md").is_file());
+    assert!(global_skills.join("cli-stdin/SKILL.md").is_file());
+    assert!(global_skills.join("cli-direct/SKILL.md").is_file());
+
+    let list = command()
+        .args(["skills", "list"])
+        .output()
+        .expect("spawn yolop skills list");
+    let list_stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(list.status.success(), "skills list failed: {list_stdout}");
+    for name in ["cli-file", "cli-stdin", "cli-direct"] {
+        assert!(list_stdout.contains(name), "skill missing: {list_stdout}");
+    }
+
+    let activate = command()
+        .args(["skills", "activate", "cli-stdin"])
+        .output()
+        .expect("spawn yolop skills activate");
+    let activate_stdout = String::from_utf8_lossy(&activate.stdout);
+    assert!(
+        activate.status.success(),
+        "skills activate failed: stdout={activate_stdout} stderr={}",
+        String::from_utf8_lossy(&activate.stderr)
+    );
+    assert!(
+        activate_stdout.contains("This skill proves stdin input."),
+        "unexpected activation output: {activate_stdout}"
+    );
+}
+
+#[test]
 fn openai_multistep_completion_smoke() {
     let Some(_) = live_key_or_skip("OPENAI_API_KEY") else {
         return;


### PR DESCRIPTION
## Summary

- move hook management from model tools to `yolop config hooks`
- move skill read, write, registry search, install, and delete operations to `yolop skills`
- retain eager `list_skills` and `activate_skill` model tools for prompt routing
- support bounded skill writes from files, stdin, or short direct text
- update built-in guidance, public docs, durable specs, and test scenarios

## Before / After

**Before:** hook and skill mutations occupied the model tool surface, and complete skill bodies were passed through a tool call.

**After:** agents use attached CLI commands such as `yolop config hooks list`, `yolop skills search <query>`, and `cat SKILL.md | yolop skills write <name> --scope workspace`. `list_skills` and `activate_skill` remain eager tools. The compiled-binary integration test proves file, stdin, and direct-text writes followed by list and activation.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run --quiet -- --provider llmsim -p hi`

## Security

- **TM-FS:** hook and skill writes retain scope validation, traversal rejection, and existing atomic persistence. Skill file/stdin/direct inputs are UTF-8 validated and capped at 1 MiB through bounded reads.
- **TM-BASH:** no shell interpolation or execution behavior changed. The attached CLI remains a direct foreground invocation.
- **TM-LLM:** mutating management schemas leave the model-facing tool surface. No key handling changed.
- **TM-TOOL:** `list_skills` and `activate_skill` intentionally remain eager; removed hook and skill tools are asserted absent.
- **TM-DEP:** no dependencies added.

## Knowledge

Updated hooks, skills, configuration, and conversational-control concepts plus the durable knowledge log and affected live scenario.

## Follow-ups

- A deterministic compiled-binary registry-install test still needs an injectable skills.sh base URL and local mock server. Existing client-level registry tests remain in place.

Produced by [yolop](https://everruns.com/yolop)
