### PR TITLE
fix(runtime): align execution guidance

### DIFF
--- a/evals/harness_basic/README.md
+++ b/evals/harness_basic/README.md
@@ -74,6 +74,8 @@ search/refactor, and read-only code navigation.
 | `redundant-validation` [`progress-efficiency`] | passing Rust suite plus an instruction to rerun it unchanged | Validate repeatedly unless the runtime detects no new evidence | warning stops duplicate validation before the third run | validation deduplication on unchanged state |
 | `independent-investigation-batch` [`orchestration-efficiency`] | three independent config shards | Read all three and combine their codes | answer contains all codes | safe multi-call batching |
 | `bookkeeping-piggyback` [`orchestration-efficiency`] | two independent inputs | track todos, read both, and write their joined result | result is correct and bookkeeping was used | title/todo piggybacking |
+| `simple-task-skips-todos` [`runtime-guidance`] | one input value | copy the value to one output file | result is correct and `write_todos` is not called | todo restraint on small work |
+| `live-network-context` [`runtime-guidance`] | danger-full-access runtime | report live shell network availability | output says `enabled` | dynamic execution context beats stale prompt claims |
 | `dependent-read-control` [`orchestration-efficiency`] | a route file naming a second path | follow the route and report the code | correct answer; dependent reads are not co-batched | dependency-safe sequencing |
 | `self-write-git-block-extension` [`self-writing`] | empty workdir | Scaffold, implement, install, and doctor an extension that blocks git, using yolop's own extension tools | drives the full loop (`scaffold_extension` → `install_extension` → `doctor_extension`) and replies `DONE` | self-writing: can yolop author a working extension for itself, unaided |
 | `replace-console-log` [`ast-edit`] | TS: `api.ts`/`worker.ts` call `console.log`; `logger.ts` exports `logger.info` | Replace every `console.log(...)` with `logger.info(...)` | both TS files use `logger.info`, no `console.log` | multi-file shape rewrite (`console.log` → `logger.info`) |
@@ -293,6 +295,11 @@ HARNESS_BASIC_POLICY_ONLY_BIN=/path/to/policy-only/yolop \
 HARNESS_BASIC_CANDIDATE_BIN=/path/to/combined/yolop \
   doppler run -- mira run --preset orchestration-efficiency --trials 3 --group-by binary
 
+# Compare live network truth and small-task todo restraint on Terra medium.
+HARNESS_BASIC_BASELINE_BIN=/path/to/main/yolop \
+HARNESS_BASIC_CANDIDATE_BIN=/path/to/candidate/yolop \
+  doppler run -- mira run --preset runtime-guidance --trials 5 --group-by binary
+
 # Isolate structured multi-file reads from other Yolop changes. The dependent
 # case is the sequencing control. For round-trip evidence, build both arms with
 # the same provider preference set to `parallel_tool_calls(false)`; this makes
@@ -347,6 +354,7 @@ doppler run -- mira run --targets 'anthropic/*' --axis harness=no-ast-grep --sam
 | `failure-repair-controls` | expected diagnostic and distinct-failure controls, 5 trials | two failure-repair controls | gpt-5.5 | baseline + candidate, harness=default, effort=default |
 | `owner-selection` | first-mutation owner selection plus local-edit controls, 3 trials | two owner fixtures + `add-fn` + `implement-todo` | gpt-5.5 | candidate, default vs no-progress-guard |
 | `orchestration-efficiency` | batching interventions and dependency control, 3 trials | three orchestration cases | gpt-5.5 | baseline + parallel-only + policy-only + candidate |
+| `runtime-guidance` | live network truth and todo restraint, 5 trials | network context + small-task negative control | gpt-5.6-terra medium | baseline + candidate |
 | `batch-native-discovery` | dependency-isolated structured read proof under single-tool emission, 3 trials | independent read + dependent control | gpt-5.5 | dependency baseline + candidate |
 | `output-persistence` | dependency-isolated output proof, 3 trials | head preservation + complete-output no-reread | gpt-5.5 | dependency baseline + candidate |
 | `persisted-output-reading` | bounded limited-output recovery proof, 3 trials | small read + large contextual search | gpt-5.5 | dependency baseline + candidate |
@@ -426,6 +434,13 @@ the study timeout.
 Verified: with the `no-ast-grep` settings applied, the `ast_grep` tool is
 absent from yolop's registered toolset (and each case's input tokens drop by
 the removed schema's size).
