### PR TITLE
feat(mcp): complete configuration CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,17 @@ enum McpCommand {
         #[arg(short = 'C', long = "cwd")]
         cwd: Option<PathBuf>,
     },
+    /// Show one configured MCP server.
+    Show {
+        /// Server name.
+        name: String,
+        /// Scope to inspect (`global`, `workspace`, or `effective`).
+        #[arg(long, default_value = "effective")]
+        scope: McpScopeArg,
+        /// Workspace root for workspace/effective config.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
     /// Add or replace an MCP server.
     Add {
         /// Scope to write (`global` or `workspace`).
@@ -339,16 +350,24 @@ enum McpCommand {
         #[arg(short = 'C', long = "cwd")]
         cwd: Option<PathBuf>,
     },
-    /// Enable or disable an MCP server without deleting it.
+    /// Enable an MCP server.
     Enable {
         /// Scope to write (`global` or `workspace`).
         #[arg(long, default_value = "global")]
         scope: McpScopeArg,
         /// Server name.
         name: String,
-        /// Disable instead of enable.
-        #[arg(long, default_value_t = false)]
-        disable: bool,
+        /// Workspace root when writing workspace config.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
+    /// Disable an MCP server without deleting it.
+    Disable {
+        /// Scope to write (`global` or `workspace`).
+        #[arg(long, default_value = "global")]
+        scope: McpScopeArg,
+        /// Server name.
+        name: String,
         /// Workspace root when writing workspace config.
         #[arg(short = 'C', long = "cwd")]
         cwd: Option<PathBuf>,
@@ -1163,6 +1182,25 @@ fn run_mcp_command(command: McpCommand) -> Result<()> {
             }
             Ok(())
         }
+        McpCommand::Show { name, scope, cwd } => {
+            let store = store(cwd)?;
+            let server = store
+                .effective()
+                .map_err(anyhow::Error::msg)?
+                .servers
+                .into_iter()
+                .find(|server| {
+                    server.name == name
+                        && match scope {
+                            McpScopeArg::Global => server.scope == McpConfigScope::Global,
+                            McpScopeArg::Workspace => server.scope == McpConfigScope::Workspace,
+                            McpScopeArg::Effective => server.effective,
+                        }
+                })
+                .with_context(|| format!("MCP server `{name}` was not found in {scope:?} scope"))?;
+            println!("{}", serde_json::to_string_pretty(&server)?);
+            Ok(())
+        }
         McpCommand::Add {
             scope,
             name,
@@ -1243,19 +1281,27 @@ fn run_mcp_command(command: McpCommand) -> Result<()> {
             }
             Ok(())
         }
-        McpCommand::Enable {
-            scope,
-            name,
-            disable,
-            cwd,
-        } => {
+        McpCommand::Enable { scope, name, cwd } => {
             let store = store(cwd)?;
             store
-                .set_enabled(write_scope(scope)?, &name, !disable)
+                .set_enabled(write_scope(scope)?, &name, true)
                 .map_err(anyhow::Error::msg)?;
             println!(
-                "{} MCP server `{name}` in {} scope",
-                if disable { "disabled" } else { "enabled" },
+                "enabled MCP server `{name}` in {} scope",
+                mcp_scope_label(write_scope(scope)?)
+            );
+            println!(
+                "restart or start a new yolop session for MCP connection changes to take effect"
+            );
+            Ok(())
+        }
+        McpCommand::Disable { scope, name, cwd } => {
+            let store = store(cwd)?;
+            store
+                .set_enabled(write_scope(scope)?, &name, false)
+                .map_err(anyhow::Error::msg)?;
+            println!(
+                "disabled MCP server `{name}` in {} scope",
                 mcp_scope_label(write_scope(scope)?)
             );
             println!(
@@ -2377,6 +2423,18 @@ mod tests {
                 .execute()
                 .await
                 .expect("execute detached command");
+        }
+    }
+
+    #[test]
+    fn mcp_cli_exposes_management_and_runtime_commands() {
+        for argv in [
+            vec!["yolop", "mcp", "list"],
+            vec!["yolop", "mcp", "show", "demo"],
+            vec!["yolop", "mcp", "enable", "demo"],
+            vec!["yolop", "mcp", "disable", "demo"],
+        ] {
+            Cli::try_parse_from(argv).expect("parse MCP command");
         }
     }
 


### PR DESCRIPTION
## What changed

- adds `yolop mcp show <name>` with global, workspace, and effective scope selection
- splits the overloaded `yolop mcp enable --disable` behavior into symmetric `enable` and `disable` commands
- adds CLI parser coverage for the complete configuration-management surface

## Why

The first MCP CLI iteration exposed list/add/remove/enable but made inspection require opening configuration files and hid disable behind a flag. This completes the configuration management experience with explicit, discoverable commands comparable to the extensions CLI.

Live-session `reload` and `login` remain owned by the existing `/mcp reload` and `/mcp login <name>` runtime paths and by the agent's typed `run_yolop_command { command: "mcp", ... }` interface. Moving those to external attached CLI control requires extracting the root MCP parser into `CliCapability`/`ControlCapability`; this PR does not add misleading detached commands that cannot reach a running session.

## Before / After

Before:

```text
yolop mcp show demo      # unknown command
yolop mcp disable demo   # unknown command
yolop mcp enable demo --disable
```

After:

```text
yolop mcp show demo
yolop mcp disable demo
yolop mcp enable demo
```

An end-to-end temporary-config smoke added a server, showed it, disabled it, and listed the resulting global configuration successfully.

## Risk

Low. The commands delegate to the existing `McpConfigStore::effective` and `set_enabled` boundaries. No transport, credential, OAuth, or live-runtime behavior changes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required. This makes the already-documented first-class MCP configuration CLI more complete without changing MCP architecture, persistence policy, or runtime behavior.

## Security

- **TM-FS:** scope resolution and writes continue through `McpConfigStore`; no new paths or traversal surface are introduced.
- **TM-TOOL:** no capability registration changes.
- **TM-BASH / TM-LLM / TM-DEP:** no shell, prompt, key handling, or dependency changes.
- `show` may display configured header values to the local invoking user, matching the existing local configuration ownership. Output is not logged or sent externally by Yolop.

## Follow-ups

- Extract the MCP root command into `CliCapability`/`ControlCapability`, then add attached `yolop mcp reload` and `yolop mcp login <name>` backed by the running session's existing `UiCommand::ManageMcp` path. This is a transport refactor, not a config CLI concern.

Produced by [yolop](https://everruns.com/yolop)
