### PR TITLE
chore(release): prepare v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.17.2](https://github.com/everruns/yolop/releases/tag/v0.17.2) - 2026-08-31
+
+* feat(config): unify configuration commands ([#639](https://github.com/everruns/yolop/pull/639)) by @chaliy
+* feat(worktree): make auto initialization model-driven ([#640](https://github.com/everruns/yolop/pull/640)) by @chaliy
+* feat(models): default to the gpt-5.6 line and Claude 5 ([#641](https://github.com/everruns/yolop/pull/641)) by @chaliy
+* fix(agent): redirect repeated reads to semantic tools ([#642](https://github.com/everruns/yolop/pull/642)) by @chaliy
+* refactor(filesystem): use physical repository paths ([#643](https://github.com/everruns/yolop/pull/643)) by @chaliy
+* fix(agent): harden ACP compaction and shell failures ([#644](https://github.com/everruns/yolop/pull/644)) by @chaliy
+* feat(commands): redesign model and setup controls ([#645](https://github.com/everruns/yolop/pull/645)) by @chaliy
+* feat(tui): render help as markdown ([#646](https://github.com/everruns/yolop/pull/646)) by @chaliy
+* fix(tui): keep wide Mermaid diagrams rendered ([#647](https://github.com/everruns/yolop/pull/647)) by @chaliy
+* feat(subagents): allow depth-two delegation ([#648](https://github.com/everruns/yolop/pull/648)) by @chaliy
+* fix(codex): re-probe native compaction availability ([#649](https://github.com/everruns/yolop/pull/649)) by @chaliy
+* feat(cli): manage hooks and skills with commands ([#650](https://github.com/everruns/yolop/pull/650)) by @chaliy
+* feat(cli): add realistic help examples ([#651](https://github.com/everruns/yolop/pull/651)) by @chaliy
+
 All notable user-visible changes to yolop are recorded here.
 
 The format follows the [release spec](./knowledge/specs/release.md): one section per

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10041,7 +10041,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## Changelog

* feat(config): unify configuration commands ([#639](https://github.com/everruns/yolop/pull/639)) by @chaliy
* feat(worktree): make auto initialization model-driven ([#640](https://github.com/everruns/yolop/pull/640)) by @chaliy
* feat(models): default to the gpt-5.6 line and Claude 5 ([#641](https://github.com/everruns/yolop/pull/641)) by @chaliy
* fix(agent): redirect repeated reads to semantic tools ([#642](https://github.com/everruns/yolop/pull/642)) by @chaliy
* refactor(filesystem): use physical repository paths ([#643](https://github.com/everruns/yolop/pull/643)) by @chaliy
* fix(agent): harden ACP compaction and shell failures ([#644](https://github.com/everruns/yolop/pull/644)) by @chaliy
* feat(commands): redesign model and setup controls ([#645](https://github.com/everruns/yolop/pull/645)) by @chaliy
* feat(tui): render help as markdown ([#646](https://github.com/everruns/yolop/pull/646)) by @chaliy
* fix(tui): keep wide Mermaid diagrams rendered ([#647](https://github.com/everruns/yolop/pull/647)) by @chaliy
* feat(subagents): allow depth-two delegation ([#648](https://github.com/everruns/yolop/pull/648)) by @chaliy
* fix(codex): re-probe native compaction availability ([#649](https://github.com/everruns/yolop/pull/649)) by @chaliy
* feat(cli): manage hooks and skills with commands ([#650](https://github.com/everruns/yolop/pull/650)) by @chaliy
* feat(cli): add realistic help examples ([#651](https://github.com/everruns/yolop/pull/651)) by @chaliy

## Publish-readiness

- `cargo fmt --check`: passed
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`: passed
- `cargo test --workspace --features yolop-yep/schema`: passed
- `python3 scripts/validate_okf.py knowledge --check-links`: passed
- `cargo publish --dry-run -p yolop-yep`: passed
- `cargo publish --dry-run --locked --allow-dirty -p yolop`: passed
- crates.io currently serves `yolop` 0.17.1, below 0.17.2
- `Cargo.toml` and the `yolop` entry in `Cargo.lock` both report 0.17.2
- No `yolop-yep` or first-party extension source changed since v0.17.1, so their versions remain unchanged

## Post-merge verification

- [ ] `release.yml` succeeds and creates the v0.17.2 GitHub release
- [ ] `publish.yml` succeeds and crates.io serves `yolop` 0.17.2
- [ ] `cli-binaries.yml` builds the complete target matrix and attaches all expected archives
- [ ] `everruns/homebrew-tap` points the `yolop` formula at v0.17.2 with matching checksums

Produced by [yolop](https://everruns.com/yolop)
