### PR TITLE
chore(deps): adopt the everruns 0.20 facade release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef79123793a55cb73d6ad16336ba6f627d81f7636b143d1129ef4f78a96ba49f"
+checksum = "ac54a475d72bf165139dc84f964cc84ea0b4cb160970c9455455c73a17117eba"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28da83571906d0c18a23c62430da3022122084061b6e7b4f44c376bdeab5e079"
+checksum = "8527f35f92b638e7501cf2f1b5c59c12a1dce4728ddc587dfb676e1177308252"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2174,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.5"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d78420291af77ae17f4ebb1d0c937d4840cd8b0c8b3109a85f67c19ffff017a"
+checksum = "1c521fd3e9e4132b31dff76c3f93e27c3d083201a45942be2cbd2af467a14f21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2205,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bdc8fecfb739bbb0622ad2a858722367308537521338d66a2df0acd24fb784"
+checksum = "f1f98e1c32cac6efc7ca16ffe91f47cbff91c3566ee69b5155af0763afc8a667"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2219,7 +2219,7 @@ dependencies = [
  "futures",
  "globset",
  "inventory",
- "jsonschema 0.49.9",
+ "jsonschema",
  "rand 0.10.2",
  "regex",
  "serde",
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99bd3d66ddeb56d0124a56210d0e740f905ecf171e2e981ed77fbdcd51f2c20"
+checksum = "95eb14f580d691730b6a60c46ea98658a87fbb6fa3e7bc69df6ecf04c0007291"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661b4e5b668b8f4ddf1f46d10f6375a543f3aa7a91fec1675206238aae2a3946"
+checksum = "61e438ee09577a11da2052fd365715db50429cefedae833bac6d17e6073f33a2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2269,8 +2269,10 @@ dependencies = [
  "everruns-engine",
  "everruns-mcp",
  "everruns-provider",
+ "fs2",
  "futures",
  "ignore",
+ "libc",
  "regex",
  "reqwest 0.13.4",
  "serde",
@@ -2375,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd61800c3bd04180be2fb4b92b166b2f5419f1e34c86f9f32fa895d1e250cb7"
+checksum = "efa3cd68acc6dedf6c16b6e94ebfbebdb4c869fa1d99c93b601a976798c295db"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2391,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c50d380b0c21fa03eb33f355d0ff0063c0bd57b68319a158bf445040c5ac5eb"
+checksum = "e9143be2c4fafaf57bae896172b27af047ef6467431e2157a140270d2195bfac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2416,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678ea25d73733151047df63ffb286e9533328a164a1155a38535d77b515bc8fc"
+checksum = "1591ec4a9fac26b9f2082d2c222a6bc35e326f0a18aeba97058f2c8addd12dae"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2428,10 +2430,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "everruns-openai"
-version = "0.18.2"
+name = "everruns-model-profiles"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019a64e89e3141fcb2f382e9f738917856f1d8eaee0b96dd497607a9934f4e00"
+checksum = "2d42c74ebfcddfcf463affdbb36080a6278464af3864c57ec94f00e87f1f2d61"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "everruns-openai"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e284f619d5c15ed5808f48a074e5962f1d34c494f204c04597bb8674bd5d86c4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2445,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50bebe0830c26920caf7f147e140d760a608c8e65ceb0414e875a4b57b5fd4a"
+checksum = "5303d86d817daa57db293668a02e36e4594b9c79538fd98bf70f262fe51905cb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2459,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f5f0c2c67532f2d6d3502a1afa8885ae97399d421021db640285f975b0a5f0"
+checksum = "5c4a81dac9eea4f3c62017b8123f84284b64a84ad57f01f44f2da6d5b7ed0745"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2472,7 +2483,7 @@ dependencies = [
  "everruns-host",
  "everruns-provider",
  "inventory",
- "jsonschema 0.49.9",
+ "jsonschema",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -2483,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e890de18e510543148a6c0e7260d733dcde6cd39c4c379621ed8b0e659b1d46a"
+checksum = "638de963dfa6441bef7a5694b30db4911e60cf4239279b3cdb2e288ee481aa10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2493,6 +2504,7 @@ dependencies = [
  "bytes",
  "chrono",
  "eventsource-stream",
+ "everruns-model-profiles",
  "futures",
  "hex",
  "http",
@@ -2784,16 +2796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fraction"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
-dependencies = [
- "lazy_static",
- "num",
 ]
 
 [[package]]
@@ -4009,35 +4011,6 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
-dependencies = [
- "ahash",
- "bytecount",
- "data-encoding",
- "email_address",
- "fancy-regex 0.19.0",
- "fraction 0.15.4",
- "getrandom 0.3.4",
- "idna",
- "itoa",
- "jsonschema-regex 0.49.9",
- "jsonschema-value 0.49.9",
- "num-cmp",
- "num-traits",
- "percent-encoding",
- "referencing 0.49.9",
- "regex",
- "serde",
- "serde_json",
- "strum 0.28.0",
- "unicode-general-category",
- "uuid-simd",
-]
-
-[[package]]
-name = "jsonschema"
 version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
@@ -4047,30 +4020,21 @@ dependencies = [
  "data-encoding",
  "email_address",
  "fancy-regex 0.19.0",
- "fraction 0.17.0",
+ "fraction",
  "getrandom 0.3.4",
  "itoa",
- "jsonschema-regex 0.52.1",
- "jsonschema-value 0.52.1",
+ "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing 0.52.1",
+ "referencing",
  "regex",
  "serde",
  "serde_json",
  "strum 0.28.0",
  "unicode-general-category",
  "uuid-simd",
-]
-
-[[package]]
-name = "jsonschema-regex"
-version = "0.49.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
-dependencies = [
- "regex-syntax",
 ]
 
 [[package]]
@@ -4084,27 +4048,13 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
-dependencies = [
- "ahash",
- "bytecount",
- "fraction 0.15.4",
- "num-cmp",
- "num-traits",
- "serde_json",
-]
-
-[[package]]
-name = "jsonschema-value"
 version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
 dependencies = [
  "ahash",
  "bytecount",
- "fraction 0.17.0",
+ "fraction",
  "num-cmp",
  "num-traits",
  "serde_json",
@@ -6421,23 +6371,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "referencing"
-version = "0.49.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
-dependencies = [
- "ahash",
- "fluent-uri",
- "getrandom 0.3.4",
- "hashbrown 0.17.1",
- "itoa",
- "micromap",
- "parking_lot",
- "percent-encoding",
- "serde_json",
 ]
 
 [[package]]
@@ -10092,7 +10025,7 @@ dependencies = [
  "image",
  "include_dir",
  "inventory",
- "jsonschema 0.52.1",
+ "jsonschema",
  "landlock",
  "libc",
  "mistralrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,17 +169,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # transports, the driver registry). Adopting it today would collapse two of nine
 # dependencies and route the rest through escape hatches. Revisit when the
 # facade promotes provider registration, MCP, and capability wiring.
-everruns-anthropic = "=0.18.2"
-everruns-core = "=0.19.0"
+everruns-anthropic = "=0.18.3"
+everruns-core = "=0.19.1"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "=0.19.1"
-everruns-openai = "=0.18.2"
-everruns-meta = "=0.18.2"
+everruns-platform = "=0.19.2"
+everruns-openai = "=0.18.3"
+everruns-meta = "=0.18.3"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "=0.18.2"
+everruns-openrouter = "=0.18.3"
 # Filesystem persistence comes from the `everruns` facade's `local` feature, not
 # the standalone `everruns-local` crate: same SQLite, git-workspace, and durable
 # log backend, re-exported under `everruns::local`. `everruns-local` is not a
@@ -187,30 +187,30 @@ everruns-openrouter = "=0.18.2"
 # its latest release (0.18.0) is yanked outright.
 # Only the `local` feature is wanted; the facade's provider and capability
 # re-exports would duplicate the direct dependencies below.
-everruns = { version = "=0.19.1", default-features = false, features = ["local"] }
-everruns-mcp = { version = "=0.19.2", features = ["stdio"] }
+everruns = { version = "=0.20.0", default-features = false, features = ["local"] }
+everruns-mcp = { version = "=0.19.3", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
 #
 # everruns-host replaces everruns-runtime, which upstream deleted in #3101 as a
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
-everruns-host = { version = "=0.20.3", features = ["mcp-stdio"] }
+everruns-host = { version = "=0.20.5", features = ["mcp-stdio"] }
 # DirectEgressService, which yolop uses for MCP OAuth discovery, is host's own
 # `direct-egress` module; `mcp-stdio` already turns that feature on. The
 # standalone everruns-http crate that used to carry it is yanked on crates.io,
 # and a yanked dependency would make yolop unpublishable.
 # #3182 completed the library boundary cleanup: driver/model/provider types
 # and the built-in capabilities left everruns-core for their own crates.
-everruns-provider = "=0.20.0"
-everruns-builtins = "=0.18.5"
+everruns-provider = "=0.20.1"
+everruns-builtins = "=0.18.6"
 everruns-capability = "=0.18.1"
 # Yolop ships `--provider llmsim` as a user-facing offline mode, not just a test
 # fixture, so the simulator is a production dependency. 0.18 split it into the
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as
 # test-only and must not be used from production code. The `host` feature carries
 # the runtime-builder extension trait.
-everruns-llmsim = { version = "=0.18.4", features = ["host"] }
+everruns-llmsim = { version = "=0.18.5", features = ["host"] }
 # Filesystem and web-fetch capability implementations moved out of
 # everruns-core into their own integration crates (#3119).
 everruns-integrations-filesystem = "=0.18.3"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,24 @@
 # Knowledge Log
 
+## 2026-09-10, Everruns 0.20 facade adopted
+
+- The family moved to the 2026-09-09 batch plus `everruns` 0.20.0 and
+  `everruns-host` 0.20.5, the facade release that fixed the call site behind the
+  install break recorded on 2026-09-09. The exact pins moved as one set and were
+  validated by compiling a from-scratch resolution, not only the lockfile.
+- `WakeRoutes::register` is now async: it waits out a synchronous fallback turn
+  already in flight for the same session, so `register_host_route` awaits it
+  rather than going live underneath one and driving a session from two loops.
+- Explicit compaction can return native items the narrow `CompactOutputItem`
+  shapes do not model. The codex driver passes `CompactOutputItem::ProviderItem`
+  through verbatim so reasoning and other provider state survive a checkpoint
+  reload instead of being dropped.
+- `McpServerAuthMode::OAuth` now serializes as `oauth` rather than `o_auth`,
+  with `o_auth` kept as a read alias, so existing settings files still parse and
+  newly written ones use the canonical spelling. Yolop's own `oauth` -> `o_auth`
+  rewrite on the MCP settings read path is obsolete and removed. A compile
+  passes either way; only a test asserting the on-disk text caught this.
+
 ## 2026-09-09, Everruns versions are exact pins lifted as a set
 
 - [Maintenance](specs/maintenance.md): every `everruns-*` requirement is an exact

--- a/src/capabilities/herdr.rs
+++ b/src/capabilities/herdr.rs
@@ -588,6 +588,9 @@ mod tests {
                     turn_id,
                     input_message_id: MessageId::from_seed(93),
                     input_content: Some("test".to_string()),
+                    agent_id: None,
+                    agent_name: None,
+                    agent_description: None,
                 },
             ))
             .expect("send turn started");

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -303,17 +303,14 @@ fn save_workspace_mcp_settings(path: &Path, settings: &WorkspaceMcpSettings) -> 
     std::fs::write(path, bytes).map_err(|err| format!("write {}: {err}", path.display()))
 }
 
+// `auth_mode` needs no normalizing here: everruns-core 0.19.1 renamed the
+// serialized form of `McpServerAuthMode::OAuth` from `o_auth` to `oauth` and
+// kept `o_auth` as a serde alias, so both spellings deserialize on their own.
 fn normalize_server_entry_value(mut value: JsonValue) -> JsonValue {
-    if let JsonValue::Object(object) = &mut value {
-        if let Some(transport_type) = object.remove("transport_type") {
-            object.entry("type".to_string()).or_insert(transport_type);
-        }
-        if object.get("auth_mode").and_then(JsonValue::as_str) == Some("oauth") {
-            object.insert(
-                "auth_mode".to_string(),
-                JsonValue::String("o_auth".to_string()),
-            );
-        }
+    if let JsonValue::Object(object) = &mut value
+        && let Some(transport_type) = object.remove("transport_type")
+    {
+        object.entry("type".to_string()).or_insert(transport_type);
     }
     value
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1815,10 +1815,7 @@ Authorization = "Bearer ${LINEAR_API_KEY}"
         save_to(&path, &snapshot).expect("save");
         let on_disk = std::fs::read_to_string(&path).expect("read");
         assert!(on_disk.contains("[mcp.servers.linear]"), "got: {on_disk}");
-        assert!(
-            on_disk.contains(r#"auth_mode = "o_auth""#),
-            "got: {on_disk}"
-        );
+        assert!(on_disk.contains(r#"auth_mode = "oauth""#), "got: {on_disk}");
     }
 
     #[test]

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -753,6 +753,11 @@ enum CodexInputItem {
         r#type: String,
         encrypted_content: String,
     },
+    /// Complete provider item preserved verbatim. Explicit compaction can
+    /// return reasoning and other native items whose shape the variants above
+    /// do not model; re-serializing the original value keeps that state intact
+    /// across a checkpoint reload instead of dropping it.
+    ProviderItem(serde_json::Value),
 }
 
 #[derive(Debug, Serialize)]
@@ -858,7 +863,7 @@ fn compose_input(
     compacted_context: Option<&ProviderOpaqueContext>,
     transcript_input: Vec<CodexInputItem>,
 ) -> Vec<CodexInputItem> {
-    let Some(ProviderOpaqueContext::OpenResponsesCompact { output }) = compacted_context else {
+    let Some(ProviderOpaqueContext::OpenResponsesCompact { output, .. }) = compacted_context else {
         return transcript_input;
     };
 
@@ -899,6 +904,7 @@ fn compact_output_item(item: &CompactOutputItem) -> CodexInputItem {
             r#type: "compaction".to_string(),
             encrypted_content: encrypted_content.clone(),
         },
+        CompactOutputItem::ProviderItem(value) => CodexInputItem::ProviderItem(value.clone()),
     }
 }
 
@@ -1681,6 +1687,7 @@ mod tests {
     #[test]
     fn compacted_context_is_preserved_in_order_before_raw_suffix() {
         let context = ProviderOpaqueContext::OpenResponsesCompact {
+            reasoning_state: None,
             output: vec![
                 CompactOutputItem::Message {
                     role: "user".to_string(),
@@ -1708,6 +1715,36 @@ mod tests {
     }
 
     #[test]
+    fn compacted_context_passes_native_provider_items_through_verbatim() {
+        // Explicit compaction returns reasoning and other native items the
+        // narrow message/compaction shapes cannot represent. Dropping or
+        // reshaping them would lose provider state across a checkpoint reload.
+        let native_reasoning = json!({
+            "type": "reasoning",
+            "id": "rs_123",
+            "encrypted_content": "opaque-reasoning",
+            "summary": [{ "type": "summary_text", "text": "thought about it" }]
+        });
+        let context = ProviderOpaqueContext::OpenResponsesCompact {
+            reasoning_state: None,
+            output: vec![
+                CompactOutputItem::ProviderItem(native_reasoning.clone()),
+                CompactOutputItem::Compaction {
+                    encrypted_content: "opaque-checkpoint".to_string(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            serde_json::to_value(compose_input(Some(&context), Vec::new())).unwrap(),
+            json!([
+                native_reasoning,
+                { "type": "compaction", "encrypted_content": "opaque-checkpoint" }
+            ])
+        );
+    }
+
+    #[test]
     fn reports_the_codex_model_context_window_to_runtime_policy() {
         let driver = test_driver("http://127.0.0.1:1/responses".to_string());
 
@@ -1728,6 +1765,7 @@ mod tests {
             &driver,
             &ProviderEndpoint::default(),
             CompactRequest {
+                reasoning_state: None,
                 model: "gpt-5.6".to_string(),
                 input: vec![everruns_provider::compact::CompactInputItem::Message {
                     role: "user".to_string(),
@@ -1780,6 +1818,7 @@ mod tests {
         let cooldown = Duration::from_secs(30 * 60);
         let driver = test_driver_with_compaction_policy(responses_url, cooldown, clock);
         let request = CompactRequest {
+            reasoning_state: None,
             model: "gpt-5.6".to_string(),
             input: vec![everruns_provider::compact::CompactInputItem::Message {
                 role: "user".to_string(),
@@ -1852,6 +1891,7 @@ mod tests {
                 .compact(
                     &ProviderEndpoint::default(),
                     CompactRequest {
+                        reasoning_state: None,
                         model: "gpt-5.6".to_string(),
                         input: Vec::new(),
                         previous_response_id: None,
@@ -1895,6 +1935,7 @@ mod tests {
                 &driver,
                 &ProviderEndpoint::default(),
                 CompactRequest {
+                    reasoning_state: None,
                     model: "gpt-5.6".to_string(),
                     input: Vec::new(),
                     previous_response_id: None,
@@ -1920,6 +1961,7 @@ mod tests {
         )]);
         let driver = test_driver(responses_url);
         let request = CompactRequest {
+            reasoning_state: None,
             model: "gpt-5.6".to_string(),
             input: Vec::new(),
             previous_response_id: None,
@@ -2227,6 +2269,7 @@ mod tests {
         message.tool_call_id = Some("call_1".to_string());
         let (_, input) = build_input(&[
             LlmMessage {
+                configuration_update: None,
                 role: LlmMessageRole::Assistant,
                 content: LlmMessageContent::Text(String::new()),
                 tool_calls: Some(vec![ToolCall {
@@ -2302,6 +2345,7 @@ mod tests {
         orphaned_result.tool_call_id = Some("call_missing_call".to_string());
         let (_, input) = build_input(&[
             LlmMessage {
+                configuration_update: None,
                 role: LlmMessageRole::Assistant,
                 content: LlmMessageContent::Text(String::new()),
                 tool_calls: Some(vec![

--- a/src/drivers/local.rs
+++ b/src/drivers/local.rs
@@ -365,6 +365,7 @@ mod tests {
             tool_call_id: None,
             phase: None,
             reasoning: Vec::new(),
+            configuration_update: None,
         }
     }
 

--- a/src/runtime/background_wake.rs
+++ b/src/runtime/background_wake.rs
@@ -343,12 +343,16 @@ impl WakeRunner {
 
 /// Register a live host session with Everruns' route registry and translate
 /// raw route messages into Yolop's authenticated wake representation.
-pub fn register_host_route(
+///
+/// Async because `WakeRoutes::register` waits out a synchronous fallback turn
+/// already in flight for this session before handing over the route; going live
+/// underneath one would leave two loops driving the same session.
+pub async fn register_host_route(
     runner: Arc<HostRoutedRunner<WakeRunner>>,
     session_id: SessionId,
 ) -> (WakeSender, WakeReceiver) {
     let routes = runner.routes().clone();
-    let mut raw = routes.register(session_id);
+    let mut raw = routes.register(session_id).await;
     let (wake_tx, wake_rx) = mpsc::unbounded_channel();
     let bridge_tx = wake_tx.clone();
     let bridge_runner = runner.clone();
@@ -719,7 +723,7 @@ mod tests {
     async fn upstream_router_delivers_an_enriched_host_wake() {
         let session_id = SessionId::from_seed(910_001);
         let runner = Arc::new(HostRoutedRunner::new(runner(), WakeRoutes::new()));
-        let (_, mut wakes) = register_host_route(runner.clone(), session_id);
+        let (_, mut wakes) = register_host_route(runner.clone(), session_id).await;
 
         runner
             .send_message(session_id, "for host")
@@ -750,8 +754,8 @@ mod tests {
         let session_a = SessionId::from_seed(910_005);
         let session_b = SessionId::from_seed(910_006);
         let runner = Arc::new(HostRoutedRunner::new(runner(), WakeRoutes::new()));
-        let (_, rx_a) = register_host_route(runner.clone(), session_a);
-        let (_, rx_b) = register_host_route(runner.clone(), session_b);
+        let (_, rx_a) = register_host_route(runner.clone(), session_a).await;
+        let (_, rx_b) = register_host_route(runner.clone(), session_b).await;
 
         let routable = runner
             .routable_session_ids()

--- a/src/runtime/compaction_checkpoint.rs
+++ b/src/runtime/compaction_checkpoint.rs
@@ -406,6 +406,7 @@ mod tests {
             format_version: COMPACTION_CHECKPOINT_FORMAT_VERSION,
             payload: CompactionCheckpointPayload::ProviderOpaque {
                 context: ProviderOpaqueContext::OpenResponsesCompact {
+                    reasoning_state: None,
                     output: vec![CompactOutputItem::Compaction {
                         encrypted_content: format!("opaque-{sequence}"),
                     }],

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3656,7 +3656,7 @@ pub async fn build_with_options(
         everruns::local::WakeRoutes::new(),
     ));
     let (background_wake_tx, background_wake_rx) =
-        crate::runtime::background_wake::register_host_route(wake_runner.clone(), session_id);
+        crate::runtime::background_wake::register_host_route(wake_runner.clone(), session_id).await;
     let project_id = coordination_project_id(&canonical_root);
     let coordination_host = coordination_config
         .map(|config| {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5251,6 +5251,7 @@ mod tests {
                 model: None,
                 iteration: Some(3),
                 phase: None,
+                reasoning_state: None,
             },
         );
 


### PR DESCRIPTION
## What changed

Moves the whole `everruns-*` set to the 2026-09-09 batch plus `everruns` 0.20.0 and `everruns-host` 0.20.5, and reconciles the API changes that come with it. Closes #665.

| crate | from | to |
| --- | --- | --- |
| everruns | 0.19.1 | 0.20.0 |
| everruns-host | 0.20.3 | 0.20.5 |
| everruns-core | 0.19.0 | 0.19.1 |
| everruns-platform | 0.19.1 | 0.19.2 |
| everruns-provider | 0.20.0 | 0.20.1 |
| everruns-mcp | 0.19.2 | 0.19.3 |
| everruns-builtins | 0.18.5 | 0.18.6 |
| everruns-llmsim | 0.18.4 | 0.18.5 |
| everruns-openai / -anthropic / -meta / -openrouter | 0.18.2 | 0.18.3 |

`everruns-capability` and the five integration crates were already current. Pins stay exact and moved as one set, per `knowledge/specs/maintenance.md` § Dependency Discipline.

User-visible behavior changes, both from upstream:

- **MCP settings write `auth_mode = "oauth"`** instead of `o_auth`. Upstream renamed the serialized form and kept `o_auth` as a read alias, so existing `settings.toml` files still parse; newly written ones use the canonical spelling.
- **Native compaction items survive a checkpoint reload.** Explicit compaction can return reasoning and other provider items the narrow shapes cannot represent; those were previously unrepresentable and are now passed through verbatim.

## Why

#665: the batch was unadoptable because `everruns-host` 0.20.4 changed `Runtime::append_accepted_inputs` while the published `everruns` facade still called the old form. Upstream published facade 0.20.0 (against host 0.20.5) at 2026-09-09T23:59Z, which fixes that call site. The blocker is gone, so the pins move.

## Before / After

The bump is not a version-only change — it needed real reconciliation:

- **`WakeRoutes::register` is now async.** It waits out a synchronous fallback turn already in flight for the same session; becoming live underneath one would leave two loops driving one session. `register_host_route` awaits it and is now `async`, as are its four call sites.
- **`CompactOutputItem::ProviderItem` is a new variant.** `CodexInputItem` gained an untagged passthrough variant so the value re-serializes verbatim rather than being dropped or reshaped. Locked by a new test:

```
$ cargo test --bin yolop compacted_context
test drivers::codex::tests::compacted_context_passes_native_provider_items_through_verbatim ... ok
test drivers::codex::tests::compacted_context_is_preserved_in_order_before_raw_suffix ... ok
```

- **New optional fields** on `ProviderOpaqueContext`, `CompactRequest`, `OutputMessageStartedData`, `TurnStartedData` and `LlmMessage`. Yolop is not in the modes they describe (Astra reasoning state, configuration-update history, agent-labelled turns), so they are `None` at every construction — behavior-preserving.
- **`McpServerAuthMode::OAuth` renamed.** This compiled clean and was caught only by the test asserting the on-disk text — exactly the class of change `knowledge/specs/maintenance.md` § Upstream Mirror warns a clean compile will not catch. Yolop's own `oauth` → `o_auth` rewrite on the MCP read path is now obsolete and removed.

Validation on this branch:

```
$ cargo fmt --check                                                  # clean
$ cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings
    exit 0
$ cargo test --workspace --features yolop-yep/schema
    1442 passed; 0 failed; 0 ignored
$ python3 scripts/validate_okf.py knowledge --check-links
    43 concept(s) checked in knowledge — 0 error(s)
$ cargo run -- --provider llmsim -p "hi"
    I'm running in offline mode (llmsim — no API key set). ...
```

From-scratch resolution, the check #665 requires and the one that would have caught the break the pins were added for:

```
$ cargo generate-lockfile     # empty project, same requirements
$ grep -A1 'name = "everruns"$' Cargo.lock
name = "everruns"
version = "0.20.0"
$ cargo check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 19s
```

It resolves *and compiles*, and reports no `everruns-*` crate as lagging.

No live-provider smoke ran locally — Doppler is unavailable in this environment. Unlike the previous pin-only change, this one does move runtime code, so CI's `Live Provider Smoke (Doppler)` job is load-bearing here rather than a formality. Flagging rather than claiming it.

## Risk

- **Medium**

What can break:

- The agent loop's wake path changed shape (`register_host_route` is async). The two background-wake tests cover routing and per-session isolation, but the await introduces a real ordering dependency at session start that only a live run exercises fully.
- `reasoning_state` / `configuration_update` are `None` everywhere on the judgment that yolop does not use those modes. If that reading is wrong, the symptom would be silently dropped provider state rather than a failure.
- The `auth_mode` spelling change is on-disk. Reads are safe both ways via the alias; a settings file written by this build and then read by an older yolop would carry `oauth`, which the older build's normalizer rewrites to `o_auth` — so that direction also works. Worth a reviewer's eye anyway.
- Upstream published this batch hours ago, well inside the release-age floor in `knowledge/specs/maintenance.md` (≥1 day patch, ≥7 days minor). Adopting it now is a deliberate exception, taken because it clears a live installability bug and because the exact pins mean a bad release cannot reach users without another commit here.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

`knowledge/log.md` — entry for 2026-09-10 recording the adoption, the async `register`, the provider-item passthrough, and the `oauth` rename.

No spec change: `knowledge/specs/maintenance.md` § Dependency Discipline already states the exact-pin policy and the from-scratch-resolution requirement this change follows, and yesterday's incident narrative there remains accurate history.

## Security

Threat-model review against the categories in `.agents/skills/ship/SKILL.md`:

- **TM-DEP** — the main category. Twelve `everruns-*` crates move; all come from the same upstream workspace already trusted as yolop's runtime, and all stay exact-pinned, so a fresh install resolves exactly the reviewed set. `everruns-model-profiles` 0.1.0 enters the tree as a new transitive dependency of `everruns-provider`; `jsonschema` and its `fraction` / `referencing` / `jsonschema-regex` / `jsonschema-value` chain leave it.
- **TM-LLM** — `CodexInputItem::ProviderItem` sends a provider-supplied JSON value back to the provider that produced it. It is stored compaction state echoed to its origin, not attacker-controlled input crossing a trust boundary, and it is serialized as structured JSON rather than interpolated into a prompt. No key handling changed.
- **TM-BASH**, **TM-FS**, **TM-TOOL** — unchanged. No shell execution, filesystem boundary, write blocklist, or capability registration is touched.
- No new injection, traversal, or unbounded-resource path: the async `register` waits on a bounded per-session condition, not on unbounded external input.

## Follow-ups

- Consider a CI job that resolves the manifest from scratch, so installability regressions surface in CI rather than in users' installs. Carried over from #666; still not folded in, since it wants its own change.
- Report the facade/host publish skew upstream. Host 0.20.4 shipped a signature change its own facade could not compile against, and the gap lasted about 19 hours; nothing prevents a repeat. Belongs in `everruns/everruns`, which this branch cannot touch.

Closes #665

https://claude.ai/code/session_01QfzYc2eJx6XPvkv2wSZVLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfzYc2eJx6XPvkv2wSZVLS)_