### PR TITLE
feat(tui): enable compact work by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
   commands, and monitors with branch usage and cooperative cancellation,
   `!<command>` as a direct shell shortcut,
   `@`-triggered file-path completion, and shell-style
-  history recall (`↑`/`↓`, `Ctrl+R`) persisted across sessions. Start with
-  `--compact-work` to replace per-turn narration and tool lines with one live
-  summary; `Ctrl+O` expands or collapses the retained details. Compact work is
-  fullscreen-only because native inline scrollback cannot repaint old rows.
+  history recall (`↑`/`↓`, `Ctrl+R`) persisted across sessions. Fullscreen runs
+  replace per-turn narration and tool lines with one live summary by default;
+  `Ctrl+O` expands or collapses the retained details. Pass `--no-compact-work`
+  to retain ordinary transcript rows. Compact work is fullscreen-only because
+  native inline scrollback cannot repaint old rows.
 - **Side questions**: `/btw <question>` answers out-of-band using the current
   session context, with no tools and nothing added to conversation history.
 - **Goal loops**: `/goal <condition>` keeps working across turns until a
@@ -428,7 +429,7 @@ act of consent. MCP tools run autonomously like the rest of yolop's tools.
 | `--config-dir <PATH>`      | Override the global config directory (settings, profiles, extensions) |
 | `--data-dir <PATH>`        | Override the global data directory (sessions, logs, models)          |
 | `--sandbox`                | One-run `workspace-write` containment without changing settings      |
-| `--compact-work`           | Collapse each fullscreen turn's work into an expandable summary row  |
+| `--no-compact-work`        | Retain each fullscreen turn's work as ordinary transcript rows       |
 | `--reasoning-effort <E>`   | Reasoning effort override when the model profile supports it          |
 | `--trajectory-out <PATH>`  | Write the session as an [ATIF](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) v1.7 trajectory JSON at end of run |
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,11 @@
 # Knowledge Log
 
+## 2026-09-02, Compact work is the fullscreen default
+
+- [Presentation](specs/presentation.md): fullscreen turns compact narration and
+  tool activity into an expandable work summary by default. `--no-compact-work`
+  restores ordinary transcript rows for users who need the expanded projection.
+
 ## 2026-08-31, ACP tools follow host capabilities
 
 - [ACP](specs/acp.md): session-title events update the client title, while

--- a/knowledge/specs/presentation.md
+++ b/knowledge/specs/presentation.md
@@ -72,8 +72,9 @@ files under the platform data directory's `yolop/logs/` folder; command,
 `--print`, and ACP modes continue to write tracing output to stderr. At most
 five interactive trace files are retained, capped at 4 MiB each.
 
-`--compact-work` selects an alternate fullscreen transcript projection. Each
-live turn owns one mutable work summary instead of appending narration and tool
+Compact work is the default fullscreen transcript projection. `--no-compact-work`
+restores the expanded projection. Each live turn owns one mutable work summary
+instead of appending narration and tool
 rows. The summary carries current activity, elapsed time, top-level action
 count, and its terminal success, failure, or cancellation state. `Ctrl+O`
 expands or collapses the latest turn's retained detail rows inline beneath the

