### PR TITLE
feat(cli): add realistic help examples

### DIFF
--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -58,6 +58,9 @@ enum ConfigCommand {
         #[command(subcommand)]
         command: Option<ModelsCliCommand>,
     },
+    #[command(
+        after_help = "Examples:\n  Reject edits to environment files before a write tool runs:\n    yolop config hooks set protect-env PreToolUse --matcher 'write_file|edit_file' --command ./scripts/reject-env-edits.sh --timeout-secs 5 --scope workspace\n\n  Disable a global hook for this workspace without deleting its global definition:\n    yolop config hooks set release-check PreToolUse --command true --scope workspace --disabled"
+    )]
     Hooks {
         #[command(subcommand)]
         command: HooksCommand,
@@ -201,7 +204,9 @@ impl ControlCapability for ConfigCapability {
 #[async_trait]
 impl CliCapability for ConfigCapability {
     fn cli_command(&self) -> clap::Command {
-        ConfigCommandLine::augment_args(Command::new("config"))
+        ConfigCommandLine::augment_args(Command::new("config")).after_help(
+            "Examples:\n  Inspect one capability override and its effective schema:\n    yolop config get capabilities.web_fetch\n\n  Add a labeled fallback immediately after the default model:\n    yolop config models add anthropic claude-sonnet-4-6 --label fallback --after default",
+        )
     }
 
     fn control_request_from_cli(

--- a/src/capabilities/model_cli.rs
+++ b/src/capabilities/model_cli.rs
@@ -44,6 +44,7 @@ impl ModelCliCapability {
     fn command() -> Command {
         Command::new(MODEL_ROUTE)
             .about("Show or switch the current session model")
+            .after_help("Examples:\n  Switch this session to the configured model labeled review:\n    yolop model use review\n\n  Temporarily use a high-effort model without changing defaults:\n    yolop model use openai/gpt-5.4:high")
             .subcommand(
                 Command::new("use")
                     .about("Switch the current session model without changing defaults")

--- a/src/capabilities/session_coordination.rs
+++ b/src/capabilities/session_coordination.rs
@@ -1237,6 +1237,7 @@ enum CoordinationCliCommand {
 #[command(
     name = "coordination",
     about = "Coordinate work across local Yolop sessions",
+    after_help = "Examples:\n  Delegate an isolated test task to a specific idle session:\n    yolop coordination dispatch --title 'Add parser tests' --request 'Cover malformed frontmatter' --target-session-id <session-id>\n\n  Finish assigned work and report validation plus the changed artifact:\n    yolop coordination complete --status succeeded --summary 'Fixed parser' --validation 'cargo test' --artifact src/parser.rs",
     disable_help_subcommand = true
 )]
 struct CoordinationCommandLine {

--- a/src/capabilities/setup_cli.rs
+++ b/src/capabilities/setup_cli.rs
@@ -45,6 +45,7 @@ impl SetupCliCapability {
     fn command() -> Command {
         Command::new(SETUP_CONTROL_ROUTE)
             .about("Set up provider authentication")
+            .after_help("Examples:\n  Replace an expired OpenAI credential:\n    yolop setup reauthenticate openai\n\n  Authenticate GitHub Copilot using its device-code flow:\n    yolop setup login github-copilot")
             .subcommand(Command::new("status").about("Show setup status"))
             .subcommand(
                 Command::new("login")

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -559,7 +559,9 @@ impl SkillsCommandLine {
 impl CliCapability for SkillManagementCapability {
     fn cli_command(&self) -> clap::Command {
         use clap::Args;
-        SkillsCommandLine::augment_args(clap::Command::new("skills"))
+        SkillsCommandLine::augment_args(clap::Command::new("skills")).after_help(
+            "Examples:\n  Install a registry skill only for this repository:\n    yolop skills install cloudflare/skills/cloudflare --scope workspace\n\n  Replace a substantial global skill from a reviewed local file:\n    yolop skills write release-checklist --file ./SKILL.md --scope global",
+        )
     }
     fn control_request_from_cli(
         &self,

--- a/src/capabilities/worktree_cmd.rs
+++ b/src/capabilities/worktree_cmd.rs
@@ -24,7 +24,11 @@ pub(crate) const WORKTREE_CONTROL_ROUTE: ControlRoute = ControlRoute {
 };
 
 #[derive(Debug, Clone, Parser)]
-#[command(name = "worktree", about = "Control this session's Yolop worktree")]
+#[command(
+    name = "worktree",
+    about = "Control this session's Yolop worktree",
+    after_help = "Examples:\n  Preview cleanup of worktrees no longer referenced by saved sessions:\n    yolop worktree prune --dry-run\n\n  Inspect the active session's policy and workspace path:\n    yolop worktree status"
+)]
 struct WorktreeCommandLine {
     #[command(subcommand)]
     command: WorktreeCliCommand,

--- a/src/extensions/manage.rs
+++ b/src/extensions/manage.rs
@@ -136,6 +136,7 @@ enum ExtensionSecretCommand {
 #[command(
     name = "extensions",
     about = "Manage Yolop extensions. A direct invocation from Yolop's foreground Bash updates the current session as well as persisted state",
+    after_help = "Examples:\n  Scaffold a Python extension with a command and a tool:\n    yolop extensions scaffold release-notes --command draft --tool changelog --dir ./extensions\n\n  Apply an extension's updated package without restarting Yolop:\n    yolop extensions reload release-notes",
     disable_help_subcommand = true
 )]
 struct ExtensionCommandLine {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -113,6 +113,56 @@ fn coordination_cli_advertises_dispatch_and_completion() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("dispatch"), "stdout={stdout}");
     assert!(stdout.contains("complete"), "stdout={stdout}");
+    assert!(
+        stdout.contains("yolop coordination dispatch --title 'Add parser tests'"),
+        "stdout={stdout}"
+    );
+}
+
+#[test]
+fn command_group_help_includes_realistic_examples() {
+    let cases = [
+        (
+            &["config", "--help"][..],
+            "yolop config get capabilities.web_fetch",
+        ),
+        (&["model", "--help"][..], "yolop model use review"),
+        (
+            &["setup", "--help"][..],
+            "yolop setup reauthenticate openai",
+        ),
+        (
+            &["worktree", "--help"][..],
+            "yolop worktree prune --dry-run",
+        ),
+        (
+            &["extensions", "--help"][..],
+            "yolop extensions reload release-notes",
+        ),
+        (
+            &["skills", "--help"][..],
+            "yolop skills install cloudflare/skills/cloudflare --scope workspace",
+        ),
+        (
+            &["config", "hooks", "--help"][..],
+            "yolop config hooks set protect-env PreToolUse",
+        ),
+    ];
+
+    for (args, example) in cases {
+        let output = Command::new(yolop_binary())
+            .args(args)
+            .output()
+            .unwrap_or_else(|error| panic!("show help for {args:?}: {error}"));
+        assert!(
+            output.status.success(),
+            "args={args:?}, stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("Examples:"), "args={args:?}, stdout={stdout}");
+        assert!(stdout.contains(example), "args={args:?}, stdout={stdout}");
+    }
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -160,7 +160,10 @@ fn command_group_help_includes_realistic_examples() {
             String::from_utf8_lossy(&output.stderr)
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("Examples:"), "args={args:?}, stdout={stdout}");
+        assert!(
+            stdout.contains("Examples:"),
+            "args={args:?}, stdout={stdout}"
+        );
         assert!(stdout.contains(example), "args={args:?}, stdout={stdout}");
     }
 }


### PR DESCRIPTION
## What

Add one or two realistic workflow examples to the help output for config, model, setup, coordination, worktree, extensions, skills, and config hooks command groups.

Add integration coverage that runs each affected help route through the compiled binary and asserts its example is rendered.

## Why

Agents and users need examples that demonstrate useful option combinations and real workflows, not restatements of basic command syntax.

## How

Attach curated `after_help` text to each command's owning clap definition. Keep nested hooks examples on `config hooks`, where that group is defined.

## Before / After

Before, `yolop config --help` ended after its arguments and options.

After:

```console
Examples:
  Inspect one capability override and its effective schema:
    yolop config get capabilities.web_fetch

  Add a labeled fallback immediately after the default model:
    yolop config models add anthropic claude-sonnet-4-6 --label fallback --after default
```

The same `Examples:` section now appears on the other affected group help screens.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema`
- `cargo run --quiet -- --provider llmsim -p 'Reply with exactly: help examples smoke ok'`
- Manual rendered output checks for all affected `--help` routes

The first full test run had one transient timing failure in `capabilities::herdr::tests::monitor_reports_turn_lifecycle_and_releases_the_agent`; the focused retry and a second full workspace run passed.

## Risk

Low. This changes static clap help metadata and adds binary-level assertions. Command parsing and execution are unchanged.

## Security

No security-relevant behavior changes. Reviewed TM-FS, TM-BASH, TM-LLM, TM-TOOL, and TM-DEP: the examples are static help strings, add no execution paths, expose no data, and add no dependencies.

## Knowledge

No knowledge update required. This is discoverability text for existing commands and does not alter durable behavior, architecture, policy, or maintainer process.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
