### PR TITLE
fix(release): correct v0.17.2 changelog header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.17.2](https://github.com/everruns/yolop/releases/tag/v0.17.2) - 2026-08-31
+## [0.17.2] - 2026-08-31
 
 * feat(config): unify configuration commands ([#639](https://github.com/everruns/yolop/pull/639)) by @chaliy
 * feat(worktree): make auto initialization model-driven ([#640](https://github.com/everruns/yolop/pull/640)) by @chaliy


### PR DESCRIPTION
## Summary

Correct the 0.17.2 changelog header to the release workflow's specified format. The previous `v` prefix prevented `release.yml` from extracting release notes, so the workflow stopped before creating a tag or publishing artifacts.

## Validation

- Reproduced the failed workflow extraction against the merged header
- Verified the workflow's exact `awk` command extracts the complete 0.17.2 notes after this change
- `git diff --check` passes
- No tag, GitHub release, crate, or Homebrew update was created by the failed run

Produced by [yolop](https://everruns.com/yolop)
