### PR TITLE
fix(deps): pin the everruns family to exact versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,24 @@ tree-sitter-zig = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Every `everruns-*` version below is an exact `=` pin, and they are lifted as a
+# set, never one at a time. The family ships from one upstream workspace whose
+# crates depend on each other by caret, so a caret here lets cargo re-resolve the
+# whole family on `cargo install yolop` even though the committed lockfile still
+# builds. That is not hypothetical: host 0.20.4 added a required `turn_id`
+# argument to the `#[doc(hidden)]` `Runtime::append_accepted_inputs` in a *patch*
+# release, while the published `everruns` facade 0.19.1 still calls the two-arg
+# form and accepts host `^0.20.3`. Caret ranges resolved both together and broke
+# every fresh install. Upstream has already fixed the call site in git but has
+# not republished the facade, so 0.20.4 and the whole batch published alongside
+# it (core 0.19.1, platform 0.19.2, provider 0.20.1, mcp 0.19.3, builtins 0.18.6,
+# llmsim 0.18.5, openai/anthropic/meta/openrouter 0.18.3) stay unadoptable: they
+# all require host `^0.20.4` directly or transitively. Lift these pins in one
+# commit once a facade release that compiles against host 0.20.4 is on crates.io.
+# `everruns-local` is not an escape hatch: its latest release (0.18.0) is yanked,
+# so the facade's `local` feature is the only supported route to the SQLite,
+# git-workspace, and durable-log backends.
+
 # 0.17.24 added a value-first `everruns` facade crate that re-exports core and
 # runtime behind one dependency. Yolop deliberately does not use it: the facade
 # covers core + runtime (plus an `openai` feature), while yolop also needs the
@@ -151,54 +169,55 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # transports, the driver registry). Adopting it today would collapse two of nine
 # dependencies and route the rest through escape hatches. Revisit when the
 # facade promotes provider registration, MCP, and capability wiring.
-everruns-anthropic = "0.18.2"
-everruns-core = "0.19.0"
+everruns-anthropic = "=0.18.2"
+everruns-core = "=0.19.0"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "0.19.1"
-everruns-openai = "0.18.2"
-everruns-meta = "0.18.2"
+everruns-platform = "=0.19.1"
+everruns-openai = "=0.18.2"
+everruns-meta = "=0.18.2"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "0.18.2"
+everruns-openrouter = "=0.18.2"
 # Filesystem persistence comes from the `everruns` facade's `local` feature, not
 # the standalone `everruns-local` crate: same SQLite, git-workspace, and durable
-# log backend, re-exported under `everruns::local`. `everruns-local` is published
-# only against host ^0.18.0, so depending on it pinned yolop off the 0.19 line.
+# log backend, re-exported under `everruns::local`. `everruns-local` is not a
+# substitute: its last non-yanked release builds only against host ^0.18.0, and
+# its latest release (0.18.0) is yanked outright.
 # Only the `local` feature is wanted; the facade's provider and capability
 # re-exports would duplicate the direct dependencies below.
