### PR TITLE
test(evals): add native agent comparison

### DIFF
--- a/evals/terminal_bench/README.md
+++ b/evals/terminal_bench/README.md
@@ -209,6 +209,24 @@ table bills full `prompt_tokens`, including cache reads that dominate these
 agentic runs, and Terra and Luna have different configured rates. The absolute
 figures are ceilings; the 58.9% delta describes yolop's estimator.
 
+### Yolop vs native agents
+
+Run [`20260904T012919Z-eafd`](results/20260904T012919Z-eafd/report.json) is the
+fixed `terra-medium-compare` record. All nine cases completed without an
+infrastructure error under the same 12 GiB task-container limit.
+
+| agent | model and effort | resolved | cost | summed case wall |
+|---|---|---:|---:|---:|
+| Claude Code 2.1.260 | Sonnet 5, default effort | 3/3 | $0.452 | 6m17s |
+| yolop 0.17.2 | GPT-5.6 Terra, medium | 2/3 | $0.453 | 5m07s |
+| Codex | GPT-5.6 Terra, Harbor default high | 2/3 | $0.374 | 4m42s |
+
+Yolop and Codex both missed `chess-best-move`; every agent passed
+`count-dataset-tokens` and `modernize-scientific-stack`. This is an
+agent-default comparison, not an effort-matched model comparison. It is one
+trial on three tasks, so use it as an effectiveness record and trajectory source,
+not a population-level ranking.
+
 It is selected deterministically by `suites/select_control.py`, no hand-picking:
 tasks needing a GPU or more than 4 GiB are excluded (so the suite runs
 concurrently on an ordinary box), each tier is ordered by `(agent timeout, name)`
@@ -301,7 +319,20 @@ targets.
 | `smoke` | Integration check / validate a new config before a full run | `fix-git`, `cobol-modernization` | gpt-5.6-terra |
 | `control` | The periodic regression run ([Control suite](#control-suite)) | 8 (`control-v1`) | gpt-5.6-terra |
 | `compare` | yolop vs the other terminal agents on identical tasks | the `easy` tier | yolop ×2 + terminus-2 + claude-code + codex |
+| `terra-medium-compare` | fixed three-task record: yolop Terra medium vs Claude Code Sonnet 5 vs Codex | `modernize-scientific-stack`, `chess-best-move`, `count-dataset-tokens` | 3 agents |
 | `full` | The headline number | all 89 | gpt-5.6-terra |
+
+On this Apple Silicon host, enable Rosetta in Colima and give every task a
+12 GiB limit. Codex's x86 code-mode helper needs the memory, while Claude
+Code's native x86 binary is impractically slow under QEMU. Apply the same
+memory limit to every target so the comparison remains resource-symmetric:
+
+```bash
+colima start --memory 16 --vm-type vz --vz-rosetta
+TB_OVERRIDE_MEMORY_MB=12288 TB_MAX_COST_USD=45 \
+  doppler run --project yolop --config ci -- \
+  mira run --preset terra-medium-compare --group-by agent
+```
 
 ### Environment knobs
 
@@ -312,6 +343,7 @@ from the environment:
 |----------|--------|
 | `TB_MAX_COST_USD` | whole-run USD budget across every case (unset = no cap) |
 | `TB_YOLOP_BIN` | yolop binary to upload (default: the musl release build) |
+| `TB_OVERRIDE_MEMORY_MB` | override every task container's memory in MiB, keeping an agent comparison resource-symmetric |
 | `TB_DATASET_DIR` | use a pre-downloaded task tree instead of `.cache/dataset/` |
 | `TB_AGENT_ENV` | comma-separated `KEY=VALUE` forwarded into the agent's environment |
 | `TB_VERIFIER_ENV` | the same, for the verifier phase (it inherits nothing from the agent) |

--- a/evals/terminal_bench/harbor_claude.py
+++ b/evals/terminal_bench/harbor_claude.py
@@ -1,0 +1,42 @@
+"""Harbor's Claude Code adapter with an emulation-friendly installer."""
+
+from __future__ import annotations
+
+import shlex
+
+from harbor.agents.installed.claude_code import ClaudeCode
+from harbor.environments.base import BaseEnvironment
+
+
+class ClaudeCodeCompatibility(ClaudeCode):
+    """Install Claude Code through npm instead of its native bootstrap binary."""
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        if await self._installed_claude_satisfies_version(environment):
+            self.logger.debug("Claude Code is already available at the requested version")
+            return
+
+        # Harbor selects Anthropic's native bootstrap on glibc. Terminal-Bench
+        # uses x86 images, and that installer takes more than 20 minutes under
+        # Apple Silicon emulation. The supported npm package avoids that path.
+        await self.ensure_system_dependencies(
+            environment, ("curl", "bash", "ripgrep", "procps")
+        )
+        version_spec = f"@{self._version}" if self._version else ""
+        package_spec = shlex.quote(f"@anthropic-ai/claude-code{version_spec}")
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash && "
+                'export NVM_DIR="$HOME/.nvm" && '
+                '\\. "$NVM_DIR/nvm.sh" && '
+                "nvm install 22 && nvm alias default 22 && "
+                f"npm install -g {package_spec} && "
+                'mkdir -p "$HOME/.local/bin" && '
+                'ln -sf "$(command -v node)" "$HOME/.local/bin/node" && '
+                'ln -sf "$(command -v claude)" "$HOME/.local/bin/claude" && '
+                "claude --version"
+            ),
+            env={"NVM_NODEJS_ORG_MIRROR": "https://nodejs.org/dist"},
+        )

--- a/evals/terminal_bench/harbor_codex.py
+++ b/evals/terminal_bench/harbor_codex.py
@@ -1,0 +1,53 @@
+"""Harbor's Codex adapter with a persistent home inside task containers."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import PurePosixPath
+
+from harbor.environments.base import BaseEnvironment
+from harbor.agents.installed.codex import Codex
+
+
+class CodexCompatibility(Codex):
+    """Keep Codex's code-mode helper binaries outside the temporary directory."""
+
+    # Harbor's built-in adapter chooses /tmp/codex-home. Codex rejects that
+    # location when creating code-mode helper binaries, so all workspace tools
+    # fail before the agent can start the task.
+    _REMOTE_CODEX_HOME = PurePosixPath("/root/.codex")
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        """Install Node with nvm, without Ubuntu's broken npm package chain."""
+        if await self._installed_codex_satisfies_version(environment):
+            self.logger.debug("Codex is already available at the requested version")
+            return
+
+        # Harbor's stock adapter installs the distro `nodejs` and `npm` before
+        # nvm replaces them. On Terminal-Bench's Noble image that package set
+        # can fail while configuring node-gyp, before Codex itself starts.
+        # nvm provides Node and npm, so only its small prerequisites are needed.
+        await self.ensure_system_dependencies(environment, ("curl", "bash", "ripgrep"))
+        version_spec = f"@{self._version}" if self._version else "@latest"
+        package_spec = shlex.quote(f"@openai/codex{version_spec}")
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash && "
+                'export NVM_DIR="$HOME/.nvm" && '
+                '\\. "$NVM_DIR/nvm.sh" && '
+                "nvm install 22 && nvm alias default 22 && npm -v && "
+                f"npm install -g {package_spec} && codex --version"
+            ),
+            env={"NVM_NODEJS_ORG_MIRROR": "https://nodejs.org/dist"},
+        )
+        await self.exec_as_root(
+            environment,
+            command=(
+                "for bin in node codex; do "
+                'BIN_PATH="$(which "$bin" 2>/dev/null || true)"; '
+                'if [ -n "$BIN_PATH" ] && [ "$BIN_PATH" != "/usr/local/bin/$bin" ]; then '
+                'ln -sf "$BIN_PATH" "/usr/local/bin/$bin"; fi; done'
+            ),
+        )

--- a/evals/terminal_bench/mira.toml
+++ b/evals/terminal_bench/mira.toml
@@ -54,6 +54,12 @@ tag = "easy"
 targets = ["openai-gpt-5.6-terra", "anthropic-claude-opus-4.8", "terminus-2",
            "claude-code-opus-4.8", "codex"]
 