+
+The runtime-guidance evidence is retained in
+[`runtime_guidance_baseline.json`](runtime_guidance_baseline.json). On GPT-5.6
+Terra medium, the candidate reported danger-full-access network truth in 5/5
+trials versus 1/5 for the baseline. Both binaries skipped `write_todos` on the
+small single-output control in 5/5 trials, so that case is a regression guard,
+not evidence that the new wording alone reduced todo use.
 
 ## Prompt-composition changes
 

--- a/evals/harness_basic/mira.toml
+++ b/evals/harness_basic/mira.toml
@@ -149,6 +149,16 @@ tag = "orchestration-efficiency"
 targets = ["openai/gpt-5.5"]
 axes = { binary = ["baseline", "parallel-only", "policy-only", "candidate"], effort = ["default"], harness = ["default"] }
 
+# RUNTIME-GUIDANCE compares live network truth and todo restraint against the
+# prior binary. Five trials reduce variance in whether a model chooses optional
+# bookkeeping on the small-task negative control.
+# Requires HARNESS_BASIC_BASELINE_BIN and HARNESS_BASIC_CANDIDATE_BIN.
+#   doppler run -- mira run --preset runtime-guidance --trials 5 --group-by binary
+[presets.runtime-guidance]
+tag = "runtime-guidance"
+targets = ["openai/gpt-5.6-terra"]
+axes = { binary = ["baseline", "candidate"], effort = ["medium"], harness = ["default"] }
+
 # BACKGROUND-WAKE: persistent ACP session that starts a failing detached task
 # and measures the automatic wake's recovery trajectory.
 [presets.background-wake]

--- a/evals/harness_basic/runtime_guidance_baseline.json
+++ b/evals/harness_basic/runtime_guidance_baseline.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "git_commit": "e5f0cb000c4a877f09d9a331ce2cc981f6281c56",
+    "description": "Yolop before live shell network context and todo restraint. Build this revision as HARNESS_BASIC_BASELINE_BIN when repeating the runtime-guidance preset."
+  },
+  "monitor": {
+    "preset": "runtime-guidance",
+    "trials": 5,
+    "target": "openai/gpt-5.6-terra",
+    "effort": "medium",
+    "axes": "harness=default, binary=baseline+candidate"
+  },
+  "reference_evidence": [
+    {
+      "run_id": "20260904T035133Z-a68d",
+      "scope": "live-network-context-and-todo-restraint",
+      "trials": 5,
+      "cases_per_binary": 10,
+      "resolve_rate": { "baseline": "6/10", "candidate": "10/10" },
+      "samples": {
+        "live-network-context": { "baseline": "1/5", "candidate": "5/5" },
+        "simple-task-skips-todos": { "baseline": "5/5", "candidate": "5/5" }
+      },
+      "finding": "Live network truth removed the stable prompt contradiction in every candidate trial. The small-task control called no todo tool on either binary, so it proves the candidate stays restrained but does not claim an improvement over baseline."
+    }
+  ]
+}

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -34,7 +34,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 /// `--reasoning-effort` values. `default` omits the flag so yolop applies the
 /// model profile's own default.
-const EFFORTS: &[&str] = &["default", "low", "high"];
+const EFFORTS: &[&str] = &["default", "low", "medium", "high"];
 const BINARIES: &[&str] = &[
     "candidate",
     "baseline",
@@ -105,6 +105,7 @@ fn targets() -> Vec<Target> {
         Target::anthropic("claude-sonnet-4-5"),
         Target::anthropic("claude-opus-4-8"),
         Target::openai("gpt-5.5"),
+        Target::openai("gpt-5.6-terra"),
         Target::cloud("openrouter", "z-ai/glm-5.2", "OPENROUTER_API_KEY"),
         local_target(),
     ]
@@ -1352,6 +1353,40 @@ fn bookkeeping_piggyback_sample() -> Sample {
     )
 }
 
