### PR TITLE
fix(config): reduce repeated model help probes

### DIFF
--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -54,6 +54,15 @@ enum ConfigCommand {
         #[command(subcommand)]
         command: ConfigModelCommand,
     },
+    #[command(after_help = "Examples:
+  List models:
+    yolop config models list
+
+  Add a model:
+    yolop config models add codex gpt-5.6-sol --label sol
+
+  Remove a model:
+    yolop config models rm codex/gpt-5.6-sol")]
     Models {
         #[command(subcommand)]
         command: Option<ModelsCliCommand>,
@@ -1013,6 +1022,24 @@ mod tests {
         let command = ConfigCommandLine::augment_args(Command::new("config"));
         let matches = command.try_get_matches_from(args).expect("parse config");
         ConfigCommandLine::request(&matches).expect("config request")
+    }
+
+    #[test]
+    fn models_help_includes_common_command_forms() {
+        let mut command = ConfigCommandLine::augment_args(Command::new("config"));
+        let help = command
+            .find_subcommand_mut("models")
+            .expect("models subcommand")
+            .render_long_help()
+            .to_string();
+
+        for example in [
+            "yolop config models list",
+            "yolop config models add codex gpt-5.6-sol --label sol",
+            "yolop config models rm codex/gpt-5.6-sol",
+        ] {
+            assert!(help.contains(example), "missing help example: {example}");
+        }
     }
 
     #[test]

--- a/src/capabilities/model_list.rs
+++ b/src/capabilities/model_list.rs
@@ -37,7 +37,7 @@ pub(crate) const MODEL_LIST_CONTROL_ROUTE: ControlRoute = ControlRoute {
     resource: "models",
     cli_subcommand: "config",
     read_only_operations: &["list"],
-    summary: "show, reorder, and edit the model list, and switch this session to one of its models",
+    summary: "manage models and switch the session model",
 };
 
 #[derive(Subcommand, Debug)]

--- a/src/control.rs
+++ b/src/control.rs
@@ -321,8 +321,7 @@ impl ControlPlaneCapability {
             ));
         }
         prompt.push_str(
-            "Invoke it directly: a pipeline, redirection, quoting, substitution, or `&` runs as \
-             ordinary shell and loses the attachment.",
+            "Invoke directly: shell composition loses attachment. Do not repeat `--help`.",
         );
         Some(Self { prompt })
     }
@@ -792,7 +791,19 @@ mod tests {
         assert!(prompt.contains("- `extensions`, administer extension packages"));
         // Discovery points at the contributed help, not at a duplicated grammar.
         assert!(prompt.contains("`yolop <subcommand> --help`"));
-        assert!(prompt.contains("loses the attachment"));
+        assert!(prompt.contains("loses attachment"));
+    }
+
+    #[test]
+    fn control_plane_prompt_discourages_repeated_help_probes() {
+        let registry = service();
+        let capability = ControlPlaneCapability::new(&ControlService::routes(&registry))
+            .expect("a registered route contributes the block");
+        let prompt = capability
+            .system_prompt_addition()
+            .expect("the block is the capability's contribution");
+
+        assert!(prompt.contains("Do not repeat `--help`"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -147,6 +147,10 @@ fn command_group_help_includes_realistic_examples() {
             &["config", "hooks", "--help"][..],
             "yolop config hooks set protect-env PreToolUse",
         ),
+        (
+            &["config", "models", "--help"][..],
+            "yolop config models add codex gpt-5.6-sol --label sol",
+        ),
     ];
 
     for (args, example) in cases {


### PR DESCRIPTION
## Summary

- add complete list, add, and remove examples to `yolop config models --help`
- tell the control-plane prompt not to repeat `--help` calls
- shorten the model-list route summary to keep the always-on prompt within its budget

## Before / After

Before, `yolop config models --help` listed subcommands but required another help call to discover add or remove arguments.

After, the parent help includes directly usable forms:

```text
yolop config models list
yolop config models add codex gpt-5.6-sol --label sol
yolop config models rm codex/gpt-5.6-sol
```

The control-plane prompt now says `Do not repeat --help`.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run --quiet -- config models --help`
- `doppler run --project everruns-dev --config dev -- cargo run --quiet -- --provider openai -p "Reply with exactly: config help smoke passed"`

## Security

No security-relevant behavior changed. The change adds static CLI help and prompt text only, with no new input handling, filesystem access, shell execution, secrets, capabilities, or dependencies.

## Knowledge

No knowledge update required. This refines command discoverability without changing model-list behavior or policy.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