+# TERRA MEDIUM COMPARE — a balanced, fixed three-task record across the medium
+# control categories. All three agents get the same tasks and native harness.
+[presets.terra-medium-compare]
+samples = ["modernize-scientific-stack", "chess-best-move", "count-dataset-tokens"]
+targets = ["openai-gpt-5.6-terra-medium", "claude-code-sonnet-5", "codex"]
+
 # FULL — the whole 89-task benchmark on one config; the headline number. Each
 # case saves as it lands, so an interrupted run resumes with
 # `mira run --resume <run_id>`.

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fchess_2dbest_2dmove_40claude_2dcode_2dsonnet_2d5/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fchess_2dbest_2dmove_40claude_2dcode_2dsonnet_2d5/result.json
@@ -1,0 +1,62 @@
+{
+  "eval": "terminal_bench",
+  "sample": "chess-best-move",
+  "target": "claude-code-sonnet-5",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 0,
+    "tool_calls_count": 0,
+    "usage": {
+      "input_tokens": 12528,
+      "output_tokens": 9468,
+      "cache_read_tokens": 583241,
+      "cost_usd": 0.2426302
+    },
+    "timing": {
+      "duration_ms": 168301
+    },
+    "metrics": {
+      "cache_read_tokens": 583241.0,
+      "llm_calls": 0.0,
+      "reward": 1.0,
+      "tool_calls": 0.0
+    },
+    "metadata": {
+      "agent": "claude-code",
+      "category": "games",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "anthropic/claude-sonnet-5",
+      "model_effective": null,
+      "model_requested": "anthropic/claude-sonnet-5",
+      "provider": "anthropic",
+      "provider_effective": null,
+      "provider_requested": "anthropic",
+      "reasoning_effort": null,
+      "reasoning_effort_effective": null,
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {},
+      "yolop_version": null
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fchess_2dbest_2dmove_40codex/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fchess_2dbest_2dmove_40codex/result.json
@@ -1,0 +1,62 @@
+{
+  "eval": "terminal_bench",
+  "sample": "chess-best-move",
+  "target": "codex",
+  "passed": false,
+  "aggregate": 0.5,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 0,
+    "tool_calls_count": 0,
+    "usage": {
+      "input_tokens": 14483,
+      "output_tokens": 2403,
+      "cache_read_tokens": 101924,
+      "cost_usd": 0.08541480000000001
+    },
+    "timing": {
+      "duration_ms": 90502
+    },
+    "metrics": {
+      "cache_read_tokens": 101924.0,
+      "llm_calls": 0.0,
+      "reward": 0.0,
+      "tool_calls": 0.0
+    },
+    "metadata": {
+      "agent": "codex",
+      "category": "games",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "model_effective": null,
+      "model_requested": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "provider_effective": null,
+      "provider_requested": "openai",
+      "reasoning_effort": null,
+      "reasoning_effort_effective": null,
+      "reasoning_effort_requested": null,
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {},
+      "yolop_version": null
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fchess_2dbest_2dmove_40openai_2dgpt_2d5_2e6_2dterra_2dmedium/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fchess_2dbest_2dmove_40openai_2dgpt_2d5_2e6_2dterra_2dmedium/result.json
@@ -1,0 +1,85 @@
+{
+  "eval": "terminal_bench",
+  "sample": "chess-best-move",
+  "target": "openai-gpt-5.6-terra-medium",
+  "passed": false,
+  "aggregate": 0.5,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 0.0,
+      "pass": false,
+      "reason": "tests failed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=False",
+    "iterations": 12,
+    "tool_calls_count": 13,
+    "tool_calls": [
+      "write_session_title",
+      "list_directory",
+      "write_todos",
+      "write_todos",
+      "read_file",
+      "read_file",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "progress_checkpoint",
+      "write_file"
+    ],
+    "usage": {
+      "input_tokens": 19789,
+      "output_tokens": 4226,
+      "cache_read_tokens": 131667,
+      "cost_usd": 0.14577925000000003
+    },
+    "timing": {
+      "duration_ms": 106089
+    },
+    "metrics": {
+      "cache_read_tokens": 131667.0,
+      "llm_calls": 12.0,
+      "reward": 0.0,
+      "tool_calls": 13.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "games",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "model_effective": "gpt-5.6-terra",
+      "model_requested": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": "medium",
+      "resolved": false,
+      "reward": 0.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 5,
+        "list_directory": 1,
+        "progress_checkpoint": 1,
+        "read_file": 2,
+        "write_file": 1,
+        "write_session_title": 1,
+        "write_todos": 2
+      },
+      "yolop_version": "0.17.2"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40claude_2dcode_2dsonnet_2d5/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40claude_2dcode_2dsonnet_2d5/result.json
@@ -1,0 +1,62 @@
+{
+  "eval": "terminal_bench",
+  "sample": "count-dataset-tokens",
+  "target": "claude-code-sonnet-5",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 0,
+    "tool_calls_count": 0,
+    "usage": {
+      "input_tokens": 20260,
+      "output_tokens": 3833,
+      "cache_read_tokens": 304728,
+      "cost_usd": 0.1568836
+    },
+    "timing": {
+      "duration_ms": 143250
+    },
+    "metrics": {
+      "cache_read_tokens": 304728.0,
+      "llm_calls": 0.0,
+      "reward": 1.0,
+      "tool_calls": 0.0
+    },
+    "metadata": {
+      "agent": "claude-code",
+      "category": "model-training",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "anthropic/claude-sonnet-5",
+      "model_effective": null,
+      "model_requested": "anthropic/claude-sonnet-5",
+      "provider": "anthropic",
+      "provider_effective": null,
+      "provider_requested": "anthropic",
+      "reasoning_effort": null,
+      "reasoning_effort_effective": null,
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {},
+      "yolop_version": null
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40codex/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40codex/result.json
@@ -1,0 +1,62 @@
+{
+  "eval": "terminal_bench",
+  "sample": "count-dataset-tokens",
+  "target": "codex",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 0,
+    "tool_calls_count": 0,
+    "usage": {
+      "input_tokens": 45581,
+      "output_tokens": 3453,
+      "cache_read_tokens": 372674,
+      "cost_usd": 0.2299008
+    },
+    "timing": {
+      "duration_ms": 120772
+    },
+    "metrics": {
+      "cache_read_tokens": 372674.0,
+      "llm_calls": 0.0,
+      "reward": 1.0,
+      "tool_calls": 0.0
+    },
+    "metadata": {
+      "agent": "codex",
+      "category": "model-training",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "model_effective": null,
+      "model_requested": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "provider_effective": null,
+      "provider_requested": "openai",
+      "reasoning_effort": null,
+      "reasoning_effort_effective": null,
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {},
+      "yolop_version": null
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40openai_2dgpt_2d5_2e6_2dterra_2dmedium/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fcount_2ddataset_2dtokens_40openai_2dgpt_2d5_2e6_2dterra_2dmedium/result.json
@@ -1,0 +1,87 @@
+{
+  "eval": "terminal_bench",
+  "sample": "count-dataset-tokens",
+  "target": "openai-gpt-5.6-terra-medium",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 18,
+    "tool_calls_count": 17,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "write_todos",
+      "web_fetch",
+      "web_fetch",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "bash",
+      "progress_checkpoint",
+      "progress_checkpoint",
+      "progress_checkpoint"
+    ],
+    "usage": {
+      "input_tokens": 38820,
+      "output_tokens": 4929,
+      "cache_read_tokens": 237085,
+      "cost_usd": 0.23025625
+    },
+    "timing": {
+      "duration_ms": 139573
+    },
+    "metrics": {
+      "cache_read_tokens": 237085.0,
+      "llm_calls": 18.0,
+      "reward": 1.0,
+      "tool_calls": 17.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "model-training",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "model_effective": "gpt-5.6-terra",
+      "model_requested": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": "medium",
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 8,
+        "progress_checkpoint": 3,
+        "web_fetch": 2,
+        "write_session_title": 1,
+        "write_todos": 3
+      },
+      "yolop_version": "0.17.2"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40claude_2dcode_2dsonnet_2d5/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40claude_2dcode_2dsonnet_2d5/result.json
@@ -1,0 +1,62 @@
+{
+  "eval": "terminal_bench",
+  "sample": "modernize-scientific-stack",
+  "target": "claude-code-sonnet-5",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 0,
+    "tool_calls_count": 0,
+    "usage": {
+      "input_tokens": 7163,
+      "output_tokens": 1265,
+      "cache_read_tokens": 112064,
+      "cost_usd": 0.05296630000000001
+    },
+    "timing": {
+      "duration_ms": 65075
+    },
+    "metrics": {
+      "cache_read_tokens": 112064.0,
+      "llm_calls": 0.0,
+      "reward": 1.0,
+      "tool_calls": 0.0
+    },
+    "metadata": {
+      "agent": "claude-code",
+      "category": "scientific-computing",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "anthropic/claude-sonnet-5",
+      "model_effective": null,
+      "model_requested": "anthropic/claude-sonnet-5",
+      "provider": "anthropic",
+      "provider_effective": null,
+      "provider_requested": "anthropic",
+      "reasoning_effort": null,
+      "reasoning_effort_effective": null,
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {},
+      "yolop_version": null
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40codex/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40codex/result.json
@@ -1,0 +1,62 @@
+{
+  "eval": "terminal_bench",
+  "sample": "modernize-scientific-stack",
+  "target": "codex",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 0,
+    "tool_calls_count": 0,
+    "usage": {
+      "input_tokens": 15322,
+      "output_tokens": 1044,
+      "cache_read_tokens": 38013,
+      "cost_usd": 0.058429600000000005
+    },
+    "timing": {
+      "duration_ms": 71157
+    },
+    "metrics": {
+      "cache_read_tokens": 38013.0,
+      "llm_calls": 0.0,
+      "reward": 1.0,
+      "tool_calls": 0.0
+    },
+    "metadata": {
+      "agent": "codex",
+      "category": "scientific-computing",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "model_effective": null,
+      "model_requested": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "provider_effective": null,
+      "provider_requested": "openai",
+      "reasoning_effort": null,
+      "reasoning_effort_effective": null,
+      "reasoning_effort_requested": null,
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {},
+      "yolop_version": null
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40openai_2dgpt_2d5_2e6_2dterra_2dmedium/result.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/cases/terminal_5fbench_2fmodernize_2dscientific_2dstack_40openai_2dgpt_2d5_2e6_2dterra_2dmedium/result.json
@@ -1,0 +1,85 @@
+{
+  "eval": "terminal_bench",
+  "sample": "modernize-scientific-stack",
+  "target": "openai-gpt-5.6-terra-medium",
+  "passed": true,
+  "aggregate": 1.0,
+  "scores": [
+    {
+      "scorer": "succeeded",
+      "value": 1.0,
+      "pass": true,
+      "reason": "no error"
+    },
+    {
+      "scorer": "resolved",
+      "value": 1.0,
+      "pass": true,
+      "reason": "tests passed"
+    }
+  ],
+  "transcript": {
+    "final_response": "resolved=True",
+    "iterations": 9,
+    "tool_calls_count": 12,
+    "tool_calls": [
+      "write_session_title",
+      "write_todos",
+      "write_todos",
+      "repo_map",
+      "list_directory",
+      "list_directory",
+      "read_many_files",
+      "progress_checkpoint",
+      "write_file",
+      "write_file",
+      "bash",
+      "bash"
+    ],
+    "usage": {
+      "input_tokens": 13301,
+      "output_tokens": 1459,
+      "cache_read_tokens": 85493,
+      "cost_usd": 0.07651074999999999
+    },
+    "timing": {
+      "duration_ms": 61294
+    },
+    "metrics": {
+      "cache_read_tokens": 85493.0,
+      "llm_calls": 9.0,
+      "reward": 1.0,
+      "tool_calls": 12.0
+    },
+    "metadata": {
+      "agent": "yolop",
+      "category": "scientific-computing",
+      "difficulty": "medium",
+      "exception": null,
+      "model": "openai/gpt-5.6-terra",
+      "model_effective": "gpt-5.6-terra",
+      "model_requested": "openai/gpt-5.6-terra",
+      "provider": "openai",
+      "provider_effective": "openai",
+      "provider_requested": "openai",
+      "reasoning_effort": "medium",
+      "reasoning_effort_effective": "medium",
+      "reasoning_effort_requested": "medium",
+      "resolved": true,
+      "reward": 1.0,
+      "stop_reason": "completed",
+      "tools_used": {
+        "bash": 2,
+        "list_directory": 2,
+        "progress_checkpoint": 1,
+        "read_many_files": 1,
+        "repo_map": 1,
+        "write_file": 2,
+        "write_session_title": 1,
+        "write_todos": 2
+      },
+      "yolop_version": "0.17.2"
+    }
+  },
+  "skipped": false
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/meta.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/meta.json
@@ -1,0 +1,33 @@
+{
+  "format": 1,
+  "run_id": "20260904T012919Z-eafd",
+  "study": "terminal_bench",
+  "study_version": "0.1.0",
+  "started_unix": 1788485359,
+  "finished_unix": 1788486325,
+  "environment": {
+    "git": {
+      "commit": "48b0fb62d3c01baea7181138c7d48edbec9d70ba",
+      "dirty": true
+    },
+    "os": "macos",
+    "arch": "aarch64",
+    "hostname": "Mykhailos-Mac-mini.local",
+    "cpus": 12,
+    "mira_version": "0.3.0",
+    "labels": {
+      "benchmark": "terminal-bench-2-1"
+    }
+  },
+  "summary": {
+    "scored": 9,
+    "passed": 7,
+    "failed": 2,
+    "na": 0,
+    "skipped": 0,
+    "total_tokens": 219327,
+    "total_cost_usd": 1.27877155,
+    "total_tool_calls": 42,
+    "total_duration_ms": 966013
+  }
+}

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/report.html
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/report.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mira eval report</title>
+<style>
+:root{color-scheme:light dark;--ok:#1a7f37;--bad:#cf222e;--warn:#9a6700;--mut:#57606a;--bg:#fff;--fg:#1f2328;--line:#d0d7de}
+@media(prefers-color-scheme:dark){:root{--bg:#0d1117;--fg:#e6edf3;--line:#30363d;--mut:#8b949e}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif}
+main{max-width:960px;margin:0 auto;padding:2rem 1.25rem}
+h1{font-size:1.6rem;margin:0 0 1rem}h2{font-size:1.15rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem}
+.cards{display:flex;flex-wrap:wrap;gap:.75rem}
+.card{flex:1;min-width:96px;border:1px solid var(--line);border-radius:8px;padding:.75rem 1rem;text-align:center}
+.card b{display:block;font-size:1.5rem}.card span{color:var(--mut);font-size:.8rem;text-transform:uppercase;letter-spacing:.04em}
+.card.ok b{color:var(--ok)}.card.bad b{color:var(--bad)}.card.warn b{color:var(--warn)}
+table.matrix{border-collapse:collapse;width:100%}table.matrix th,table.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:center}
+table.matrix td:first-child,table.matrix th:first-child{text-align:left}
+.case{border:1px solid var(--line);border-radius:8px;margin:.5rem 0;padding:.25rem .75rem}
+.case summary{cursor:pointer;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap}
+.case code{font-size:.92rem}.metrics{color:var(--mut);font-size:.8rem;margin-left:auto}
+.badge{font-size:.7rem;font-weight:700;padding:.1rem .4rem;border-radius:4px;color:#fff}
+.badge.pass{background:var(--ok)}.badge.fail{background:var(--bad)}.badge.skip{background:var(--mut)}.badge.na{background:var(--warn)}
+.scores{list-style:none;padding:0;margin:.5rem 0}.scores li{padding:.15rem 0}.scores li.pass{color:var(--ok)}.scores li.fail{color:var(--bad)}.scores li.na{color:var(--mut)}
+.tools,.meta{font-size:.85rem;color:var(--mut)}
+pre{background:rgba(127,127,127,.1);border-radius:6px;padding:.6rem .75rem;overflow:auto;font-size:.85rem;white-space:pre-wrap}
+pre.error{color:var(--bad)}a{color:#0969da}
+</style>
+</head>
+<body>
+<main>
+<h1>Mira eval report</h1>
+<section class="cards">
+<div class="card bad"><b>7/9</b><span>passed</span></div>
+<div class="card"><b>2</b><span>failed</span></div>
+<div class="card"><b>0</b><span>n/a</span></div>
+<div class="card"><b>0</b><span>skipped</span></div>
+<div class="card"><b>219327</b><span>tokens</span></div>
+<div class="card"><b>$1.2788</b><span>cost</span></div>
+</section>
+<h2>Matrix</h2>
+<table class="matrix">
+<thead><tr><th>eval</th><th>openai-gpt-5.6-terra-medium</th><th>claude-code-sonnet-5</th><th>codex</th></tr></thead>
+<tbody>
+<tr><td>terminal_bench</td><td>2/3</td><td>3/3</td><td>2/3</td></tr>
+</tbody>
+</table>
+<h2>Resolve rate by agent</h2>
+<table class="matrix">
+<thead><tr><th>agent</th><th>passed</th><th>scored</th><th>rate</th></tr></thead>
+<tbody>
+<tr><td>claude-code</td><td>3</td><td>3</td><td>100%</td></tr>
+<tr><td>codex</td><td>2</td><td>3</td><td>67%</td></tr>
+<tr><td>yolop</td><td>2</td><td>3</td><td>67%</td></tr>
+</tbody>
+</table>
+<h2>Cases</h2>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/chess-best-move@openai-gpt-5.6-terra-medium</code><span class="metrics">24015 tok · $0.1458 · 106089ms · 13 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, list_directory, write_todos, write_todos, read_file, read_file, bash, bash, bash, bash, bash, progress_checkpoint, write_file</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=131667, llm_calls=12, reward=0, tool_calls=13</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=games, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, model_effective=gpt-5.6-terra, model_requested=openai/gpt-5.6-terra, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=medium, resolved=false, reward=0.0, stop_reason=completed, tools_used={"bash":5,"list_directory":1,"progress_checkpoint":1,"read_file":2,"write_file":1,"write_session_title":1,"write_todos":2}, yolop_version=0.17.2</p>
+<pre class="response">resolved=False</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/chess-best-move@claude-code-sonnet-5</code><span class="metrics">21996 tok · $0.2426 · 168301ms · 0 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="meta"><b>metrics:</b> cache_read_tokens=583241, llm_calls=0, reward=1, tool_calls=0</p>
+<p class="meta"><b>metadata:</b> agent=claude-code, category=games, difficulty=medium, exception=null, model=anthropic/claude-sonnet-5, model_effective=null, model_requested=anthropic/claude-sonnet-5, provider=anthropic, provider_effective=null, provider_requested=anthropic, reasoning_effort=null, reasoning_effort_effective=null, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={}, yolop_version=null</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case fail">
+<summary><span class="badge fail">FAIL</span> <code>terminal_bench/chess-best-move@codex</code><span class="metrics">16886 tok · $0.0854 · 90502ms · 0 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="fail">✗ <b>resolved</b> — tests failed</li>
+</ul>
+<p class="meta"><b>metrics:</b> cache_read_tokens=101924, llm_calls=0, reward=0, tool_calls=0</p>
+<p class="meta"><b>metadata:</b> agent=codex, category=games, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, model_effective=null, model_requested=openai/gpt-5.6-terra, provider=openai, provider_effective=null, provider_requested=openai, reasoning_effort=null, reasoning_effort_effective=null, reasoning_effort_requested=null, resolved=false, reward=0.0, stop_reason=completed, tools_used={}, yolop_version=null</p>
+<pre class="response">resolved=False</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/count-dataset-tokens@openai-gpt-5.6-terra-medium</code><span class="metrics">43749 tok · $0.2303 · 139573ms · 17 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, write_todos, web_fetch, web_fetch, bash, bash, bash, bash, bash, bash, bash, bash, progress_checkpoint, progress_checkpoint, progress_checkpoint</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=237085, llm_calls=18, reward=1, tool_calls=17</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=model-training, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, model_effective=gpt-5.6-terra, model_requested=openai/gpt-5.6-terra, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=medium, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":8,"progress_checkpoint":3,"web_fetch":2,"write_session_title":1,"write_todos":3}, yolop_version=0.17.2</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/count-dataset-tokens@claude-code-sonnet-5</code><span class="metrics">24093 tok · $0.1569 · 143250ms · 0 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="meta"><b>metrics:</b> cache_read_tokens=304728, llm_calls=0, reward=1, tool_calls=0</p>
+<p class="meta"><b>metadata:</b> agent=claude-code, category=model-training, difficulty=medium, exception=null, model=anthropic/claude-sonnet-5, model_effective=null, model_requested=anthropic/claude-sonnet-5, provider=anthropic, provider_effective=null, provider_requested=anthropic, reasoning_effort=null, reasoning_effort_effective=null, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={}, yolop_version=null</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/count-dataset-tokens@codex</code><span class="metrics">49034 tok · $0.2299 · 120772ms · 0 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="meta"><b>metrics:</b> cache_read_tokens=372674, llm_calls=0, reward=1, tool_calls=0</p>
+<p class="meta"><b>metadata:</b> agent=codex, category=model-training, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, model_effective=null, model_requested=openai/gpt-5.6-terra, provider=openai, provider_effective=null, provider_requested=openai, reasoning_effort=null, reasoning_effort_effective=null, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={}, yolop_version=null</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/modernize-scientific-stack@openai-gpt-5.6-terra-medium</code><span class="metrics">14760 tok · $0.0765 · 61294ms · 12 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="tools"><b>tools:</b> write_session_title, write_todos, write_todos, repo_map, list_directory, list_directory, read_many_files, progress_checkpoint, write_file, write_file, bash, bash</p>
+<p class="meta"><b>metrics:</b> cache_read_tokens=85493, llm_calls=9, reward=1, tool_calls=12</p>
+<p class="meta"><b>metadata:</b> agent=yolop, category=scientific-computing, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, model_effective=gpt-5.6-terra, model_requested=openai/gpt-5.6-terra, provider=openai, provider_effective=openai, provider_requested=openai, reasoning_effort=medium, reasoning_effort_effective=medium, reasoning_effort_requested=medium, resolved=true, reward=1.0, stop_reason=completed, tools_used={"bash":2,"list_directory":2,"progress_checkpoint":1,"read_many_files":1,"repo_map":1,"write_file":2,"write_session_title":1,"write_todos":2}, yolop_version=0.17.2</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/modernize-scientific-stack@claude-code-sonnet-5</code><span class="metrics">8428 tok · $0.0530 · 65075ms · 0 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="meta"><b>metrics:</b> cache_read_tokens=112064, llm_calls=0, reward=1, tool_calls=0</p>
+<p class="meta"><b>metadata:</b> agent=claude-code, category=scientific-computing, difficulty=medium, exception=null, model=anthropic/claude-sonnet-5, model_effective=null, model_requested=anthropic/claude-sonnet-5, provider=anthropic, provider_effective=null, provider_requested=anthropic, reasoning_effort=null, reasoning_effort_effective=null, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={}, yolop_version=null</p>
+<pre class="response">resolved=True</pre>
+</details>
+<details class="case pass">
+<summary><span class="badge pass">PASS</span> <code>terminal_bench/modernize-scientific-stack@codex</code><span class="metrics">16366 tok · $0.0584 · 71157ms · 0 tool calls</span></summary>
+<ul class="scores">
+<li class="pass">✓ <b>succeeded</b> — no error</li>
+<li class="pass">✓ <b>resolved</b> — tests passed</li>
+</ul>
+<p class="meta"><b>metrics:</b> cache_read_tokens=38013, llm_calls=0, reward=1, tool_calls=0</p>
+<p class="meta"><b>metadata:</b> agent=codex, category=scientific-computing, difficulty=medium, exception=null, model=openai/gpt-5.6-terra, model_effective=null, model_requested=openai/gpt-5.6-terra, provider=openai, provider_effective=null, provider_requested=openai, reasoning_effort=null, reasoning_effort_effective=null, reasoning_effort_requested=null, resolved=true, reward=1.0, stop_reason=completed, tools_used={}, yolop_version=null</p>
+<pre class="response">resolved=True</pre>
+</details>
+<script type="application/json" id="mira-data">
+{"cases":[{"aggregate":0.5,"eval":"terminal_bench","passed":false,"sample":"chess-best-move","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"openai-gpt-5.6-terra-medium","transcript":{"final_response":"resolved=False","iterations":12,"metadata":{"agent":"yolop","category":"games","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","model_effective":"gpt-5.6-terra","model_requested":"openai/gpt-5.6-terra","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":"medium","resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{"bash":5,"list_directory":1,"progress_checkpoint":1,"read_file":2,"write_file":1,"write_session_title":1,"write_todos":2},"yolop_version":"0.17.2"},"metrics":{"cache_read_tokens":131667.0,"llm_calls":12.0,"reward":0.0,"tool_calls":13.0},"timing":{"duration_ms":106089},"tool_calls":["write_session_title","list_directory","write_todos","write_todos","read_file","read_file","bash","bash","bash","bash","bash","progress_checkpoint","write_file"],"tool_calls_count":13,"usage":{"cache_read_tokens":131667,"cost_usd":0.14577925000000003,"input_tokens":19789,"output_tokens":4226}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"chess-best-move","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"claude-code-sonnet-5","transcript":{"final_response":"resolved=True","iterations":0,"metadata":{"agent":"claude-code","category":"games","difficulty":"medium","exception":null,"model":"anthropic/claude-sonnet-5","model_effective":null,"model_requested":"anthropic/claude-sonnet-5","provider":"anthropic","provider_effective":null,"provider_requested":"anthropic","reasoning_effort":null,"reasoning_effort_effective":null,"reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{},"yolop_version":null},"metrics":{"cache_read_tokens":583241.0,"llm_calls":0.0,"reward":1.0,"tool_calls":0.0},"timing":{"duration_ms":168301},"tool_calls_count":0,"usage":{"cache_read_tokens":583241,"cost_usd":0.2426302,"input_tokens":12528,"output_tokens":9468}}},{"aggregate":0.5,"eval":"terminal_bench","passed":false,"sample":"chess-best-move","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":false,"reason":"tests failed","scorer":"resolved","value":0.0}],"skipped":false,"target":"codex","transcript":{"final_response":"resolved=False","iterations":0,"metadata":{"agent":"codex","category":"games","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","model_effective":null,"model_requested":"openai/gpt-5.6-terra","provider":"openai","provider_effective":null,"provider_requested":"openai","reasoning_effort":null,"reasoning_effort_effective":null,"reasoning_effort_requested":null,"resolved":false,"reward":0.0,"stop_reason":"completed","tools_used":{},"yolop_version":null},"metrics":{"cache_read_tokens":101924.0,"llm_calls":0.0,"reward":0.0,"tool_calls":0.0},"timing":{"duration_ms":90502},"tool_calls_count":0,"usage":{"cache_read_tokens":101924,"cost_usd":0.08541480000000001,"input_tokens":14483,"output_tokens":2403}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"count-dataset-tokens","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra-medium","transcript":{"final_response":"resolved=True","iterations":18,"metadata":{"agent":"yolop","category":"model-training","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","model_effective":"gpt-5.6-terra","model_requested":"openai/gpt-5.6-terra","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":"medium","resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":8,"progress_checkpoint":3,"web_fetch":2,"write_session_title":1,"write_todos":3},"yolop_version":"0.17.2"},"metrics":{"cache_read_tokens":237085.0,"llm_calls":18.0,"reward":1.0,"tool_calls":17.0},"timing":{"duration_ms":139573},"tool_calls":["write_session_title","write_todos","write_todos","write_todos","web_fetch","web_fetch","bash","bash","bash","bash","bash","bash","bash","bash","progress_checkpoint","progress_checkpoint","progress_checkpoint"],"tool_calls_count":17,"usage":{"cache_read_tokens":237085,"cost_usd":0.23025625,"input_tokens":38820,"output_tokens":4929}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"count-dataset-tokens","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"claude-code-sonnet-5","transcript":{"final_response":"resolved=True","iterations":0,"metadata":{"agent":"claude-code","category":"model-training","difficulty":"medium","exception":null,"model":"anthropic/claude-sonnet-5","model_effective":null,"model_requested":"anthropic/claude-sonnet-5","provider":"anthropic","provider_effective":null,"provider_requested":"anthropic","reasoning_effort":null,"reasoning_effort_effective":null,"reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{},"yolop_version":null},"metrics":{"cache_read_tokens":304728.0,"llm_calls":0.0,"reward":1.0,"tool_calls":0.0},"timing":{"duration_ms":143250},"tool_calls_count":0,"usage":{"cache_read_tokens":304728,"cost_usd":0.1568836,"input_tokens":20260,"output_tokens":3833}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"count-dataset-tokens","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"codex","transcript":{"final_response":"resolved=True","iterations":0,"metadata":{"agent":"codex","category":"model-training","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","model_effective":null,"model_requested":"openai/gpt-5.6-terra","provider":"openai","provider_effective":null,"provider_requested":"openai","reasoning_effort":null,"reasoning_effort_effective":null,"reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{},"yolop_version":null},"metrics":{"cache_read_tokens":372674.0,"llm_calls":0.0,"reward":1.0,"tool_calls":0.0},"timing":{"duration_ms":120772},"tool_calls_count":0,"usage":{"cache_read_tokens":372674,"cost_usd":0.2299008,"input_tokens":45581,"output_tokens":3453}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"modernize-scientific-stack","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"openai-gpt-5.6-terra-medium","transcript":{"final_response":"resolved=True","iterations":9,"metadata":{"agent":"yolop","category":"scientific-computing","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","model_effective":"gpt-5.6-terra","model_requested":"openai/gpt-5.6-terra","provider":"openai","provider_effective":"openai","provider_requested":"openai","reasoning_effort":"medium","reasoning_effort_effective":"medium","reasoning_effort_requested":"medium","resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{"bash":2,"list_directory":2,"progress_checkpoint":1,"read_many_files":1,"repo_map":1,"write_file":2,"write_session_title":1,"write_todos":2},"yolop_version":"0.17.2"},"metrics":{"cache_read_tokens":85493.0,"llm_calls":9.0,"reward":1.0,"tool_calls":12.0},"timing":{"duration_ms":61294},"tool_calls":["write_session_title","write_todos","write_todos","repo_map","list_directory","list_directory","read_many_files","progress_checkpoint","write_file","write_file","bash","bash"],"tool_calls_count":12,"usage":{"cache_read_tokens":85493,"cost_usd":0.07651074999999999,"input_tokens":13301,"output_tokens":1459}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"modernize-scientific-stack","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"claude-code-sonnet-5","transcript":{"final_response":"resolved=True","iterations":0,"metadata":{"agent":"claude-code","category":"scientific-computing","difficulty":"medium","exception":null,"model":"anthropic/claude-sonnet-5","model_effective":null,"model_requested":"anthropic/claude-sonnet-5","provider":"anthropic","provider_effective":null,"provider_requested":"anthropic","reasoning_effort":null,"reasoning_effort_effective":null,"reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{},"yolop_version":null},"metrics":{"cache_read_tokens":112064.0,"llm_calls":0.0,"reward":1.0,"tool_calls":0.0},"timing":{"duration_ms":65075},"tool_calls_count":0,"usage":{"cache_read_tokens":112064,"cost_usd":0.05296630000000001,"input_tokens":7163,"output_tokens":1265}}},{"aggregate":1.0,"eval":"terminal_bench","passed":true,"sample":"modernize-scientific-stack","scores":[{"pass":true,"reason":"no error","scorer":"succeeded","value":1.0},{"pass":true,"reason":"tests passed","scorer":"resolved","value":1.0}],"skipped":false,"target":"codex","transcript":{"final_response":"resolved=True","iterations":0,"metadata":{"agent":"codex","category":"scientific-computing","difficulty":"medium","exception":null,"model":"openai/gpt-5.6-terra","model_effective":null,"model_requested":"openai/gpt-5.6-terra","provider":"openai","provider_effective":null,"provider_requested":"openai","reasoning_effort":null,"reasoning_effort_effective":null,"reasoning_effort_requested":null,"resolved":true,"reward":1.0,"stop_reason":"completed","tools_used":{},"yolop_version":null},"metrics":{"cache_read_tokens":38013.0,"llm_calls":0.0,"reward":1.0,"tool_calls":0.0},"timing":{"duration_ms":71157},"tool_calls_count":0,"usage":{"cache_read_tokens":38013,"cost_usd":0.058429600000000005,"input_tokens":15322,"output_tokens":1044}}}],"groups":{"agent":{"claude-code":{"passed":3,"scored":3},"codex":{"passed":2,"scored":3},"yolop":{"passed":2,"scored":3}}},"summary":{"failed":2,"na":0,"passed":7,"scored":9,"skipped":0,"total_cost_usd":1.27877155,"total_duration_ms":966013,"total_tokens":219327,"total_tool_calls":42}}
+</script>
+</main>
+</body>
+</html>

--- a/evals/terminal_bench/results/20260904T012919Z-eafd/report.json
+++ b/evals/terminal_bench/results/20260904T012919Z-eafd/report.json
@@ -1,0 +1,660 @@
+{
+  "cases": [
+    {
+      "aggregate": 0.5,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "chess-best-move",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra-medium",
+      "transcript": {
+        "final_response": "resolved=False",
+        "iterations": 12,
+        "metadata": {
+          "agent": "yolop",
+          "category": "games",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "model_effective": "gpt-5.6-terra",
+          "model_requested": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": "medium",
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 5,
+            "list_directory": 1,
+            "progress_checkpoint": 1,
+            "read_file": 2,
+            "write_file": 1,
+            "write_session_title": 1,
+            "write_todos": 2
+          },
+          "yolop_version": "0.17.2"
+        },
+        "metrics": {
+          "cache_read_tokens": 131667.0,
+          "llm_calls": 12.0,
+          "reward": 0.0,
+          "tool_calls": 13.0
+        },
+        "timing": {
+          "duration_ms": 106089
+        },
+        "tool_calls": [
+          "write_session_title",
+          "list_directory",
+          "write_todos",
+          "write_todos",
+          "read_file",
+          "read_file",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "progress_checkpoint",
+          "write_file"
+        ],
+        "tool_calls_count": 13,
+        "usage": {
+          "cache_read_tokens": 131667,
+          "cost_usd": 0.14577925000000003,
+          "input_tokens": 19789,
+          "output_tokens": 4226
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "chess-best-move",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "claude-code-sonnet-5",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 0,
+        "metadata": {
+          "agent": "claude-code",
+          "category": "games",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "anthropic/claude-sonnet-5",
+          "model_effective": null,
+          "model_requested": "anthropic/claude-sonnet-5",
+          "provider": "anthropic",
+          "provider_effective": null,
+          "provider_requested": "anthropic",
+          "reasoning_effort": null,
+          "reasoning_effort_effective": null,
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {},
+          "yolop_version": null
+        },
+        "metrics": {
+          "cache_read_tokens": 583241.0,
+          "llm_calls": 0.0,
+          "reward": 1.0,
+          "tool_calls": 0.0
+        },
+        "timing": {
+          "duration_ms": 168301
+        },
+        "tool_calls_count": 0,
+        "usage": {
+          "cache_read_tokens": 583241,
+          "cost_usd": 0.2426302,
+          "input_tokens": 12528,
+          "output_tokens": 9468
+        }
+      }
+    },
+    {
+      "aggregate": 0.5,
+      "eval": "terminal_bench",
+      "passed": false,
+      "sample": "chess-best-move",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": false,
+          "reason": "tests failed",
+          "scorer": "resolved",
+          "value": 0.0
+        }
+      ],
+      "skipped": false,
+      "target": "codex",
+      "transcript": {
+        "final_response": "resolved=False",
+        "iterations": 0,
+        "metadata": {
+          "agent": "codex",
+          "category": "games",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "model_effective": null,
+          "model_requested": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "provider_effective": null,
+          "provider_requested": "openai",
+          "reasoning_effort": null,
+          "reasoning_effort_effective": null,
+          "reasoning_effort_requested": null,
+          "resolved": false,
+          "reward": 0.0,
+          "stop_reason": "completed",
+          "tools_used": {},
+          "yolop_version": null
+        },
+        "metrics": {
+          "cache_read_tokens": 101924.0,
+          "llm_calls": 0.0,
+          "reward": 0.0,
+          "tool_calls": 0.0
+        },
+        "timing": {
+          "duration_ms": 90502
+        },
+        "tool_calls_count": 0,
+        "usage": {
+          "cache_read_tokens": 101924,
+          "cost_usd": 0.08541480000000001,
+          "input_tokens": 14483,
+          "output_tokens": 2403
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "count-dataset-tokens",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra-medium",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 18,
+        "metadata": {
+          "agent": "yolop",
+          "category": "model-training",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "model_effective": "gpt-5.6-terra",
+          "model_requested": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": "medium",
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 8,
+            "progress_checkpoint": 3,
+            "web_fetch": 2,
+            "write_session_title": 1,
+            "write_todos": 3
+          },
+          "yolop_version": "0.17.2"
+        },
+        "metrics": {
+          "cache_read_tokens": 237085.0,
+          "llm_calls": 18.0,
+          "reward": 1.0,
+          "tool_calls": 17.0
+        },
+        "timing": {
+          "duration_ms": 139573
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "write_todos",
+          "web_fetch",
+          "web_fetch",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "bash",
+          "progress_checkpoint",
+          "progress_checkpoint",
+          "progress_checkpoint"
+        ],
+        "tool_calls_count": 17,
+        "usage": {
+          "cache_read_tokens": 237085,
+          "cost_usd": 0.23025625,
+          "input_tokens": 38820,
+          "output_tokens": 4929
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "count-dataset-tokens",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "claude-code-sonnet-5",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 0,
+        "metadata": {
+          "agent": "claude-code",
+          "category": "model-training",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "anthropic/claude-sonnet-5",
+          "model_effective": null,
+          "model_requested": "anthropic/claude-sonnet-5",
+          "provider": "anthropic",
+          "provider_effective": null,
+          "provider_requested": "anthropic",
+          "reasoning_effort": null,
+          "reasoning_effort_effective": null,
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {},
+          "yolop_version": null
+        },
+        "metrics": {
+          "cache_read_tokens": 304728.0,
+          "llm_calls": 0.0,
+          "reward": 1.0,
+          "tool_calls": 0.0
+        },
+        "timing": {
+          "duration_ms": 143250
+        },
+        "tool_calls_count": 0,
+        "usage": {
+          "cache_read_tokens": 304728,
+          "cost_usd": 0.1568836,
+          "input_tokens": 20260,
+          "output_tokens": 3833
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "count-dataset-tokens",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "codex",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 0,
+        "metadata": {
+          "agent": "codex",
+          "category": "model-training",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "model_effective": null,
+          "model_requested": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "provider_effective": null,
+          "provider_requested": "openai",
+          "reasoning_effort": null,
+          "reasoning_effort_effective": null,
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {},
+          "yolop_version": null
+        },
+        "metrics": {
+          "cache_read_tokens": 372674.0,
+          "llm_calls": 0.0,
+          "reward": 1.0,
+          "tool_calls": 0.0
+        },
+        "timing": {
+          "duration_ms": 120772
+        },
+        "tool_calls_count": 0,
+        "usage": {
+          "cache_read_tokens": 372674,
+          "cost_usd": 0.2299008,
+          "input_tokens": 45581,
+          "output_tokens": 3453
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "modernize-scientific-stack",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "openai-gpt-5.6-terra-medium",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 9,
+        "metadata": {
+          "agent": "yolop",
+          "category": "scientific-computing",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "model_effective": "gpt-5.6-terra",
+          "model_requested": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "provider_effective": "openai",
+          "provider_requested": "openai",
+          "reasoning_effort": "medium",
+          "reasoning_effort_effective": "medium",
+          "reasoning_effort_requested": "medium",
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {
+            "bash": 2,
+            "list_directory": 2,
+            "progress_checkpoint": 1,
+            "read_many_files": 1,
+            "repo_map": 1,
+            "write_file": 2,
+            "write_session_title": 1,
+            "write_todos": 2
+          },
+          "yolop_version": "0.17.2"
+        },
+        "metrics": {
+          "cache_read_tokens": 85493.0,
+          "llm_calls": 9.0,
+          "reward": 1.0,
+          "tool_calls": 12.0
+        },
+        "timing": {
+          "duration_ms": 61294
+        },
+        "tool_calls": [
+          "write_session_title",
+          "write_todos",
+          "write_todos",
+          "repo_map",
+          "list_directory",
+          "list_directory",
+          "read_many_files",
+          "progress_checkpoint",
+          "write_file",
+          "write_file",
+          "bash",
+          "bash"
+        ],
+        "tool_calls_count": 12,
+        "usage": {
+          "cache_read_tokens": 85493,
+          "cost_usd": 0.07651074999999999,
+          "input_tokens": 13301,
+          "output_tokens": 1459
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "modernize-scientific-stack",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "claude-code-sonnet-5",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 0,
+        "metadata": {
+          "agent": "claude-code",
+          "category": "scientific-computing",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "anthropic/claude-sonnet-5",
+          "model_effective": null,
+          "model_requested": "anthropic/claude-sonnet-5",
+          "provider": "anthropic",
+          "provider_effective": null,
+          "provider_requested": "anthropic",
+          "reasoning_effort": null,
+          "reasoning_effort_effective": null,
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {},
+          "yolop_version": null
+        },
+        "metrics": {
+          "cache_read_tokens": 112064.0,
+          "llm_calls": 0.0,
+          "reward": 1.0,
+          "tool_calls": 0.0
+        },
+        "timing": {
+          "duration_ms": 65075
+        },
+        "tool_calls_count": 0,
+        "usage": {
+          "cache_read_tokens": 112064,
+          "cost_usd": 0.05296630000000001,
+          "input_tokens": 7163,
+          "output_tokens": 1265
+        }
+      }
+    },
+    {
+      "aggregate": 1.0,
+      "eval": "terminal_bench",
+      "passed": true,
+      "sample": "modernize-scientific-stack",
+      "scores": [
+        {
+          "pass": true,
+          "reason": "no error",
+          "scorer": "succeeded",
+          "value": 1.0
+        },
+        {
+          "pass": true,
+          "reason": "tests passed",
+          "scorer": "resolved",
+          "value": 1.0
+        }
+      ],
+      "skipped": false,
+      "target": "codex",
+      "transcript": {
+        "final_response": "resolved=True",
+        "iterations": 0,
+        "metadata": {
+          "agent": "codex",
+          "category": "scientific-computing",
+          "difficulty": "medium",
+          "exception": null,
+          "model": "openai/gpt-5.6-terra",
+          "model_effective": null,
+          "model_requested": "openai/gpt-5.6-terra",
+          "provider": "openai",
+          "provider_effective": null,
+          "provider_requested": "openai",
+          "reasoning_effort": null,
+          "reasoning_effort_effective": null,
+          "reasoning_effort_requested": null,
+          "resolved": true,
+          "reward": 1.0,
+          "stop_reason": "completed",
+          "tools_used": {},
+          "yolop_version": null
+        },
+        "metrics": {
+          "cache_read_tokens": 38013.0,
+          "llm_calls": 0.0,
+          "reward": 1.0,
+          "tool_calls": 0.0
+        },
+        "timing": {
+          "duration_ms": 71157
+        },
+        "tool_calls_count": 0,
+        "usage": {
+          "cache_read_tokens": 38013,
+          "cost_usd": 0.058429600000000005,
+          "input_tokens": 15322,
+          "output_tokens": 1044
+        }
+      }
+    }
+  ],
+  "groups": {
+    "agent": {
+      "claude-code": {
+        "passed": 3,
+        "scored": 3
+      },
+      "codex": {
+        "passed": 2,
+        "scored": 3
+      },
+      "yolop": {
+        "passed": 2,
+        "scored": 3
+      }
+    }
+  },
+  "summary": {
+    "failed": 2,
+    "na": 0,
+    "passed": 7,
+    "scored": 9,
+    "skipped": 0,
+    "total_cost_usd": 1.27877155,
+    "total_duration_ms": 966013,
+    "total_tokens": 219327,
+    "total_tool_calls": 42
+  }
+}

--- a/evals/terminal_bench/terminal_bench.py
+++ b/evals/terminal_bench/terminal_bench.py
@@ -37,7 +37,7 @@ CLI flags): `TB_YOLOP_BIN` (yolop binary to upload; default the musl build),
 (pre-downloaded task tree), `TB_AGENT_ENV` / `TB_VERIFIER_ENV` (comma-separated
 `KEY=VALUE` passed into the agent's resp. the verifier's environment),
 `TB_CA_CERT` (CA bundle to install in the container, for sandboxes behind a
-TLS-terminating proxy), `TB_JOB_TIMEOUT`,
+TLS-terminating proxy), `TB_OVERRIDE_MEMORY_MB` (shared task-container memory), `TB_JOB_TIMEOUT`,
 `TB_TIMEOUT_MULTIPLIER`, `TB_KEEP_JOBS=0` (discard retained Harbor job dirs).
 
 stdout carries ONLY protocol JSON (one object per line); logs go to stderr.
@@ -126,6 +126,9 @@ MATRIX: dict[str, dict[str, Any]] = {
     # yolop x OpenAI (default provider)
     "openai-gpt-5.6-luna": {"agent": "yolop", "model": "openai/gpt-5.6-luna"},
     "openai-gpt-5.6-terra": {"agent": "yolop", "model": "openai/gpt-5.6-terra"},
+    "openai-gpt-5.6-terra-medium": {
+        "agent": "yolop", "model": "openai/gpt-5.6-terra", "reasoning_effort": "medium",
+    },
     "openai-gpt-5.6-terra-high": {
         "agent": "yolop", "model": "openai/gpt-5.6-terra", "reasoning_effort": "high",
     },
@@ -147,7 +150,15 @@ MATRIX: dict[str, dict[str, Any]] = {
     # Harbor's own agents, for cross-agent comparison on identical tasks.
     "terminus-2": {"agent": "terminus-2", "model": "openai/gpt-5.6-terra"},
     "claude-code-opus-4.8": {"agent": "claude-code", "model": "anthropic/claude-opus-4-8"},
-    "codex": {"agent": "codex", "model": "openai/gpt-5.6-terra"},
+    "claude-code-sonnet-5": {
+        "agent": "claude-code",
+        "harbor_agent": "harbor_claude:ClaudeCodeCompatibility",
+        "model": "anthropic/claude-sonnet-5",
+    },
+    "codex": {
+        "agent": "codex", "harbor_agent": "harbor_codex:CodexCompatibility",
+        "model": "openai/gpt-5.6-terra",
+    },
 }
 
 # provider (the part before `/` in a model id) -> env var that makes it runnable.
@@ -346,12 +357,13 @@ def _verifier_env_pairs() -> list[str]:
 def build_command(task: Task, spec: dict, job_dir: Path, *, jobs_dir: Path) -> list[str]:
     cfg = {**DEFAULTS, **spec}
     agent = cfg.get("agent", "yolop")
+    harbor_agent = cfg.get("harbor_agent") or (YOLOP_AGENT_IMPORT_PATH if agent == "yolop" else agent)
     cmd = [
         harbor_bin(), "run",
         "-p", str(task.path),
         "--jobs-dir", str(jobs_dir),
         "--job-name", job_dir.name,
-        "--agent", YOLOP_AGENT_IMPORT_PATH if agent == "yolop" else agent,
+        "--agent", harbor_agent,
         # Mira owns concurrency across cases; one Harbor job is one case, so its
         # own trial concurrency stays at 1.
         "-n", "1",
@@ -360,6 +372,10 @@ def build_command(task: Task, spec: dict, job_dir: Path, *, jobs_dir: Path) -> l
     ]
     if cfg.get("model"):
         cmd += ["--model", cfg["model"]]
+    if cfg.get("agent_setup_timeout_multiplier") is not None:
+        cmd += ["--agent-setup-timeout-multiplier", str(cfg["agent_setup_timeout_multiplier"])]
+    if (memory_mb := _int("TB_OVERRIDE_MEMORY_MB", None)) is not None:
+        cmd += ["--override-memory-mb", str(memory_mb)]
     if agent == "yolop":
         cmd += ["--ak", f"binary_path={YOLOP_BIN}"]
         if cfg.get("max_cost_usd") is not None:

--- a/evals/terminal_bench/tests/test_harbor_claude.py
+++ b/evals/terminal_bench/tests/test_harbor_claude.py
@@ -1,0 +1,46 @@
+"""Tests for the local Claude Code compatibility adapter."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harbor_claude import ClaudeCodeCompatibility
+
+
+class TestClaudeCodeCompatibility(unittest.IsolatedAsyncioTestCase):
+    async def test_installs_with_nvm_and_exposes_stable_binary_links(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = ClaudeCodeCompatibility(Path(tmp), version="2.1.260")
+            agent._installed_claude_satisfies_version = mock.AsyncMock(return_value=False)
+            agent.ensure_system_dependencies = mock.AsyncMock()
+            agent.exec_as_agent = mock.AsyncMock()
+
+            await agent.install(mock.AsyncMock())
+
+        agent.ensure_system_dependencies.assert_awaited_once_with(
+            mock.ANY, ("curl", "bash", "ripgrep", "procps")
+        )
+        install_call = agent.exec_as_agent.await_args
+        command = install_call.kwargs["command"]
+        self.assertIn("nvm install 22", command)
+        self.assertIn("npm install -g @anthropic-ai/claude-code@2.1.260", command)
+        self.assertIn('ln -sf "$(command -v node)" "$HOME/.local/bin/node"', command)
+        self.assertIn('ln -sf "$(command -v claude)" "$HOME/.local/bin/claude"', command)
+
+    async def test_quotes_the_configured_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = ClaudeCodeCompatibility(Path(tmp), version="2.1.260; false")
+            agent._installed_claude_satisfies_version = mock.AsyncMock(return_value=False)
+            agent.ensure_system_dependencies = mock.AsyncMock()
+            agent.exec_as_agent = mock.AsyncMock()
+
+            await agent.install(mock.AsyncMock())
+
+        command = agent.exec_as_agent.await_args.kwargs["command"]
+        self.assertIn("npm install -g '@anthropic-ai/claude-code@2.1.260; false'", command)

--- a/evals/terminal_bench/tests/test_harbor_codex.py
+++ b/evals/terminal_bench/tests/test_harbor_codex.py
@@ -1,0 +1,50 @@
+"""Tests for the local Codex compatibility adapter."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harbor_codex import CodexCompatibility
+
+
+class TestCodexCompatibility(unittest.IsolatedAsyncioTestCase):
+    def test_uses_a_non_temporary_codex_home(self):
+        self.assertEqual(str(CodexCompatibility._REMOTE_CODEX_HOME), "/root/.codex")
+
+    async def test_installs_with_nvm_and_exposes_stable_binary_links(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = CodexCompatibility(Path(tmp), version="0.104.0")
+            agent._installed_codex_satisfies_version = mock.AsyncMock(return_value=False)
+            agent.ensure_system_dependencies = mock.AsyncMock()
+            agent.exec_as_agent = mock.AsyncMock()
+            agent.exec_as_root = mock.AsyncMock()
+
+            await agent.install(mock.AsyncMock())
+
+        agent.ensure_system_dependencies.assert_awaited_once_with(
+            mock.ANY, ("curl", "bash", "ripgrep")
+        )
+        install_command = agent.exec_as_agent.await_args.kwargs["command"]
+        self.assertIn("nvm install 22", install_command)
+        self.assertIn("npm install -g @openai/codex@0.104.0", install_command)
+        link_command = agent.exec_as_root.await_args.kwargs["command"]
+        self.assertIn("/usr/local/bin/$bin", link_command)
+
+    async def test_quotes_the_configured_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = CodexCompatibility(Path(tmp), version="0.104.0; false")
+            agent._installed_codex_satisfies_version = mock.AsyncMock(return_value=False)
+            agent.ensure_system_dependencies = mock.AsyncMock()
+            agent.exec_as_agent = mock.AsyncMock()
+            agent.exec_as_root = mock.AsyncMock()
+
+            await agent.install(mock.AsyncMock())
+
+        command = agent.exec_as_agent.await_args.kwargs["command"]
+        self.assertIn("npm install -g '@openai/codex@0.104.0; false'", command)

--- a/evals/terminal_bench/tests/test_study.py
+++ b/evals/terminal_bench/tests/test_study.py
@@ -64,6 +64,30 @@ class TestMatrix(unittest.TestCase):
             tb.MATRIX["openrouter-claude-sonnet-5"],
             {"agent": "yolop", "model": "openrouter/anthropic/claude-sonnet-5"},
         )
+        self.assertEqual(
+            tb.MATRIX["claude-code-sonnet-5"],
+            {
+                "agent": "claude-code",
+                "harbor_agent": "harbor_claude:ClaudeCodeCompatibility",
+                "model": "anthropic/claude-sonnet-5",
+            },
+        )
+
+    def test_terra_medium_compare_preset_is_explicit_and_balanced(self):
+        config_path = Path(__file__).resolve().parents[1] / "mira.toml"
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            tb.MATRIX["openai-gpt-5.6-terra-medium"],
+            {"agent": "yolop", "model": "openai/gpt-5.6-terra", "reasoning_effort": "medium"},
+        )
+        self.assertEqual(
+            config["presets"]["terra-medium-compare"],
+            {
+                "samples": ["modernize-scientific-stack", "chess-best-move", "count-dataset-tokens"],
+                "targets": ["openai-gpt-5.6-terra-medium", "claude-code-sonnet-5", "codex"],
+            },
+        )
 
 
 class TestBuildCommand(unittest.TestCase):
@@ -84,11 +108,32 @@ class TestBuildCommand(unittest.TestCase):
         cmd = self._command(tb.MATRIX["openai-gpt-5.6-terra-high"])
         self.assertIn("reasoning_effort=high", cmd)
 
+    def test_medium_reasoning_effort_rides_as_an_agent_kwarg(self):
+        cmd = self._command(tb.MATRIX["openai-gpt-5.6-terra-medium"])
+        self.assertIn("reasoning_effort=medium", cmd)
+
     def test_harbor_native_agent_is_passed_through(self):
         cmd = self._command(tb.MATRIX["terminus-2"])
         self.assertEqual(cmd[cmd.index("--agent") + 1], "terminus-2")
         # Adapter-only kwargs must not leak onto a Harbor-native agent.
         self.assertNotIn("--ak", cmd)
+
+    def test_competitor_workarounds_are_passed_to_harbor(self):
+        codex_cmd = self._command(tb.MATRIX["codex"])
+        self.assertEqual(
+            codex_cmd[codex_cmd.index("--agent") + 1],
+            "harbor_codex:CodexCompatibility",
+        )
+
+        claude_cmd = self._command(tb.MATRIX["claude-code-sonnet-5"])
+        self.assertEqual(
+            claude_cmd[claude_cmd.index("--agent") + 1],
+            "harbor_claude:ClaudeCodeCompatibility",
+        )
+
+    def test_memory_override_is_shared_by_every_target(self):
+        cmd = self._command(tb.MATRIX["codex"], env={"TB_OVERRIDE_MEMORY_MB": "4096"})
+        self.assertEqual(cmd[cmd.index("--override-memory-mb") + 1], "4096")
 
     def test_agent_env_pairs_are_forwarded(self):
         cmd = self._command(tb.MATRIX["llmsim"],

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,13 @@
 # Knowledge Log
 
+## 2026-09-04, Native-agent Terminal-Bench comparison
+
+- The fixed three-task `terra-medium-compare` preset records Yolop with GPT-5.6
+  Terra medium against the native Claude Code Sonnet 5 and Codex adapters.
+- Compatibility installers avoid Harbor bootstrap failures on Apple Silicon;
+  the comparison runs all task containers with the same configurable memory
+  limit and records the resulting nine-case archive under the eval study.
+
 ## 2026-09-03, Background completions are handled once
 
 - [Background execution](specs/background.md): a terminal task snapshot observed


### PR DESCRIPTION
## What changed

Adds a fixed three-task Terminal-Bench comparison across Yolop with GPT-5.6 Terra medium, Claude Code with Sonnet 5, and Codex with GPT-5.6 Terra. Local compatibility adapters make the native agents reliable in the x86 task images on Apple Silicon, and a shared memory override keeps resources symmetric.

The successful nine-case result archive is committed alongside a concise comparison in the eval README.

## Why

The previous cross-agent run could not measure Codex or Claude Code because their stock Harbor installation paths failed before model work began. We need a repeatable, infrastructure-valid effectiveness record for Yolop against native coding agents.

## Before / After

Before: Codex failed while creating code-mode helpers under `/tmp/codex-home`; Claude Code's native x86 bootstrap exceeded 20 minutes under QEMU. These were infrastructure failures, not agent outcomes.

After: run `20260904T012919Z-eafd` completed all nine cases with zero infrastructure errors:

| Agent | Result | Cost | Summed case wall |
|---|---:|---:|---:|
| Claude Code, Sonnet 5 | 3/3 | $0.452 | 6m17s |
| Yolop, GPT-5.6 Terra medium | 2/3 | $0.453 | 5m07s |
| Codex, GPT-5.6 Terra | 2/3 | $0.374 | 4m42s |

Yolop and Codex missed `chess-best-move`; every agent passed the other two tasks.

## Risk

- Low. Changes are isolated to the external eval study.
- Harbor upgrades could change private adapter methods or make the compatibility installers unnecessary.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated

Validation:

- `UV_CACHE_DIR=/tmp/yolop-uv uv run --with mira-eval --with harbor -m unittest discover -s evals/terminal_bench/tests`, 61 passed
- `python3 scripts/validate_okf.py knowledge --check-links`, 43 concepts checked, 0 errors
- Full `terra-medium-compare` run, 9 scored cases, 7 passes, 0 infrastructure errors

## Knowledge

Updated `knowledge/log.md` with the native-agent comparison and compatibility constraints. Eval procedure and results live in `evals/terminal_bench/README.md`.

## Security

Reviewed TM-FS, TM-BASH, and TM-DEP. Installers create only fixed binary links inside disposable task containers, retain bounded Harbor execution, and add no project dependency. Configured package versions are shell-quoted before entering npm commands. No keys are persisted in the committed result archive.

## Follow-ups

- Analyze the retained Yolop chess trajectory against Claude Code and Codex to identify product changes that can improve Yolop's win rate. This follows after the measurement infrastructure lands so it does not mix harness and product changes.