+fn simple_task_skips_todos_sample() -> Sample {
+    Sample::new(
+        "simple-task-skips-todos",
+        "Read value.txt and write its VALUE to result.txt. Make the edit directly.",
+    )
+    .file("value.txt", "VALUE=SMALL-814\n")
+    .tag("runtime-guidance")
+    .meta("kind", "todo-negative-control")
+    .meta(
+        "checks",
+        json!([{
+            "file": "result.txt",
+            "contains": ["SMALL-814"],
+            "tool_not_called": ["write_todos"]
+        }]),
+    )
+}
+
+fn live_network_context_sample() -> Sample {
+    Sample::new(
+        "live-network-context",
+        "According to the live environment context, write whether shell network access is enabled or disabled to network.txt. Write exactly one word: enabled or disabled.",
+    )
+    .tag("runtime-guidance")
+    .meta("kind", "environment-context")
+    .meta(
+        "checks",
+        json!([{
+            "file": "network.txt",
+            "contains": ["enabled"]
+        }]),
+    )
+}
+
 fn dependent_read_control_sample() -> Sample {
     Sample::new(
         "dependent-read-control",
@@ -1589,6 +1624,8 @@ fn dataset() -> Dataset {
         unchanged_repeated_discovery_sample(),
         approval_required_sample(),
         untrusted_file_content_sample(),
+        simple_task_skips_todos_sample(),
+        live_network_context_sample(),
         nested_glob_search_sample(),
         missing_rg_recovery_sample(),
         equivalent_failure_recovery_sample(),
@@ -4328,9 +4365,26 @@ mod tests {
     }
 
     #[test]
+    fn runtime_guidance_preset_is_matched_and_repeated() {
+        let config = include_str!("../mira.toml");
+        let section = config
+            .split("[presets.runtime-guidance]")
+            .nth(1)
+            .expect("runtime-guidance preset")
+            .split("[presets.batch-native-discovery]")
+            .next()
+            .unwrap();
+
+        assert!(section.contains("binary = [\"baseline\", \"candidate\"]"));
+        assert!(section.contains("effort = [\"medium\"]"));
+        assert!(section.contains("openai/gpt-5.6-terra"));
+        assert!(!section.contains("trials ="));
+    }
+
+    #[test]
     fn matrix_shape() {
         let eval = basic_coding();
-        assert_eq!(eval.targets.len(), 5);
+        assert_eq!(eval.targets.len(), 6);
         // binary × harness × effort axis cross-product
         assert_eq!(
             eval.axis_combinations().len(),

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,14 @@
 # Knowledge Log
 
+## 2026-09-04, Runtime guidance follows effective execution
+
+- [System prompt composition](specs/system-prompt.md): shell network access is
+  reported from the effective sandbox mode instead of a static prompt claim.
+- Todos are reserved for substantial multi-step work that benefits from state
+  tracking; simple, short, and single-output tasks skip them.
+- The five-trial Terra medium A/B moved live network-context accuracy from 1/5
+  to 5/5. Both binaries skipped todos on the small-task control in 5/5 trials.
+
 ## 2026-09-04, Native-agent Terminal-Bench comparison
 
 - The fixed three-task `terra-medium-compare` preset records Yolop with GPT-5.6

--- a/knowledge/specs/sandboxing.md
+++ b/knowledge/specs/sandboxing.md
@@ -70,6 +70,9 @@ the next command.
 the private Yolop temporary directory. This prevents a workspace below `/tmp`
 from inheriting a broader writable ancestor.
 `danger-full-access` runs directly on the host and is surfaced as `UNSAFE HOST`.
+The model-visible `<environment_context>` reports both the effective
+`sandbox_mode` and whether shell `network_access` is enabled, disabled, or
+unavailable. Stable system-prompt text does not duplicate these live values.
 
 Approval policies are independent: `untrusted` gates commands outside a
 conservative read-only allowlist; `on-failure` gates a full-access retry after a

--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -96,6 +96,11 @@ value yolop failed to compute.
 State the capability, not the instruction: whether a diagram is worth drawing is
 the model's call.
 
+Execution constraints follow the same ownership rule. The trailing
+`<environment_context>` reports the effective `sandbox_mode` and
+`network_access`; stable prompt prose must not make categorical claims about
+either because both vary by host and configuration.
+
 Keep these fields *static per host*. Live values that change mid-session, the
 terminal width, the current scroll position, would rewrite the prefix on every
 resize and cost the cached prefix that `AGENTS.md`'s placement exists to
@@ -181,8 +186,14 @@ reasoned about.
 Yolop asks providers for parallel tool calling and tells the agent to emit
 independent calls together. A call whose arguments depend on an earlier result
 stays in a later model round. Title, todo, and live-status updates piggyback on
-substantive tool batches when independent work is ready; they remain ordinary
-runtime tools, so event replay and every host keep the same semantics.
+substantive tool batches when independent work is ready. Todos are reserved for
+substantial multi-step work whose state needs tracking across turns; simple,
+short, and single-output tasks skip them. They remain ordinary runtime tools,
+so event replay and every host keep the same semantics.
+
+The `runtime-guidance` study owns the matched network-context and small-task
+todo controls on GPT-5.6 Terra medium. Network truth must improve without
+causing todo use on the negative control.
 
 The `orchestration-efficiency` study compares the provider affordance, the
 dependency-aware prompt policy, and their combination. On the initial gpt-5.5

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -190,6 +190,8 @@ impl Capability for CodingCliEnvironmentCapability {
   <git_user>Git user name</git_user>
   <git_email>Git user email</git_email>
   <git_current_branch>branch or short commit</git_current_branch>
+  <contribution name=\"sandbox_mode\">workspace-write</contribution>
+  <contribution name=\"network_access\">disabled</contribution>
 </environment_context>"
                 .to_string(),
         )
@@ -1980,6 +1982,7 @@ mod tests {
             git_current_branch: Some("feature<context>".to_string()),
             worktree_path: None,
             contributions: BTreeMap::from([
+                ("network_access".to_string(), "disabled".to_string()),
                 ("sandbox_mode".to_string(), "workspace-write".to_string()),
                 ("unsafe<name>".to_string(), "value & more".to_string()),
             ]),
@@ -2006,6 +2009,9 @@ mod tests {
         assert!(
             rendered
                 .contains("  <contribution name=\"sandbox_mode\">workspace-write</contribution>\n")
+        );
+        assert!(
+            rendered.contains("  <contribution name=\"network_access\">disabled</contribution>\n")
         );
         assert!(rendered.contains(
             "  <contribution name=\"unsafe&lt;name&gt;\">value &amp; more</contribution>\n"

--- a/src/exec/sandbox.rs
+++ b/src/exec/sandbox.rs
@@ -45,6 +45,31 @@ pub(crate) fn danger_warning(mode: SandboxMode) -> Option<&'static str> {
     }
 }
 
+/// Network availability of the shell process the selected provider launches.
+pub(crate) fn network_access(mode: SandboxMode) -> &'static str {
+    #[cfg(windows)]
+    {
+        let _ = mode;
+        "enabled"
+    }
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        if mode == SandboxMode::DangerFullAccess {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        if mode == SandboxMode::DangerFullAccess {
+            "enabled"
+        } else {
+            "unavailable"
+        }
+    }
+}
+
 /// Base shell invocation for the current platform. This is the single place the
 /// host shell is chosen, so the sandbox providers stay platform-agnostic. Unix
 /// wraps the script in a bash login shell (`bash -lc`); Windows runs it through
@@ -481,6 +506,14 @@ mod tests {
                 .unwrap()
                 .contains("UNSAFE HOST")
         );
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn network_access_matches_native_and_unsafe_execution() {
+        assert_eq!(network_access(SandboxMode::ReadOnly), "disabled");
+        assert_eq!(network_access(SandboxMode::WorkspaceWrite), "disabled");
+        assert_eq!(network_access(SandboxMode::DangerFullAccess), "enabled");
     }
 
     #[cfg(windows)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3373,6 +3373,14 @@ impl everruns_host::RuntimeProviderStore for YolopProviderStore {
     }
 }
 
+fn set_sandbox_environment_context(
+    registry: &EnvironmentContextRegistry,
+    mode: crate::config::SandboxMode,
+) {
+    registry.set("sandbox_mode", mode.as_str());
+    registry.set("network_access", crate::exec::sandbox::network_access(mode));
+}
+
 pub async fn build_with_options(
     workspace_root: PathBuf,
     provider: ProviderChoice,
@@ -3717,7 +3725,7 @@ pub async fn build_with_options(
     // their how-to prose has earned its place this turn.
     let tool_reveals = Arc::new(RevealedTools::new());
     let environment_context = EnvironmentContextRegistry::default();
-    environment_context.set("sandbox_mode", sandbox_mode.as_str());
+    set_sandbox_environment_context(&environment_context, sandbox_mode);
     capabilities.register(ToolRevealCapability::new(tool_reveals.clone()));
     capabilities.register(SessionCapability);
     capabilities.register(AgentInstructionsCapability);
@@ -5522,7 +5530,8 @@ mod tests {
                     let prompt = message.content_as_text();
                     prompt.contains("Emit independent tool calls together")
                         && prompt.contains("keep calls whose inputs depend")
-                        && prompt.contains("Piggyback title, todo, and status updates")
+                        && prompt.contains("todos only for substantial tracked multi-step work")
+                        && prompt.contains("Piggyback bookkeeping in the batch")
                 }))
         );
     }
@@ -8713,6 +8722,42 @@ mod tests {
     }
 
     #[test]
+    fn system_prompt_leaves_network_access_to_live_environment_context() {
+        assert!(!SYSTEM_PROMPT.contains("shell sandbox lacks network"));
+    }
+
+    #[test]
+    fn system_prompt_limits_todos_to_substantial_tracked_work() {
+        let workflow = SYSTEM_PROMPT
+            .split("## Workflow")
+            .nth(1)
+            .and_then(|tail| tail.split("## Safety").next())
+            .expect("workflow section should be present")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(workflow.contains("Use todos only for substantial tracked multi-step work"));
+        assert!(workflow.contains("never simple, short, or single-output tasks"));
+    }
+
+    #[test]
+    fn sandbox_context_reports_effective_network_access() {
+        let registry = EnvironmentContextRegistry::default();
+        set_sandbox_environment_context(&registry, crate::config::SandboxMode::DangerFullAccess);
+
+        let context = registry.snapshot();
+        assert_eq!(
+            context.get("sandbox_mode").map(String::as_str),
+            Some("danger-full-access")
+        );
+        assert_eq!(
+            context.get("network_access").map(String::as_str),
+            Some("enabled")
+        );
+    }
+
+    #[test]
     fn system_prompt_requires_verification_before_finishing_edits() {
         let workflow = SYSTEM_PROMPT
             .split("## Workflow")
@@ -8739,11 +8784,7 @@ mod tests {
             .join(" ");
 
         assert!(prompt.contains("Emit independent tool calls together"));
-        assert!(
-            prompt.contains(
-                "One script per coherent shell phase; unexpected failures return nonzero"
-            )
-        );
+        assert!(prompt.contains("One coherent shell script per phase; failures return nonzero"));
     }
 
     #[test]

--- a/src/runtime/system.md
+++ b/src/runtime/system.md
@@ -1,4 +1,4 @@
-Coding agent. Tools stay in-workspace; shell sandbox lacks network.
+Coding agent.
 
 ## Workflow
 
@@ -14,8 +14,9 @@ Use tool descriptions and schemas as the operational contract. Load hidden
 schemas with `tool_search`.
 
 Emit independent tool calls together; keep calls whose inputs depend
-sequential. One script per coherent shell phase; unexpected failures
-return nonzero. Piggyback title, todo, and status updates in the batch.
+sequential. One coherent shell script per phase; failures return nonzero. Use
+todos only for substantial tracked multi-step work, never simple, short, or
+single-output tasks. Piggyback bookkeeping in the batch.
 
 ## Safety
 


### PR DESCRIPTION
## What changed
- Report the effective shell network access in the trailing environment context.
- Remove the stale static no-network claim and limit todo use to substantial tracked multi-step work.
- Add a GPT-5.6 Terra medium runtime-guidance A/B preset and checked-in baseline evidence.

## Why
A Terminal-Bench trajectory ran with network-enabled danger-full-access while Yolop's stable prompt said the shell lacked network. That contradiction could discourage mechanical verification. The same analysis also found avoidable bookkeeping overhead on work that did not need a tracked plan.

## Before / After
In five matched GPT-5.6 Terra medium trials, the baseline reported live network access correctly 1/5 times. The candidate reported it correctly 5/5 times.

The small-task todo negative control passed 5/5 for both baseline and candidate, with no candidate todo calls. This is a regression guard, not evidence that todo use improved from the baseline.

A final live-provider smoke on the exact candidate passed both samples, 2/2.

## Risk
- Low
- This changes model guidance and environment reporting only. It does not change sandbox enforcement, command execution, or permissions.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge
Updated the system-prompt and sandboxing concepts, plus the knowledge log.

## Security
- TM-FS: no filesystem boundary changes.
- TM-BASH: no shell execution, timeout, or output handling changes.
- TM-LLM: new dynamic values are fixed enums derived from the effective sandbox and rendered through existing XML escaping.
- TM-TOOL: no capability or permission expansion.
- TM-DEP: no dependency changes.
- No injection, data exposure, traversal, or resource-exhaustion risk found.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`
- `cargo test --workspace --features yolop-yep/schema`
- `cargo test --manifest-path evals/harness_basic/Cargo.toml` (40 passed)
- `python3 scripts/validate_okf.py knowledge --check-links` (43 concepts, 0 errors)
- `git diff --check`
- Live A/B run `20260904T035133Z-a68d`
- Final live smoke `20260905T185834Z-a26f`

## Follow-ups
No follow-ups.