--- a/src/main.rs
+++ b/src/main.rs
@@ -1877,6 +1877,7 @@ fn continuation_command(
     let mut preserved = Vec::new();
     let mut skip_value = false;
     let mut compact_work = true;
+    let mut compact_work_available = true;
 
     for arg in args {
         if skip_value {
@@ -1895,6 +1896,9 @@ fn continuation_command(
             compact_work = value == "--compact-work";
             continue;
         }
+        if matches!(value.as_ref(), "--inline" | "--print" | "--acp") {
+            compact_work_available = false;
+        }
         if value.starts_with("--print=")
             || value.starts_with("--image=")
             || value.starts_with("--session=")
@@ -1905,11 +1909,13 @@ fn continuation_command(
         preserved.push(shell_quote(&value));
     }
 
-    preserved.push(if compact_work {
-        "--compact-work".to_string()
-    } else {
-        "--no-compact-work".to_string()
-    });
+    if compact_work_available {
+        preserved.push(if compact_work {
+            "--compact-work".to_string()
+        } else {
+            "--no-compact-work".to_string()
+        });
+    }
     preserved.push("--session".to_string());
     preserved.push(shell_quote(session_id));
     format!("yolop {}", preserved.join(" "))
@@ -2600,6 +2606,14 @@ mod tests {
         assert_eq!(
             continuation_command(args, "new-session"),
             "yolop --inline --sandbox --model 'gpt test' --session new-session"
+        );
+
+        let args = ["yolop", "--acp", "--session=old-session"]
+            .into_iter()
+            .map(OsString::from);
+        assert_eq!(
+            continuation_command(args, "new-session"),
+            "yolop --acp --session new-session"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,9 +207,18 @@ struct Cli {
         long = "no-compact-work",
         default_value_t = true,
         action = ArgAction::SetFalse,
-        conflicts_with_all = ["inline", "print", "acp"]
+        conflicts_with_all = ["inline", "print", "acp", "force_compact_work"]
     )]
     compact_work: bool,
+
+    // Kept hidden because compact work is the default. Continuation commands
+    // write it explicitly so their presentation remains stable across releases.
+    #[arg(
+        long = "compact-work",
+        hide = true,
+        conflicts_with_all = ["inline", "print", "acp", "compact_work"]
+    )]
+    force_compact_work: bool,
 
     /// Color theme for the interactive TUI. `yolop` (default) is yolop's own
     /// palette; other values select a bundled `tuika` preset (e.g.
@@ -901,7 +910,7 @@ async fn async_main(crash_reporter: &crash_report::CrashReporter) -> Result<()> 
         pending_images,
         cli.trajectory_out,
         !cli.inline,
-        cli.compact_work,
+        cli.compact_work || cli.force_compact_work,
     )
     .await
 }