-everruns = { version = "0.19.1", default-features = false, features = ["local"] }
-everruns-mcp = { version = "0.19.2", features = ["stdio"] }
+everruns = { version = "=0.19.1", default-features = false, features = ["local"] }
+everruns-mcp = { version = "=0.19.2", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
 #
 # everruns-host replaces everruns-runtime, which upstream deleted in #3101 as a
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
-everruns-host = { version = "0.20.3", features = ["mcp-stdio"] }
+everruns-host = { version = "=0.20.3", features = ["mcp-stdio"] }
 # DirectEgressService, which yolop uses for MCP OAuth discovery, is host's own
 # `direct-egress` module; `mcp-stdio` already turns that feature on. The
 # standalone everruns-http crate that used to carry it is yanked on crates.io,
 # and a yanked dependency would make yolop unpublishable.
 # #3182 completed the library boundary cleanup: driver/model/provider types
 # and the built-in capabilities left everruns-core for their own crates.
-everruns-provider = "0.20.0"
-everruns-builtins = "0.18.5"
-everruns-capability = "0.18.1"
+everruns-provider = "=0.20.0"
+everruns-builtins = "=0.18.5"
+everruns-capability = "=0.18.1"
 # Yolop ships `--provider llmsim` as a user-facing offline mode, not just a test
 # fixture, so the simulator is a production dependency. 0.18 split it into the
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as
 # test-only and must not be used from production code. The `host` feature carries
 # the runtime-builder extension trait.
-everruns-llmsim = { version = "0.18.4", features = ["host"] }
+everruns-llmsim = { version = "=0.18.4", features = ["host"] }
 # Filesystem and web-fetch capability implementations moved out of
 # everruns-core into their own integration crates (#3119).
-everruns-integrations-filesystem = "0.18.3"
-everruns-integrations-web-fetch = "0.18.2"
-everruns-integrations-duckduckgo = "0.18.2"
-everruns-integrations-parallel = "0.18.2"
-everruns-integrations-daytona = "0.18.2"
+everruns-integrations-filesystem = "=0.18.3"
+everruns-integrations-web-fetch = "=0.18.2"
+everruns-integrations-duckduckgo = "=0.18.2"
+everruns-integrations-parallel = "=0.18.2"
+everruns-integrations-daytona = "=0.18.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-09-09, Everruns versions are exact pins lifted as a set
+
+- [Maintenance](specs/maintenance.md): every `everruns-*` requirement is an exact
+  `=` pin, lifted for the whole family in one change and validated by a
+  from-scratch resolution, not only by a lockfile build.
+- Host 0.20.4 changed a `#[doc(hidden)]` signature in a patch release that the
+  published `everruns` facade 0.19.1 still calls the old way. Caret ranges
+  resolved both together, so `cargo install yolop` stopped compiling while CI
+  stayed green on the committed lockfile.
+- The 2026-09-09 upstream batch is unadoptable until the facade is republished:
+  every crate in it needs host `^0.20.4` directly or transitively, and the
+  facade's `local` feature has no substitute now that `everruns-local` is yanked.
+
 ## 2026-09-04, Runtime guidance follows effective execution
 
 - [System prompt composition](specs/system-prompt.md): shell network access is

--- a/knowledge/specs/maintenance.md
+++ b/knowledge/specs/maintenance.md
@@ -89,6 +89,33 @@ The `everruns-*` family is yolop's single most consequential dependency vector:
 
 These crates ship together from one upstream workspace and are designed to be used at the same version. Yolop pins them at a single minor version. Mixing minor versions across the family is a soft API break and is not allowed without an explicit reason recorded in the PR.
 
+Every `everruns-*` requirement in `Cargo.toml` is an exact `=` pin, and the pins
+are lifted as one set, never one crate at a time. The reason is that the family's
+crates depend on each other by caret, so a caret in yolop only constrains the
+committed lockfile: `cargo install yolop` re-resolves and can pick a combination
+that was never built together. Upstream versions the family per-crate and treats
+`#[doc(hidden)]` items as private, so a *patch* release can and does change a
+signature another family crate calls. Host 0.20.4 did exactly that, adding a
+required `turn_id` to `Runtime::append_accepted_inputs` while the published
+`everruns` facade still called the two-arg form and accepted host `^0.20.3`;
+caret ranges resolved the two together and every fresh install failed to compile,
+though the lockfile build stayed green. Exact pins make the resolved set the
+reviewed set.
+
+A family bump is therefore a single change that moves every pin together and is
+validated by a from-scratch resolution, not only by `cargo build`. Generating a
+lockfile from an empty project carrying the same requirements is the cheap check
+that `cargo install yolop` still resolves. When one crate in a batch is
+unadoptable, the whole batch waits: the rest of the batch requires it directly or
+transitively, so a partial bump reintroduces the untested combination it was
+meant to avoid.
+
+The `everruns` facade is load-bearing despite the note beside it in `Cargo.toml`:
+its `local` feature is the only supported route to the SQLite, git-workspace, and
+durable-log backends, because the standalone `everruns-local` crate's latest
+release is yanked. A facade that lags the rest of the family therefore gates the
+whole family, and the lag is worth reporting upstream rather than working around.
+
 Beyond the everruns family, dependency hygiene means:
 
 - no known CVEs in the tree (`cargo audit` when available, plus the repo's Dependabot alerts)


### PR DESCRIPTION
## What changed

`cargo install yolop` currently fails to compile. This restores it, by pinning every `everruns-*` requirement to an exact `=` version at the set already in `Cargo.lock`.

No dependency version moves and `Cargo.lock` is unchanged, so the built binary is identical. What changes is which versions a *fresh* resolution is allowed to pick.

This started as the requested everruns bump. The bump itself is blocked upstream and is deferred to #665 — see **Follow-ups**.

## Why

The everruns crates ship from one upstream workspace and depend on each other by caret, so a caret requirement in yolop only constrains the committed lockfile. `cargo install` re-resolves from scratch and can select a combination that was never built together.

That is what happened. Upstream published `everruns-host` 0.20.4 on 2026-09-09, adding a required `turn_id` argument to `Runtime::append_accepted_inputs` in a **patch** release. The published `everruns` facade 0.19.1 still calls the two-argument form and accepts host `^0.20.3`, so caret ranges resolved the two together:

```
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
    --> everruns-0.19.1/src/session.rs:591:18
 591 |                 .append_accepted_inputs(self.session_id, remaining)
     |                  ^^^^^^^^^^^^^^^^^^^^^^                  --------- argument #2 of type `TypedId<TurnIdMarker>` is missing
```

Upstream treats `#[doc(hidden)]` items as private, so this is a semver-legal patch for them and a silent break for us. CI stayed green throughout because CI builds the lockfile. Exact pins make the resolved set the reviewed set.

## Before / After

Resolution from scratch with yolop's requirements, which is what `cargo install` does.

**Before** (caret requirements from `main`):

```
$ cargo generate-lockfile && grep -A1 'name = "everruns-host"' Cargo.lock
name = "everruns-host"
version = "0.20.4"          # facade 0.19.1 cannot compile against this
$ cargo check
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
error: could not compile `everruns` (lib) due to 1 previous error
```

**After** (this branch):

```
$ cargo generate-lockfile
      Adding everruns-platform v0.19.1 (available: v0.19.2)
      Adding everruns-provider v0.20.0 (available: v0.20.1)
$ grep -A1 'name = "everruns-host"' Cargo.lock
name = "everruns-host"
version = "0.20.3"
```

Cargo now reports the newer versions as available rather than selecting them, and the resolution compiles.

Repository checks, all on this branch:

```
$ cargo fmt --check                                                  # clean
$ cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 59.52s
$ cargo test --workspace --features yolop-yep/schema
    1440 passed; 0 failed; 0 ignored
$ python3 scripts/validate_okf.py knowledge --check-links
    43 concept(s) checked in knowledge — 0 error(s)
$ cargo metadata --locked                                            # lockfile unchanged by the pins
```

Offline smoke:

```
$ cargo run -- --provider llmsim -p "hi"
I'm running in offline mode (llmsim — no API key set). Set ANTHROPIC_API_KEY or OPENAI_API_KEY for real responses.
```

The live-provider smoke could not be run locally (Doppler is unavailable in the authoring environment), so it was left to CI rather than claimed. CI's **Live Provider Smoke (Doppler)** job passed on this head, which closes that gap. All 17 checks are green, including `Clippy + Tests (local-inference)`, both `Build with metal` targets, `Windows Build + Shell Smoke`, and both `Sandbox Contract` runners — the feature combinations that could not be compiled locally.

## Risk

- **Low**

What can break:

- Exact pins mean Dependabot and manual bumps must move the family as a set. That is the intent, and it is now enforced by the resolver instead of by convention. The maintenance spec and a `Cargo.toml` comment both say so, and #665 carries the lifting procedure.
- A future transitive dependency requiring a different `everruns-*` patch would now fail resolution instead of silently mis-resolving. That is the safer failure and is visible at resolve time.
- No behavior, API, or dependency version changes, so there is nothing for a runtime regression to come from.

## Checklist

- [x] Tests added or updated — no new test; see note below
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

On tests: the failure mode is dependency *resolution*, not code, so no test in the suite can observe it — the whole point is that a lockfile build passes while a fresh resolve fails. The check that would catch a regression is a from-scratch resolution, which is recorded as the required validation step in `knowledge/specs/maintenance.md` and in #665. Automating it in CI is a reasonable follow-up but wants its own change; noted under **Follow-ups**.

## Knowledge

Updated:

- `knowledge/specs/maintenance.md` § Dependency Discipline — everruns requirements are exact pins lifted as a set; a family bump is validated by a from-scratch resolution, not only by a lockfile build; the facade is load-bearing because `everruns-local` is yanked, so a lagging facade gates the whole family.
- `knowledge/log.md` — entry for 2026-09-09.

## Security

Threat-model review against the categories in `.agents/skills/ship/SKILL.md`:

- **TM-DEP** — the only relevant category, and the change reduces risk. No dependency is added, removed, or moved; `Cargo.lock` is byte-identical. Exact pins narrow what a fresh `cargo install` may resolve to the set that was actually built and tested, closing a window in which a patch release of a transitive family crate could enter a user's build unreviewed. The failure this fixes was a compile error, not a compromise, but the same resolution latitude is the vector a malicious patch would use.
- **TM-FS**, **TM-BASH**, **TM-LLM**, **TM-TOOL** — no changes. No Rust source is touched; the diff is `Cargo.toml` requirement strings plus two knowledge documents. The write blocklist, bounded shell execution, key handling, and capability registration are all untouched.

## Follow-ups

- #665 — lift the pins and adopt the 2026-09-09 everruns batch once a facade compatible with host 0.20.4 is published. Blocked on upstream: the fix is in `everruns/everruns` git but the facade was not republished.
- Report the facade/host publish skew upstream, so host 0.20.4 does not keep breaking downstream fresh installs while the facade lags. Not done here because it belongs in `everruns/everruns`, which this branch cannot touch.
- Consider a CI job that resolves the manifest from scratch (`cargo generate-lockfile` in a scratch project, or `cargo install --path . --locked=false`) so installability regressions surface in CI rather than in users' installs. Deliberately not folded into this change, which is deliberately zero-behavior.

https://claude.ai/code/session_01QfzYc2eJx6XPvkv2wSZVLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfzYc2eJx6XPvkv2wSZVLS)_