### PR TITLE
fix(tui): remove agent status tool

### DIFF
--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -2078,7 +2078,7 @@ struct Mined {
 fn is_bookkeeping_tool(name: &str) -> bool {
     matches!(
         name,
-        "write_session_title" | "write_todos" | "set_status" | "progress_checkpoint"
+        "write_session_title" | "write_todos" | "progress_checkpoint"
     )
 }
 

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -17,18 +17,13 @@
 //! [`crate::capabilities::agent_commands`], which resolves names against the
 //! live registry rather than any list kept here.
 
-use crate::capabilities::narration::stable_labeled;
 use crate::tui::host_ui::{HostUi, UiCommand};
 use async_trait::async_trait;
 use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
-use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
 use everruns_core::{Capability, CapabilityStatus};
-use everruns_core::{Tool, ToolExecutionResult};
-use everruns_provider::ToolCall;
-use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
@@ -40,8 +35,6 @@ Terminal commands, all runnable with `run_command`: `/help`, `/tools`, `/mcp`,
 "clear the screen", "show tools", "switch model", "restart MCP", "reconnect MCP",
 or "refresh MCP" (`/mcp reload`), "log in to an MCP server" (`/mcp login <name>`);
 never invent a manager window. `/shell` is typed-only; use `bash`.
-`set_status` sets a concise live description of turn progress; it clears when the
-turn finishes, or send an empty value to clear it earlier.
 </capability>"#;
 
 pub(crate) struct ClientCommandsCapability {
@@ -77,12 +70,6 @@ impl Capability for ClientCommandsCapability {
 
     fn commands(&self) -> Vec<CommandDescriptor> {
         command_descriptors()
-    }
-
-    fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(SetStatusTool {
-            ui: self.ui.clone(),
-        })]
     }
 
     async fn execute_command(
@@ -195,72 +182,6 @@ fn arg(name: &str, required: bool) -> CommandArg {
     }
 }
 
-struct SetStatusTool {
-    ui: Arc<dyn HostUi>,
-}
-
-#[async_trait]
-impl Tool for SetStatusTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let status = arg_str(&tool_call.arguments, &["status"]).map(|value| truncate(value, 48));
-        Some(stable_labeled("Update status", status, phase))
-    }
-
-    fn name(&self) -> &str {
-        "set_status"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Status")
-    }
-
-    fn description(&self) -> &str {
-        "Set a concise, turn-scoped status shown in the interactive TUI. \
-         Use an empty status to clear it before the turn finishes."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "description": "Concise live progress, at most 120 characters. Empty clears it."
-                }
-            },
-            "required": ["status"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let Some(raw) = arguments.get("status").and_then(Value::as_str) else {
-            return ToolExecutionResult::tool_error("'status' is required");
-        };
-        let status = raw.trim();
-        if status.chars().count() > 120 {
-            return ToolExecutionResult::tool_error("status must be at most 120 characters");
-        }
-        if status.chars().any(char::is_control) {
-            return ToolExecutionResult::tool_error("status must be a single printable line");
-        }
-        self.ui.send(UiCommand::SetAgentStatus {
-            status: status.to_string(),
-        });
-        ToolExecutionResult::success(json!({
-            "success": true,
-            "status": status
-        }))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,7 +189,7 @@ mod tests {
     use everruns_provider::typed_id::SessionId;
 
     #[test]
-    fn prompt_covers_the_terminal_commands_and_status() {
+    fn prompt_covers_the_terminal_commands() {
         let ui = Arc::new(RecordingUi::default());
         let capability = ClientCommandsCapability::new(ui);
         let prompt = capability.system_prompt_addition().expect("prompt");
@@ -279,13 +200,12 @@ mod tests {
         assert!(prompt.contains("\"restart MCP\""));
         assert!(prompt.contains("\"reconnect MCP\""));
         assert!(prompt.contains("\"refresh MCP\" (`/mcp reload`)"));
-        assert!(prompt.contains("set_status"));
     }
 
     /// The terminal commands are ordinary registry entries; `run_command` finds
     /// them there rather than in a list this capability hands the model.
     #[test]
-    fn capability_contributes_commands_and_only_the_status_tool() {
+    fn capability_contributes_terminal_commands() {
         let capability = ClientCommandsCapability::new(Arc::new(RecordingUi::default()));
 
         let commands: Vec<String> = capability
@@ -295,13 +215,7 @@ mod tests {
             .collect();
         assert!(commands.contains(&"quit".to_string()), "{commands:?}");
         assert!(commands.contains(&"mcp".to_string()), "{commands:?}");
-
-        let tools: Vec<String> = capability
-            .tools()
-            .iter()
-            .map(|tool| tool.name().to_string())
-            .collect();
-        assert_eq!(tools, vec!["set_status".to_string()]);
+        assert!(capability.tools().is_empty());
     }
 
     /// Executing a client command emits its `UiCommand` and returns an empty
@@ -351,69 +265,6 @@ mod tests {
             .expect_err("/setup belongs to another capability");
 
         assert!(error.to_string().contains("setup"), "error: {error}");
-        assert!(ui.take().is_empty());
-    }
-
-    #[test]
-    fn set_status_narration_includes_truncated_status() {
-        use everruns_core::tool_narration::ToolNarrationPhase;
-        use everruns_provider::ToolCall;
-
-        let tool = SetStatusTool {
-            ui: Arc::new(RecordingUi::default()),
-        };
-        let tool_call = ToolCall {
-            id: "call-1".to_string(),
-            name: "set_status".to_string(),
-            arguments: json!({ "status": "Auditing tool narration" }),
-        };
-
-        assert_eq!(
-            tool.narrate(
-                &tool_call,
-                ToolNarrationPhase::Started,
-                None,
-                everruns_core::tool_narration::ToolNarrationContext::default(),
-            ),
-            Some("Update status: Auditing tool narration".to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn set_status_queues_turn_scoped_status_update() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = SetStatusTool { ui: ui.clone() };
-
-        let result = tool.execute(json!({ "status": "running tests 3/8" })).await;
-
-        assert!(result.is_success(), "tool result: {result:?}");
-        assert_eq!(
-            ui.take(),
-            vec![UiCommand::SetAgentStatus {
-                status: "running tests 3/8".to_string()
-            }]
-        );
-    }
-
-    #[tokio::test]
-    async fn set_status_rejects_values_over_the_ui_limit() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = SetStatusTool { ui: ui.clone() };
-
-        let result = tool.execute(json!({ "status": "x".repeat(121) })).await;
-
-        assert!(result.is_error(), "tool result: {result:?}");
-        assert!(ui.take().is_empty());
-    }
-
-    #[tokio::test]
-    async fn set_status_rejects_terminal_control_characters() {
-        let ui = Arc::new(RecordingUi::default());
-        let tool = SetStatusTool { ui: ui.clone() };
-
-        let result = tool.execute(json!({ "status": "tests\u{1b}[2J" })).await;
-
-        assert!(result.is_error(), "tool result: {result:?}");
         assert!(ui.take().is_empty());
     }
 }

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -71,8 +71,6 @@ pub enum UiCommand {
     OpenModelOverlay { arg: Option<String> },
     /// Open the interactive reasoning-effort picker. `arg` pre-seeds it.
     OpenEffortOverlay { arg: Option<String> },
-    /// Set (or clear when empty) the agent's turn-scoped status contribution.
-    SetAgentStatus { status: String },
     /// Set (or, when `status` is empty, clear) an extension's status-bar field.
     /// Pushed by an extension server's `status/changed` notification.
     SetExtensionStatus { ext: String, status: String },

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -254,8 +254,6 @@ pub struct App {
     /// extension servers over `status/changed`. Rendered in the status bar via
     /// [`App::presentation_state`].
     extension_status: std::collections::BTreeMap<String, String>,
-    /// Turn-scoped status text set by the agent through the host UI.
-    agent_status: Option<String>,
     /// Incoming extension `ui/ask` requests; each is prompted one at a time via
     /// [`App::pending_ask`].
     ask_rx: mpsc::UnboundedReceiver<crate::tui::host_ui::AskRequest>,
@@ -765,7 +763,6 @@ impl App {
             session_tokens: None,
             ui_rx: runtime.ui_rx,
             extension_status: std::collections::BTreeMap::new(),
-            agent_status: None,
             ask_rx: runtime.ask_rx,
             pending_ask: None,
             sandbox_approval_rx: runtime.sandbox_approval_rx,
@@ -1278,7 +1275,6 @@ impl App {
             ask_indicator: self.ask_indicator(),
             worktree_compact: self.worktree.status_bar_compact(),
             worktree_expanded: self.worktree.status_bar_expanded(),
-            agent_status: self.agent_status.clone(),
             extension_status: self
                 .extension_status
                 .iter()
@@ -3309,10 +3305,6 @@ impl App {
                 }
                 None => self.start_setup(),
             },
-            UiCommand::SetAgentStatus { status } => {
-                let status = status.trim();
-                self.agent_status = (!status.is_empty()).then(|| status.to_string());
-            }
             UiCommand::SetExtensionStatus { ext, status } => {
                 let status = status.trim();
                 if status.is_empty() {
@@ -3845,7 +3837,6 @@ impl App {
         self.busy = false;
         self.busy_frame = 0;
         self.turn_activity = None;
-        self.agent_status = None;
         self.turn_started_at = None;
         self.stream_preview = None;
         self.rx = None;
@@ -6294,7 +6285,6 @@ flowchart TD
             ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
-            agent_status: None,
             extension_status: Vec::new(),
         }
     }
@@ -11762,7 +11752,6 @@ flowchart TD
         let state = ViewState {
             presentation: PresentationState {
                 status_layout: StatusLayout::Expanded,
-                agent_status: Some("running tests 3/8".to_string()),
                 worktree_expanded: Some(("codex/status-drawer".into(), "…/bb69/yolop".into())),
                 ..presentation_state_idle()
             },
@@ -11783,7 +11772,6 @@ flowchart TD
             }),
             "wide drawer should place all sections in columns: {wide_text}"
         );
-        assert!(wide_text.contains("agent running tests 3/8"));
         assert!(
             wide.lines
                 .iter()
@@ -11848,25 +11836,6 @@ flowchart TD
             }
             app.setup = None;
         }
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn agent_status_is_visible_for_the_turn_and_clears_on_finish() {
-        let mut fixture = app_with_llmsim().await;
-        let app = &mut fixture.app;
-        app.apply_ui_command(UiCommand::SetAgentStatus {
-            status: "running tests 3/8".to_string(),
-        })
-        .await;
-
-        assert_eq!(
-            app.presentation_state().agent_status.as_deref(),
-            Some("running tests 3/8")
-        );
-
-        app.finish_busy();
-
-        assert!(app.presentation_state().agent_status.is_none());
     }
 
     #[test]

--- a/src/tui/presentation.rs
+++ b/src/tui/presentation.rs
@@ -108,8 +108,6 @@ pub(crate) struct PresentationState {
     pub ask_indicator: Option<String>,
     pub worktree_compact: Option<String>,
     pub worktree_expanded: Option<(String, String)>,
-    /// Turn-scoped status text contributed by the agent through the TUI host.
-    pub agent_status: Option<String>,
     /// Live status pushed by extensions over `status/changed`, as
     /// `(extension_name, status_text)` pairs. Rendered as its own status field.
     pub extension_status: Vec<(String, String)>,
@@ -304,12 +302,7 @@ impl PresentationState {
         }
         session.push(status_field("goal", goal_label(self)));
         session.push(status_field("ask", ask_label(self)));
-        if let Some(status) = self
-            .agent_status
-            .as_deref()
-            .or_else(|| self.activity_text())
-            .filter(|status| !status.is_empty())
-        {
+        if let Some(status) = self.activity_text().filter(|status| !status.is_empty()) {
             session.push(status_field("agent", status));
         }
 
@@ -696,7 +689,6 @@ mod tests {
             ask_indicator: None,
             worktree_compact: None,
             worktree_expanded: None,
-            agent_status: None,
             extension_status: Vec::new(),
         }
     }
@@ -831,7 +823,6 @@ mod tests {
     fn expanded_sections_group_runtime_session_and_workspace_status() {
         let model = PresentationState {
             status_layout: StatusLayout::Expanded,
-            agent_status: Some("running tests 3/8".to_string()),
             worktree_expanded: Some(("codex/status-drawer".into(), "…/bb69/yolop".into())),
             ..state()
         };
@@ -851,12 +842,6 @@ mod tests {
         assert!(sections[0].fields.iter().any(|field| {
             field.label == Some("effort") && field.action == Some(StatusAction::OpenEffort)
         }));
-        assert!(
-            sections[1]
-                .fields
-                .iter()
-                .any(|field| field.label == Some("agent") && field.value == "running tests 3/8")
-        );
         assert!(
             sections[2]
                 .fields


### PR DESCRIPTION
## Summary

- remove the model-callable `set_status` tool and its prompt instruction
- remove the transient agent-owned status field from the TUI and its transcript narration
- stop the basic evaluator from accepting the removed tool as bookkeeping

## Why

The status tool consumed an additional agent iteration without providing useful user-facing value.

## Validation

- `cargo fmt --check`
- `cargo test -p yolop capabilities::client_commands --features yolop-yep/schema --quiet`
- `cargo test -p yolop tui::presentation --features yolop-yep/schema --quiet`
- `cargo test --workspace --features yolop-yep/schema --quiet`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo run -- --provider llmsim -p 'Reply with exactly: smoke test passed'`
- `doppler run -- cargo run -- --provider openai -p 'Reply with exactly: live smoke passed'`

## Before / After

Before, the agent could spend a turn calling `set_status`, which created an `Update status` transcript entry and rendered a transient Agent status value. After, no model-callable status tool is registered, so no extra iteration or UI entry is produced.

## Security

No security-relevant capability was added. This removes a model-callable tool and its UI command, reducing the tool surface; filesystem, shell, prompt, and dependency behavior are unchanged.

## Knowledge

No knowledge update required. This removes an implementation detail and does not alter documented maintainer policy or architecture.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