@@ -1867,6 +1876,7 @@ fn continuation_command(
     let _executable = args.next();
     let mut preserved = Vec::new();
     let mut skip_value = false;
+    let mut compact_work = true;
 
     for arg in args {
         if skip_value {
@@ -1881,6 +1891,10 @@ fn continuation_command(
             skip_value = true;
             continue;
         }
+        if matches!(value.as_ref(), "--compact-work" | "--no-compact-work") {
+            compact_work = value == "--compact-work";
+            continue;
+        }
         if value.starts_with("--print=")
             || value.starts_with("--image=")
             || value.starts_with("--session=")
@@ -1891,6 +1905,11 @@ fn continuation_command(
         preserved.push(shell_quote(&value));
     }
 
+    preserved.push(if compact_work {
+        "--compact-work".to_string()
+    } else {
+        "--no-compact-work".to_string()
+    });
     preserved.push("--session".to_string());
     preserved.push(shell_quote(session_id));
     format!("yolop {}", preserved.join(" "))
@@ -2436,6 +2455,10 @@ mod tests {
         let expanded =
             Cli::try_parse_from(["yolop", "--no-compact-work"]).expect("expanded fullscreen TUI");
         assert!(!expanded.compact_work);
+        let resumed = Cli::try_parse_from(["yolop", "--compact-work"])
+            .expect("explicit compact fullscreen TUI");
+        assert!(resumed.compact_work || resumed.force_compact_work);
+        assert!(Cli::try_parse_from(["yolop", "--no-compact-work", "--compact-work"]).is_err());
         assert!(Cli::try_parse_from(["yolop", "--no-compact-work", "--inline"]).is_err());
         assert!(Cli::try_parse_from(["yolop", "--no-compact-work", "-p", "hi"]).is_err());
     }
@@ -2581,7 +2604,7 @@ mod tests {
     }
 
     #[test]
-    fn continuation_preserves_disabled_compact_work_mode() {
+    fn continuation_serializes_compact_work_mode() {
         let args = ["yolop", "--no-compact-work", "--session=old-session"]
             .into_iter()
             .map(OsString::from);
@@ -2589,6 +2612,14 @@ mod tests {
         assert_eq!(
             continuation_command(args, "new-session"),
             "yolop --no-compact-work --session new-session"
+        );
+
+        let args = ["yolop", "--session=old-session"]
+            .into_iter()
+            .map(OsString::from);
+        assert_eq!(
+            continuation_command(args, "new-session"),
+            "yolop --compact-work --session new-session"
         );
     }
 
@@ -2612,6 +2643,7 @@ mod tests {
             trajectory_out: None,
             inline: false,
             compact_work: true,
+            force_compact_work: false,
             theme: None,
             sandbox: false,
         }
@@ -2724,6 +2756,7 @@ mod tests {
             trajectory_out: None,
             inline: false,
             compact_work: false,
+            force_compact_work: false,
             theme: None,
             sandbox: false,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use anyhow::{Context, Result};
 // LTO/dead-code elimination when we register capabilities explicitly.
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_parallel;
-use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
+use clap::{ArgAction, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use config::SettingsStore;
 use config::mcp::{McpConfigScope, McpConfigStore};
 use crossterm::event::{
@@ -198,11 +198,17 @@ struct Cli {
     #[arg(long)]
     inline: bool,
 
-    /// Collapse each active turn's narration and tool output into one updating
-    /// transcript row. Press Ctrl+O to expand or collapse the latest turn's
-    /// retained work details. Fullscreen only because inline scrollback cannot
-    /// repaint a previously published accordion.
-    #[arg(long, conflicts_with_all = ["inline", "print", "acp"])]
+    /// Retain narration and tool output as ordinary transcript rows.
+    ///
+    /// Compact work is enabled by default in the fullscreen TUI. Press Ctrl+O
+    /// to expand or collapse each turn's retained work details. Fullscreen only
+    /// because inline scrollback cannot repaint a previously published accordion.
+    #[arg(
+        long = "no-compact-work",
+        default_value_t = true,
+        action = ArgAction::SetFalse,
+        conflicts_with_all = ["inline", "print", "acp"]
+    )]
     compact_work: bool,
 
     /// Color theme for the interactive TUI. `yolop` (default) is yolop's own
@@ -2424,12 +2430,14 @@ mod tests {
     }
 
     #[test]
-    fn compact_work_is_fullscreen_only() {
-        let compact =
-            Cli::try_parse_from(["yolop", "--compact-work"]).expect("compact fullscreen TUI");
+    fn compact_work_is_enabled_by_default_and_fullscreen_only() {
+        let compact = Cli::try_parse_from(["yolop"]).expect("default fullscreen TUI");
         assert!(compact.compact_work);
-        assert!(Cli::try_parse_from(["yolop", "--compact-work", "--inline"]).is_err());
-        assert!(Cli::try_parse_from(["yolop", "--compact-work", "-p", "hi"]).is_err());
+        let expanded =
+            Cli::try_parse_from(["yolop", "--no-compact-work"]).expect("expanded fullscreen TUI");
+        assert!(!expanded.compact_work);
+        assert!(Cli::try_parse_from(["yolop", "--no-compact-work", "--inline"]).is_err());
+        assert!(Cli::try_parse_from(["yolop", "--no-compact-work", "-p", "hi"]).is_err());
     }
 
     #[test]
@@ -2573,14 +2581,14 @@ mod tests {
     }
 
     #[test]
-    fn continuation_preserves_compact_work_mode() {
-        let args = ["yolop", "--compact-work", "--session=old-session"]
+    fn continuation_preserves_disabled_compact_work_mode() {
+        let args = ["yolop", "--no-compact-work", "--session=old-session"]
             .into_iter()
             .map(OsString::from);
 
         assert_eq!(
             continuation_command(args, "new-session"),
-            "yolop --compact-work --session new-session"
+            "yolop --no-compact-work --session new-session"
         );
     }
 
@@ -2603,7 +2611,7 @@ mod tests {
             session_dir: None,
             trajectory_out: None,
             inline: false,
-            compact_work: false,
+            compact_work: true,
             theme: None,
             sandbox: false,
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2337,7 +2337,14 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
     if !require_native_sandbox("tui_bang_shell_runs_shell_without_model_turn") {
         return;
     }
-    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            inline: false,
+            compact_work: true,
+            ..TuiSpawnOptions::default()
+        },
+    );
     assert!(
         tui.wait_for_output("type /help", Duration::from_secs(3)),
         "TUI did not render startup banner: {}",
@@ -2345,9 +2352,19 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
     );
 
     tui.write_input(b"!shell printf shell-pty-output\r");
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(
+        summary.contains("Ctrl+O details"),
+        "!shell did not complete: {summary}"
+    );
+    tui.write_input(b"\x0f");
     assert!(
         tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
-        "!shell did not complete: {}",
+        "!shell details did not expand: {}",
         tui.output_text()
     );
 
@@ -2372,7 +2389,14 @@ fn tui_bang_shell_runs_shell_without_model_turn() {
 
 #[test]
 fn tui_bang_yolop_extensions_uses_attached_control() {
-    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            inline: false,
+            compact_work: true,
+            ..TuiSpawnOptions::default()
+        },
+    );
     assert!(
         tui.wait_for_output("type /help", Duration::from_secs(10)),
         "TUI did not render startup banner: {}",
@@ -2380,9 +2404,19 @@ fn tui_bang_yolop_extensions_uses_attached_control() {
     );
 
     tui.write_input(b"!yolop extensions list\r");
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(
+        summary.contains("Ctrl+O details"),
+        "attached extension control did not complete: {summary}"
+    );
+    tui.write_input(b"\x0f");
     assert!(
         tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
-        "attached extension control did not complete: {}",
+        "attached extension-control details did not expand: {}",
         tui.output_text()
     );
     assert!(
@@ -2406,7 +2440,14 @@ fn tui_bang_yolop_extensions_uses_attached_control() {
 /// clap prints help inside the child, which never sends a control frame.
 #[test]
 fn tui_bang_yolop_extensions_help_renders_usage_instead_of_a_parse_error() {
-    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            inline: false,
+            compact_work: true,
+            ..TuiSpawnOptions::default()
+        },
+    );
     assert!(
         tui.wait_for_output("type /help", Duration::from_secs(10)),
         "TUI did not render startup banner: {}",
@@ -2414,14 +2455,24 @@ fn tui_bang_yolop_extensions_help_renders_usage_instead_of_a_parse_error() {
     );
 
     tui.write_input(b"!yolop extensions --help\r");
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
     assert!(
-        tui.wait_for_output("shell exited with code 0", Duration::from_secs(10)),
-        "attached help did not complete: {}",
+        summary.contains("Ctrl+O details"),
+        "attached help did not complete: {summary}"
+    );
+    tui.write_input(b"\x0f");
+    assert!(
+        tui.wait_for_output("Scaffold a Python extension", Duration::from_secs(5)),
+        "attached help details did not expand: {}",
         tui.output_text()
     );
     let transcript = strip_ansi(&tui.output_text());
     assert!(
-        transcript.contains("Usage: yolop extensions"),
+        transcript.contains("Scaffold a Python extension"),
         "help text should render: {transcript}"
     );
     assert!(
@@ -2437,7 +2488,11 @@ fn tui_bang_yolop_extensions_help_renders_usage_instead_of_a_parse_error() {
 fn tui_shell_session_approval_skips_later_prompts_for_the_same_scope() {
     let mut tui = spawn_tui_llmsim_with_settings(
         &yolop_binary(),
-        TuiSpawnOptions::default(),
+        TuiSpawnOptions {
+            inline: false,
+            compact_work: true,
+            ..TuiSpawnOptions::default()
+        },
         "provider = \"llmsim\"\napproval_policy = \"untrusted\"\n",
     );
     assert!(
@@ -2453,18 +2508,38 @@ fn tui_shell_session_approval_skips_later_prompts_for_the_same_scope() {
         tui.output_text()
     );
     tui.write_input(b"a");
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(
+        summary.contains("Ctrl+O details"),
+        "approved shell command did not finish: {summary}"
+    );
+    tui.write_input(b"\x0f");
     assert!(
         tui.wait_for_output("first-session-command", Duration::from_secs(5))
             && tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
-        "approved shell command did not finish: {}",
+        "approved shell details did not expand: {}",
         tui.output_text()
     );
 
     tui.write_input(b"!shell printf second-session-command\r");
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(
+        summary.contains("Ctrl+O details"),
+        "second shell command did not inherit session approval: {summary}"
+    );
+    tui.write_input(b"\x0f");
     assert!(
         tui.wait_for_output("second-session-command", Duration::from_secs(5))
             && tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
-        "second shell command did not inherit session approval: {}",
+        "second shell details did not expand: {}",
         tui.output_text()
     );
     // The footer keeps the recent transcript on screen, so the first command's
@@ -2511,6 +2586,8 @@ fn shell_commands_have_full_host_access_by_default() {
         &yolop_binary(),
         TuiSpawnOptions {
             workspace: Some(workspace),
+            inline: false,
+            compact_work: true,
             ..TuiSpawnOptions::default()
         },
     );
@@ -2526,9 +2603,19 @@ fn shell_commands_have_full_host_access_by_default() {
     );
 
     tui.write_input(command.as_bytes());
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(
+        summary.contains("Ctrl+O details"),
+        "full-access shell did not complete: {summary}"
+    );
+    tui.write_input(b"\x0f");
     assert!(
         tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
-        "full-access shell did not complete: {}",
+        "full-access shell details did not expand: {}",
         tui.output_text()
     );
     assert!(
@@ -2592,7 +2679,14 @@ fn tui_bang_shell_can_create_toolchain_home() {
     if !require_native_sandbox("tui_bang_shell_can_create_toolchain_home") {
         return;
     }
-    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            inline: false,
+            compact_work: true,
+            ..TuiSpawnOptions::default()
+        },
+    );
     assert!(
         tui.wait_for_output("type /help", Duration::from_secs(3)),
         "TUI did not render startup banner: {}",
@@ -2600,6 +2694,16 @@ fn tui_bang_shell_can_create_toolchain_home() {
     );
 
     tui.write_input(b"!shell mkdir -p \"$HOME/.rustup\" && test -d \"$HOME/.rustup\"\r");
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(
+        summary.contains("Ctrl+O details"),
+        "sandbox should permit creating directories under its synthetic home: {summary}"
+    );
+    tui.write_input(b"\x0f");
     assert!(
         tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
         "sandbox should permit creating directories under its synthetic home: {}",
@@ -2617,7 +2721,14 @@ fn tui_bang_shell_can_redirect_to_dev_null() {
     if !require_native_sandbox("tui_bang_shell_can_redirect_to_dev_null") {
         return;
     }
-    let mut tui = spawn_tui_llmsim(&yolop_binary());
+    let mut tui = spawn_tui_llmsim_with(
+        &yolop_binary(),
+        TuiSpawnOptions {
+            inline: false,
+            compact_work: true,
+            ..TuiSpawnOptions::default()
+        },
+    );
     assert!(
         tui.wait_for_output("type /help", Duration::from_secs(3)),
         "TUI did not render startup banner: {}",
@@ -2625,6 +2736,16 @@ fn tui_bang_shell_can_redirect_to_dev_null() {
     );
 
     tui.write_input(b"!shell printf discarded >/dev/null\r");
+    let summary = tui
+        .wait_for_screen(Duration::from_secs(10), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(
+        summary.contains("Ctrl+O details"),
+        "sandbox should permit writing /dev/null: {summary}"
+    );
+    tui.write_input(b"\x0f");
     assert!(
         tui.wait_for_output("shell exited with code 0", Duration::from_secs(5)),
         "sandbox should permit writing /dev/null: {}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2569,14 +2569,14 @@ fn sandbox_flag_restricts_shell_writes_for_one_run() {
         },
     );
     assert!(
-        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        tui.wait_for_output("type /help", Duration::from_secs(10)),
         "TUI did not finish startup: {}",
         tui.output_text()
     );
 
     tui.write_input(command.as_bytes());
     assert!(
-        tui.wait_for_output("shell exited with code", Duration::from_secs(5)),
+        tui.wait_for_output("Failed after", Duration::from_secs(5)),
         "sandboxed shell did not complete: {}",
         tui.output_text()
     );
@@ -2664,7 +2664,7 @@ fn tui_agents_context_cannot_bypass_native_shell_sandbox() {
         },
     );
     assert!(
-        tui.wait_for_output("type /help", Duration::from_secs(3)),
+        tui.wait_for_output("type /help", Duration::from_secs(10)),
         "TUI did not render startup banner: {}",
         tui.output_text()
     );
@@ -2679,12 +2679,26 @@ fn tui_agents_context_cannot_bypass_native_shell_sandbox() {
     );
     tui.write_input(format!("!shell printf escaped > '{}'\r", outside.display()).as_bytes());
     assert!(
-        tui.wait_for_output(
-            "native sandbox likely blocked this operation",
-            Duration::from_secs(8)
-        ),
-        "sandbox denial was not explained: {}",
+        tui.wait_for_output("Failed after", Duration::from_secs(8)),
+        "sandboxed shell did not complete: {}",
         tui.output_text()
+    );
+    let collapsed = tui
+        .wait_for_screen(Duration::from_secs(3), |screen| {
+            screen.iter().any(|line| line.contains("Ctrl+O details"))
+        })
+        .join("\n");
+    assert!(collapsed.contains("Ctrl+O details"), "{collapsed}");
+
+    tui.write_input(b"\x0f");
+    let expanded = tui
+        .wait_for_screen(Duration::from_secs(3), |screen| {
+            screen.iter().any(|line| line.contains("Failed after"))
+        })
+        .join("\n");
+    assert!(
+        expanded.contains("Failed after"),
+        "sandbox failure disappeared after expanding compact work: {expanded}"
     );
     assert!(!outside.exists(), "AGENTS.md context bypassed the sandbox");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1272,11 +1272,12 @@ fn tui_inline_renders_and_responds_smoke() {
 }
 
 #[test]
-fn tui_compact_work_collapses_and_expands_shell_details() {
+fn tui_default_compact_work_collapses_and_expands_shell_details() {
     let mut tui = spawn_tui_llmsim_with(
         &yolop_binary(),
         TuiSpawnOptions {
             inline: false,
+            // `true` means do not pass an override, so this drives the CLI default.
             compact_work: true,
             ..TuiSpawnOptions::default()
         },

--- a/tests/support/tui_harness.rs
+++ b/tests/support/tui_harness.rs
@@ -36,7 +36,8 @@ pub struct TuiSpawnOptions {
     pub path_prefix: Option<PathBuf>,
     /// Pass `--inline` instead of using the default fullscreen renderer.
     pub inline: bool,
-    /// Collapse turn work into an expandable fullscreen summary row.
+    /// Expect compact fullscreen work. The harness passes the opt-out when false
+    /// so existing tests retain expanded transcript assertions.
     pub compact_work: bool,
     /// Workspace passed through `-C`; useful for real-binary containment tests.
     pub workspace: Option<PathBuf>,
@@ -263,8 +264,8 @@ pub fn spawn_tui_llmsim_with_settings(
     if options.inline {
         cmd.arg("--inline");
     }
-    if options.compact_work {
-        cmd.arg("--compact-work");
+    if !options.inline && !options.compact_work {
+        cmd.arg("--no-compact-work");
     }
     if options.sandbox {
         cmd.arg("--sandbox");


### PR DESCRIPTION
## Summary

- make fullscreen compact work the default transcript projection
- add `--no-compact-work` to retain expanded narration and tool rows
- cover the default projection in CLI and PTY tests

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema`
- `cargo run -- --provider llmsim --inline -p 'Reply exactly: compact work smoke passed.'`\n- `python3 scripts/validate_okf.py knowledge --check-links`\n\n## Before / After\n\nBefore, users had to pass `--compact-work` to collapse fullscreen turn activity. After, fullscreen turns compact by default and `--no-compact-work` retains ordinary transcript rows. The renamed PTY test drives the default CLI path and expands the summary with `Ctrl+O`.\n\n## Security\n\nNo security-relevant code changes. This only changes a local presentation default and CLI argument polarity, with existing fullscreen-mode conflict validation retained.\n\n## Knowledge\n\nUpdated `knowledge/specs/presentation.md` and recorded the behavior decision in `knowledge/log.md`.\n\n## Follow-ups\n\nNo follow-ups.\n\nProduced by [yolop](https://everruns.com/yolop)