### PR TITLE
fix: restore web fetch and direct MCP reload

### DIFF
--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -334,6 +334,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_command_emits_mcp_reload() {
+        let ui = Arc::new(RecordingUi::default());
+        let capability = ClientCommandsCapability::new(ui.clone());
+
+        let result = capability
+            .execute_command(
+                &ExecuteCommandRequest {
+                    name: "mcp".to_string(),
+                    arguments: Some("reload".to_string()),
+                    controls: None,
+                },
+                &CommandExecutionContext::without_host(SessionId::new()),
+            )
+            .await
+            .expect("execute /mcp reload");
+
+        assert!(result.success);
+        assert!(result.message.is_empty());
+        assert_eq!(
+            ui.take(),
+            vec![UiCommand::ManageMcp {
+                arg: Some("reload".to_string())
+            }]
+        );
+    }
+
+    #[tokio::test]
     async fn execute_command_rejects_names_this_capability_does_not_own() {
         let ui = Arc::new(RecordingUi::default());
         let capability = ClientCommandsCapability::new(ui.clone());

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4269,6 +4269,7 @@ pub async fn build_with_options(
     let platform = everruns_host::HostComposition::builder()
         .capability_registry(capabilities)
         .driver_registry(driver_registry)
+        .egress_service(everruns_host::runtime_egress_service())
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
             workspace: workspace_host.clone(),
             session_dir: session_dir.clone(),


### PR DESCRIPTION
## What changed

- wires the host runtime's direct outbound egress service into the manually composed Yolop host, so the built-in `web_fetch` capability can reach public URLs
- describes MCP restart/reconnect/reload requests as the existing typed `mcp reload` client command instead of leaving the model to emulate a slash command
- adds command-dispatch coverage proving MCP reload reaches `UiCommand::ManageMcp`

## Why

Local session `session_01a05f80b2807bd0a88ac94b26648010` exposed two lifecycle gaps. `web_fetch` failed because `HostComposition` retained its default disabled egress service. MCP reload was already owned by `RuntimeHandles::reload_mcp_servers`, but the agent-facing capability did not clearly expose reload/restart/reconnect as its direct typed command.

## Before / After

Before:

```text
web_fetch: outbound egress service is disabled
MCP restart intent: model attempted command indirection instead of a direct typed MCP reload
```

After:

```text
HostComposition -> runtime_egress_service() -> DirectEgressService
run_yolop_command { command: "mcp", arguments: "reload" }
  -> UiCommand::ManageMcp { arg: Some("reload") }
  -> RuntimeHandles::reload_mcp_servers()
```

Offline smoke: `cargo run --quiet -- --provider llmsim -p "hi"` completed successfully.

## Risk

- Low
- Public web fetches now use the host's intended direct egress implementation. Existing URL policy, redirect validation, response limits, and timeouts remain owned by the web-fetch integration.
- MCP reload uses the existing typed command and runtime reload path; no persistence semantics change.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required, this restores already-intended web fetch behavior and clarifies access to an existing MCP reload operation without changing durable architecture or policy.

## Security

- **TM-TOOL / TM-FS:** MCP configuration and reload boundaries are unchanged. The new assertion only covers typed command dispatch.
- **TM-LLM:** No key handling or prompt data exposure changes.
- **TM-BASH:** No shell execution changes.
- **TM-DEP:** No dependency changes.
- Web fetch now receives the host-provided direct egress service. The integration still owns URL validation, DNS/private-address protections, redirect checks, response-size caps, and timeout limits.

## Follow-ups

- Add a first-class `yolop mcp` CLI surface, analogous to `yolop extensions`, for list/show/add/remove/enable/disable/login/reload and live status. This is intentionally separate because it needs a shared MCP management abstraction spanning config persistence and attached runtime control, rather than more command aliases.

Produced by [yolop](https://everruns.com/yolop)
