### PR TITLE
fix(runtime): resolve reasoning effort from every source that knows

### DIFF
--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -29,6 +29,7 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 - [Hooks](specs/hooks.md), lifecycle automation.
 - [Memory](specs/memory.md), durable user personalization.
 - [Model list](specs/model-list.md), the cross-provider menu of models a session offers.
+- [Reasoning effort](specs/reasoning-effort.md), how a model's effort scale is resolved and when a mandated-reasoning failure repairs itself.
 - [Session history](specs/session-history.md), discovery of earlier sessions.
 - [Session coordination](specs/session-coordination.md), local coordinator and worker orchestration.
 - [Session titles](specs/session-titles.md), automatic conversation titles.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -12,10 +12,14 @@
   `/effort` offered nothing, and the turn went out with no reasoning, which
   OpenRouter rejects with "Reasoning is mandatory for this endpoint and cannot
   be disabled" on `meta/muse-spark-1.3-contributor`.
-- That rejection now repairs itself once: the model's default effort is
-  selected, the user is told, and the same input is sent again. A turn that
-  already named an effort is not retried, it surfaces with a hint naming the
-  control that fixes it.
+- That rejection now repairs itself once, in the shared turn entry point so the
+  TUI, `--print` and ACP all get it: the model's default effort is selected, the
+  user is told, and the same input is sent again. A turn that already named an
+  effort is not retried, it surfaces with a hint naming the control that fixes
+  it.
+- Verified against the live endpoint: a request with no `reasoning` field is
+  accepted, `effort: "none"` and the driver's bare `reasoning.exclude: true` are
+  what it refuses, and the same request with an effort succeeds.
 
 ## 2026-09-10, Everruns 0.20 facade adopted
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,22 @@
 # Knowledge Log
 
+## 2026-09-10, Reasoning effort is merged from every source that knows
+
+- [Reasoning effort](specs/reasoning-effort.md): the effort scale resolves
+  through the curated profile registry, then what the provider advertised at
+  discovery, then Yolop's own list of reasoning-required families. Each layer
+  only fills what the one above left empty, and only the registry and the
+  required families supply an effort Yolop sends on its own: an advertised
+  scale offers levels, it does not choose one.
+- A gateway model the registry has never seen used to lose the control twice:
+  `/effort` offered nothing, and the turn went out with no reasoning, which
+  OpenRouter rejects with "Reasoning is mandatory for this endpoint and cannot
+  be disabled" on `meta/muse-spark-1.3-contributor`.
+- That rejection now repairs itself once: the model's default effort is
+  selected, the user is told, and the same input is sent again. A turn that
+  already named an effort is not retried, it surfaces with a hint naming the
+  control that fixes it.
+
 ## 2026-09-10, Everruns 0.20 facade adopted
 
 - The family moved to the 2026-09-09 batch plus `everruns` 0.20.0 and

--- a/knowledge/specs/reasoning-effort.md
+++ b/knowledge/specs/reasoning-effort.md
@@ -1,0 +1,104 @@
+---
+type: Product Specification
+title: Reasoning effort
+description: Defines how Yolop resolves a model's reasoning-effort metadata across profile sources and how it recovers from endpoints that mandate reasoning.
+---
+
+# Reasoning effort
+
+Status: v1 implemented.
+
+## Why
+
+Reasoning effort is a per-model control, and Yolop used to learn about it from
+one place: the curated model-profile registry in `everruns_provider`. That
+registry is authored data on a release cadence, so it is always behind the
+catalog of a gateway like OpenRouter, where a model id can name an endpoint no
+release has described yet.
+
+A model missing from the registry lost the control twice over. `/effort` had
+nothing to offer ("current model profile does not expose reasoning efforts"),
+and every turn went out with no reasoning control at all, so an endpoint that
+mandates reasoning rejected the turn with a 400 the user could neither read nor
+act on:
+
+```
+Reasoning is mandatory for this endpoint and cannot be disabled.
+```
+
+Two answers exist for the same question, and Yolop was reading only one of them.
+
+## What
+
+### The effort scale is merged, not taken from a single source
+
+The scale `/effort` offers, and the scale an explicitly requested effort is
+validated against, come from the first source that describes the model:
+
+1. **The curated registry** (plus Yolop's local profile overrides). Authoritative
+   wherever it speaks: it is reviewed data about a specific model.
+2. **What the provider advertised at discovery.** Gateways describe their own
+   catalog: OpenRouter's `/models` carries `supported_parameters`, and its driver
+   turns that into a profile per model. This is how a model the registry has
+   never seen still gets a scale.
+3. **Yolop's reasoning-required families.** Model families whose endpoints reject
+   a turn carrying no reasoning, listed by family prefix so a new point release
+   or pricing tier is covered the day it ships rather than at the next dependency
+   bump. Scoped to the provider surfaces where the mandate holds: mandating
+   reasoning is a property of an endpoint, not of the weights, so a family
+   reached through a gateway that requires it and through its vendor's own API
+   that does not is described once, for the surface that requires it.
+
+Each layer only fills what the one above left empty. Discovery never overrides a
+registry answer, and Yolop's own metadata never overrides either.
+
+### Offering a level is not choosing one
+
+Only layers 1 and 3 supply the effort Yolop selects by itself for a model the
+user has given none. A provider catalog saying a model *accepts* efforts is not
+the same as its endpoint needing one, and sending a level the user never chose
+changes how a model behaves whose own default is fine. So a discovered scale
+fills the picker and validates an explicit choice, while the effort actually
+sent stays unset until the user picks one, the curated profile names a default,
+or the family is one whose endpoint mandates reasoning.
+
+Discovery is asynchronous while the effort selector is not, so what a provider
+advertised is cached per process by the paths that already list models: the
+pre-turn availability check and the `/model` browser. Before any discovery call
+has run the layer is simply empty, which is why layer 3 exists: a model whose
+endpoint mandates reasoning has a scale and a default from the first turn.
+
+### A mandated-reasoning rejection repairs itself once
+
+When a turn fails and the provider says reasoning is mandatory, and the turn
+carried no effort, Yolop selects the model's default effort, tells the user what
+it changed, and sends the same input again. The effort sticks to the model, so
+the next turn is legal too and the status bar shows the level rather than `n/a`.
+
+Exactly one retry, and only for a turn that named no effort. A rejection of a
+turn that *did* name a level is a choice only the user can make, so it surfaces
+with the failure and a hint naming the control that fixes it (`/effort`, or
+`/model` to switch models). Every other provider failure is untouched.
+
+## Ownership boundary
+
+- `crate::runtime::reasoning` owns the reasoning-required families, the
+  fallback scale, recognizing the provider's mandate error, and choosing the
+  recovery effort.
+- `crate::runtime::discovered_profiles` owns the process-wide cache of
+  provider-advertised profiles; the discovery paths write to it, the effort
+  lookups read it.
+- `merged_reasoning_effort_config` in `crate::runtime` owns the merge order every
+  effort surface resolves through, and
+  `ProviderChoice::auto_reasoning_effort_for_model` owns the narrower question of
+  which effort Yolop selects unasked.
+- `crate::runtime::session` owns the one-shot retry, and it is the only place
+  that changes the model behind the user's back.
+
+## Related
+
+- [Model list](model-list.md), the menu of models a session offers, whose entries
+  may pin an effort.
+- [Conversational control](conversational-control.md), the control surfaces
+  (`set_reasoning_effort`, `/effort`, `/setup effort`) this metadata feeds.
+- [ACP](acp.md), the `reasoning_effort` config option served to editors.

--- a/knowledge/specs/reasoning-effort.md
+++ b/knowledge/specs/reasoning-effort.md
@@ -28,6 +28,14 @@ Reasoning is mandatory for this endpoint and cannot be disabled.
 
 Two answers exist for the same question, and Yolop was reading only one of them.
 
+The rejection is narrower than the message suggests, confirmed against the live
+endpoint: a request with no `reasoning` field at all is accepted, and so is one
+naming an effort. What OpenRouter refuses is reasoning it reads as switched off,
+which is `effort: "none"` and, on this endpoint, the bare
+`reasoning.exclude: true` the OpenRouter driver always sends to keep provider
+reasoning private. Naming an effort is therefore the fix available to Yolop, and
+`none` is never one of the levels offered for such a surface.
+
 ## What
 
 ### The effort scale is merged, not taken from a single source
@@ -74,6 +82,12 @@ When a turn fails and the provider says reasoning is mandatory, and the turn
 carried no effort, Yolop selects the model's default effort, tells the user what
 it changed, and sends the same input again. The effort sticks to the model, so
 the next turn is legal too and the status bar shows the level rather than `n/a`.
+The failed attempt stays in history but its assistant text, an apology for the
+error the host went on to repair, is not shown as the turn's answer.
+
+The repair belongs to the turn, not to one surface: the TUI, `--print`, and ACP
+all start turns through the same entry point and all get it, ACP also refreshing
+the client's effort selector to the level now in force.
 
 Exactly one retry, and only for a turn that named no effort. A rejection of a
 turn that *did* name a level is a choice only the user can make, so it surfaces
@@ -92,8 +106,9 @@ with the failure and a hint naming the control that fixes it (`/effort`, or
   effort surface resolves through, and
   `ProviderChoice::auto_reasoning_effort_for_model` owns the narrower question of
   which effort Yolop selects unasked.
-- `crate::runtime::session` owns the one-shot retry, and it is the only place
-  that changes the model behind the user's back.
+- `RuntimeHandles::run_turn_with_reasoning_recovery` owns the one-shot retry and
+  is the entry point every host starts a turn through; it is the only place that
+  changes the model behind the user's back.
 
 ## Related
 

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -88,6 +88,11 @@ pub(crate) async fn discover_provider_models(
             model.model_id = bare.to_string();
         }
     }
+    // Whatever the provider said about these models is metadata the effort
+    // selector and per-turn defaults cannot ask for themselves (they are
+    // synchronous); cache it while we have it. Kept before the chat filter so
+    // the record matches the catalog, not this call's presentation.
+    crate::runtime::discovered_profiles::remember(&target.provider_type, &models);
     let mut models = retain_chat_models(models);
     models.sort_by(|a, b| {
         b.created_at

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -1556,8 +1556,25 @@ async fn run_prompt_once(
     let mut live = handles.events.subscribe();
     let events_before = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
     let turn_handles = handles.clone();
-    let turn =
-        tokio::spawn(async move { turn_handles.run_checkpointed_turn(&prompt, input).await });
+    let turn_model = session.model.clone();
+    // Set when the turn was retried with a reasoning effort, so the client's
+    // effort selector is refreshed to the level now in force.
+    let recovered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let turn_recovered = recovered.clone();
+    let turn_peer = peer.clone();
+    let turn_acp_id = acp_id.clone();
+    let turn = tokio::spawn(async move {
+        let notice = move |text: String| {
+            turn_recovered.store(true, std::sync::atomic::Ordering::SeqCst);
+            turn_peer.session_update(
+                &turn_acp_id,
+                SessionUpdate::AgentMessageChunk(protocol::text_chunk(text)),
+            );
+        };
+        turn_handles
+            .run_turn_with_reasoning_recovery(&turn_model, &prompt, input, &notice)
+            .await
+    });
 
     let mut translator = Translator::new();
     let mut cancel_rx = session.arm_cancel();
@@ -1609,6 +1626,9 @@ async fn run_prompt_once(
     }
 
     let outcome = turn.await;
+    if recovered.load(std::sync::atomic::Ordering::SeqCst) {
+        emit_config_options(&peer, &session).await;
+    }
     if let Some(notice) = handles.checkpoints.take_notice() {
         peer.session_update(
             &acp_id,
@@ -1625,6 +1645,15 @@ async fn run_prompt_once(
                         "turn error: {error}"
                     ))),
                 );
+                if let Some(hint) = crate::runtime::reasoning::reasoning_error_hint(
+                    error,
+                    session.model.reasoning_effort().as_deref(),
+                ) {
+                    peer.session_update(
+                        &acp_id,
+                        SessionUpdate::AgentMessageChunk(protocol::text_chunk(hint)),
+                    );
+                }
             }
             (StopReason::EndTurn, Some(result))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2364,7 +2364,15 @@ async fn collect_print_turn(
     if automatic {
         input = session_state::task_completion::tag_continuation(input);
     }
-    let result = handles.run_checkpointed_turn(prompt, input).await?;
+    let retried = std::sync::atomic::AtomicBool::new(false);
+    let notice = |notice: String| {
+        retried.store(true, std::sync::atomic::Ordering::SeqCst);
+        eprintln!("{notice}");
+    };
+    let result = handles
+        .run_turn_with_reasoning_recovery(model, prompt, input, &notice)
+        .await?;
+    let retried = retried.load(std::sync::atomic::Ordering::SeqCst);
     if let Some(notice) = handles.checkpoints.take_notice() {
         eprintln!("{notice}");
     }
@@ -2375,7 +2383,10 @@ async fn collect_print_turn(
         .unwrap_or_default();
 
     let mut output = Vec::new();
-    for msg in messages.iter().skip(before_msgs) {
+    for msg in messages
+        .iter()
+        .skip(runtime::agent_output_start(&messages, before_msgs, retried))
+    {
         if msg.role == MessageRole::Agent
             && !msg.has_tool_calls()
             && let Some(text) = msg.text()
@@ -2390,6 +2401,11 @@ async fn collect_print_turn(
         && let Some(err) = &result.error
     {
         eprintln!("turn error: {err}");
+        if let Some(hint) =
+            runtime::reasoning::reasoning_error_hint(err, model.reasoning_effort().as_deref())
+        {
+            eprintln!("{hint}");
+        }
     }
     Ok(PrintTurn { result, output })
 }

--- a/src/runtime/discovered_profiles.rs
+++ b/src/runtime/discovered_profiles.rs
@@ -1,0 +1,141 @@
+//! Process-wide cache of the model profiles providers advertise at discovery
+//! time.
+//!
+//! The static registry in `everruns_provider::model_profiles` is curated data
+//! that grows on release cadence, so it is always behind a gateway's catalog.
+//! Gateways describe their own models instead: OpenRouter's `/models` carries a
+//! `supported_parameters` array, and its driver turns that into a
+//! [`ModelProfile`] on every [`DiscoveredModel`] (`reasoning` in the array is
+//! what says the model takes a reasoning effort at all).
+//!
+//! Yolop's effort selector and per-turn defaults are synchronous, so they
+//! cannot query discovery themselves. Every path that already lists models
+//! (the pre-turn availability check, the `/model` browser) records what it saw
+//! here, and the lookups read it as one layer of the merge: the curated
+//! registry first where it speaks, then this, then yolop's own metadata for
+//! families neither source describes yet.
+//!
+//! Empty until a discovery call has run in this process. That is the point of
+//! the layering: a miss is a miss, not a wrong answer.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, RwLock};
+
+use everruns_provider::{DiscoveredModel, DriverId, ModelProfile, ReasoningEffortConfig};
+
+type ProfileKey = (String, String);
+
+static DISCOVERED: LazyLock<RwLock<HashMap<ProfileKey, ModelProfile>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+fn key(provider_type: &DriverId, model_id: &str) -> ProfileKey {
+    (
+        provider_type.to_string(),
+        model_id.trim().to_ascii_lowercase(),
+    )
+}
+
+/// Record every profile a discovery response carried. Models the provider
+/// described without a profile are skipped rather than cached as "no metadata",
+/// so a thinner response never masks a richer earlier one.
+pub(crate) fn remember(provider_type: &DriverId, models: &[DiscoveredModel]) {
+    let fresh = models
+        .iter()
+        .filter_map(|model| {
+            let profile = model.discovered_profile.clone()?;
+            Some((key(provider_type, &model.model_id), profile))
+        })
+        .collect::<Vec<_>>();
+    if fresh.is_empty() {
+        return;
+    }
+    let mut cache = DISCOVERED
+        .write()
+        .expect("discovered profile lock poisoned");
+    cache.extend(fresh);
+}
+
+/// The profile this provider advertised for `model`, if discovery has run.
+pub(crate) fn profile(provider_type: &DriverId, model: &str) -> Option<ModelProfile> {
+    DISCOVERED
+        .read()
+        .expect("discovered profile lock poisoned")
+        .get(&key(provider_type, model))
+        .cloned()
+}
+
+/// The effort scale this provider advertised for `model`.
+pub(crate) fn reasoning_effort_config(
+    provider_type: &DriverId,
+    model: &str,
+) -> Option<ReasoningEffortConfig> {
+    profile(provider_type, model).and_then(|profile| profile.reasoning_effort)
+}
+
+/// A profile shaped like the one OpenRouter's driver derives from
+/// `supported_parameters`, with a marker default so a test can tell it apart
+/// from the curated registry's answer.
+#[cfg(test)]
+pub(crate) fn advertised_profile_for_test() -> ModelProfile {
+    use everruns_provider::{ReasoningEffort, ReasoningEffortValue};
+
+    let mut profile = everruns_provider::model_profiles::get_model_profile(
+        &DriverId::OpenRouter,
+        "nvidia/nemotron-3-super-120b-a12b",
+    )
+    .expect("a registry profile to take the shape from");
+    profile.reasoning = true;
+    profile.reasoning_effort = Some(ReasoningEffortConfig {
+        values: vec![ReasoningEffortValue {
+            value: ReasoningEffort::High,
+            name: "High".to_string(),
+        }],
+        default: ReasoningEffort::High,
+    });
+    profile
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_provider::ReasoningEffort;
+
+    fn model(model_id: &str, profile: Option<ModelProfile>) -> DiscoveredModel {
+        DiscoveredModel {
+            model_id: model_id.to_string(),
+            display_name: None,
+            created_at: None,
+            owned_by: None,
+            capabilities: vec!["chat".to_string()],
+            discovered_profile: profile,
+        }
+    }
+
+    // The cache is process-wide, so tests use ids of their own rather than
+    // clearing it out from under each other.
+    #[test]
+    fn advertised_efforts_are_readable_after_discovery() {
+        let id = "test-vendor/advertised-reasoner";
+        remember(
+            &DriverId::OpenRouter,
+            &[
+                model(id, Some(advertised_profile_for_test())),
+                model("test-vendor/undescribed", None),
+            ],
+        );
+
+        let config = reasoning_effort_config(&DriverId::OpenRouter, id)
+            .expect("the advertised effort scale");
+        assert_eq!(config.default, ReasoningEffort::High);
+        // Case-insensitive on the model id, as provider catalogs are.
+        assert!(
+            reasoning_effort_config(&DriverId::OpenRouter, "Test-Vendor/Advertised-Reasoner")
+                .is_some()
+        );
+        // A model discovery described without a profile stays a miss, so the
+        // caller falls through to the next layer of the merge.
+        assert!(profile(&DriverId::OpenRouter, "test-vendor/undescribed").is_none());
+        // Provider-scoped: the same id on another driver is a different model.
+        assert!(profile(&DriverId::Meta, id).is_none());
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2293,6 +2293,84 @@ impl ProviderChoice {
     }
 }
 
+/// The recovery itself, with the turn taken as an argument so it is testable
+/// without a live provider.
+///
+/// The repair is to select the model's default effort (from the merged profile
+/// metadata, else a mid-scale level) and send the same input again — the model
+/// keeps the effort afterwards, so the next turn is legal too, and the user is
+/// told what changed rather than finding a setting they never chose. Exactly one
+/// retry: a rejection of a turn that *did* name an effort is a choice only the
+/// user can make, and is left to surface with its hint
+/// ([`reasoning::reasoning_error_hint`]).
+pub(crate) async fn run_with_reasoning_recovery<F, Fut>(
+    model: &ModelState,
+    input: InputMessage,
+    notice: &(dyn Fn(String) + Send + Sync),
+    run: F,
+) -> anyhow::Result<everruns_host::TurnResult>
+where
+    F: Fn(InputMessage) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<everruns_host::TurnResult>>,
+{
+    let first = run(input.clone()).await;
+    let Some(error) = turn_failure(&first) else {
+        return first;
+    };
+    let Some(effort) = reasoning::recovery_effort(
+        &error,
+        model.reasoning_effort().as_deref(),
+        model.default_reasoning_effort().as_deref(),
+    ) else {
+        return first;
+    };
+
+    if let Err(err) = model.select_reasoning_effort(&effort).await {
+        tracing::warn!("could not apply reasoning effort {effort} after {error}: {err:#}");
+        return first;
+    }
+    notice(format!(
+        "{} requires reasoning; reasoning effort set to {effort} and the turn retried.",
+        model.model_id()
+    ));
+
+    let mut retry = input;
+    reasoning::apply_reasoning_effort(&mut retry, &effort);
+    run(retry).await
+}
+
+/// Where a host should start reading this turn's agent output.
+///
+/// Normally the history length captured before the turn. After a
+/// reasoning-effort retry the failed attempt is also in history, and its
+/// assistant text is an apology for an error the host went on to repair, so the
+/// answer starts after the last user message: the input the retry re-sent.
+pub(crate) fn agent_output_start(
+    messages: &[everruns_core::Message],
+    before: usize,
+    retried: bool,
+) -> usize {
+    if !retried {
+        return before;
+    }
+    messages
+        .iter()
+        .rposition(|message| message.role == everruns_core::MessageRole::User)
+        .map(|index| index + 1)
+        .unwrap_or(before)
+}
+
+/// The provider-facing error of a finished turn, whether it failed by `Err` or
+/// by an unsuccessful [`everruns_host::TurnResult`]. `None` for a turn that
+/// succeeded.
+fn turn_failure(result: &anyhow::Result<everruns_host::TurnResult>) -> Option<String> {
+    match result {
+        Err(error) => Some(format!("{error:#}")),
+        Ok(turn) if !turn.success => turn.error.clone(),
+        Ok(_) => None,
+    }
+}
+
 fn env_non_empty(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|value| !value.is_empty())
 }
@@ -2792,6 +2870,26 @@ impl RuntimeHandles {
         }
         self.checkpoints.apply_queued_confirmation().await;
         Ok(result?)
+    }
+
+    /// Run a turn, repairing the one provider rejection the host can repair
+    /// itself: an endpoint that mandates reasoning refusing a turn that carried
+    /// no reasoning effort.
+    ///
+    /// Every host that starts a turn goes through here (TUI, `--print`, ACP), so
+    /// the repair is not a property of one surface. `notice` is how that surface
+    /// tells the user what changed.
+    pub(crate) async fn run_turn_with_reasoning_recovery(
+        &self,
+        model: &ModelState,
+        prompt: &str,
+        input: InputMessage,
+        notice: &(dyn Fn(String) + Send + Sync),
+    ) -> anyhow::Result<everruns_host::TurnResult> {
+        run_with_reasoning_recovery(model, input, notice, move |input| async move {
+            self.run_checkpointed_turn(prompt, input).await
+        })
+        .await
     }
 
     /// Provider-reported tokens consumed by one agent turn. Completion gates
@@ -8661,6 +8759,101 @@ mod tests {
                 .and_then(|controls| controls.reasoning)
                 .and_then(|reasoning| reasoning.effort),
             Some(ReasoningEffort::Medium)
+        );
+    }
+
+    /// The reported failure, end to end at the turn seam: OpenRouter rejects a
+    /// muse turn that carries no reasoning
+    /// ("Reasoning is mandatory for this endpoint and cannot be disabled"), and
+    /// the host repairs it instead of handing the user a dead turn.
+    #[tokio::test]
+    async fn mandatory_reasoning_rejection_is_retried_with_an_effort() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(crate::config::SettingsStore::open(
+            sessions.path().join("settings.toml"),
+        ));
+        settings
+            .set_token("openrouter".to_string(), "test-key".to_string())
+            .expect("store an openrouter token");
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::OpenRouter {
+                model: "meta/muse-spark-1.3-contributor".to_string(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                // The state the report was filed from: a model the profile
+                // registry has never seen, with no effort selected.
+                reasoning_effort: None,
+            },
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let model = built.model;
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<Option<String>>::new()));
+        let recorded = seen.clone();
+        let run = move |input: InputMessage| {
+            let recorded = recorded.clone();
+            async move {
+                let effort = input
+                    .controls
+                    .as_ref()
+                    .and_then(|controls| controls.reasoning.as_ref())
+                    .and_then(|reasoning| reasoning.effort)
+                    .map(|effort| effort.as_str().to_string());
+                recorded.lock().expect("recorded").push(effort.clone());
+                Ok(everruns_host::TurnResult {
+                    response: String::new(),
+                    iterations: 1,
+                    tool_calls_count: 0,
+                    success: effort.is_some(),
+                    error: effort.is_none().then(|| {
+                        "LLM error: provider 'openrouter': OpenAI Responses API error \
+                         (400 Bad Request): {\"error\":{\"message\":\"Reasoning is mandatory for \
+                         this endpoint and cannot be disabled.\",\"code\":400}}"
+                            .to_string()
+                    }),
+                    stop_reason: if effort.is_some() {
+                        everruns_core::turn::TurnStopReason::EndTurn
+                    } else {
+                        everruns_core::turn::TurnStopReason::Error
+                    },
+                    turn_id: everruns_provider::typed_id::TurnId::new(),
+                })
+            }
+        };
+
+        let notices = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let recorded_notices = notices.clone();
+        let notice = move |text: String| {
+            recorded_notices.lock().expect("notices").push(text);
+        };
+        let result =
+            run_with_reasoning_recovery(&model, model.input_message("hello"), &notice, run)
+                .await
+                .expect("the retried turn");
+
+        assert!(result.success, "the retry must be the turn the user gets");
+        assert_eq!(
+            *seen.lock().expect("recorded"),
+            vec![None, Some("medium".to_string())],
+            "the first turn is the one the user asked for; only the retry adds reasoning"
+        );
+        assert_eq!(
+            model.reasoning_effort().as_deref(),
+            Some("medium"),
+            "the effort sticks, so the next turn is legal too"
+        );
+        let lines = notices.lock().expect("notices").clone();
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("requires reasoning") && line.contains("medium")),
+            "the user is told what changed: {lines:?}"
         );
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod background_wake;
 mod compaction_checkpoint;
+pub(crate) mod discovered_profiles;
+pub(crate) mod reasoning;
 pub mod session;
 pub mod session_log;
 
@@ -1722,19 +1724,10 @@ impl ProviderChoice {
             .and_then(|config| reasoning_effort_value(&config.default))
     }
 
+    /// The effort scale for the current model. See
+    /// [`merged_reasoning_effort_config`] for the merge order.
     fn reasoning_effort_config(&self) -> Option<ReasoningEffortConfig> {
-        self.model_profile()?.reasoning_effort
-    }
-
-    fn model_profile(&self) -> Option<ModelProfile> {
-        match self {
-            Self::Codex { model, .. } => crate::drivers::codex::model_profile(model),
-            _ => {
-                let resolved = self.model_without_stored_key();
-                local_model_profile(&resolved.provider_type, &resolved.model)
-                    .or_else(|| get_model_profile(&resolved.provider_type, &resolved.model))
-            }
-        }
+        self.reasoning_effort_config_for_model(self.model_id())
     }
 
     fn reasoning_effort_value(&self) -> Option<&Option<String>> {
@@ -1966,25 +1959,39 @@ impl ProviderChoice {
                 allowed.join(", ")
             ));
         }
-        reasoning_effort_value(&config.default)
-            .ok_or_else(|| {
-                anyhow!(
-                    "model {} has an invalid profile default",
-                    self.model_label_for(model)
-                )
-            })
-            .map(Some)
+        Ok(self.auto_reasoning_effort_for_model(model))
+    }
+
+    /// The effort yolop selects for `model` when the user has named none.
+    ///
+    /// Deliberately narrower than [`Self::reasoning_effort_config_for_model`]:
+    /// a provider catalog saying a model *accepts* efforts is not the same as
+    /// the turn needing one, and sending a level the user never chose would
+    /// change how models behave whose own default is fine. So this reads only
+    /// the curated profile and yolop's reasoning-required families, never the
+    /// discovered catalog.
+    fn auto_reasoning_effort_for_model(&self, model: &str) -> Option<String> {
+        match self {
+            Self::Codex { .. } => crate::drivers::codex::model_profile(model)
+                .and_then(|profile| profile.reasoning_effort),
+            _ => {
+                let resolved = self.model_without_stored_key_for_model(model);
+                profile_reasoning_effort_config(&resolved.provider_type, &resolved.model)
+            }
+        }
+        .and_then(|config| reasoning_effort_value(&config.default))
     }
 
     fn reasoning_effort_config_for_model(&self, model: &str) -> Option<ReasoningEffortConfig> {
         match self {
-            Self::Codex { .. } => crate::drivers::codex::model_profile(model),
+            // Codex speaks to its own driver profile, not a provider catalog.
+            Self::Codex { .. } => crate::drivers::codex::model_profile(model)
+                .and_then(|profile| profile.reasoning_effort),
             _ => {
                 let resolved = self.model_without_stored_key_for_model(model);
-                get_model_profile(&resolved.provider_type, &resolved.model)
+                merged_reasoning_effort_config(&resolved.provider_type, &resolved.model)
             }
         }
-        .and_then(|profile| profile.reasoning_effort)
     }
 
     fn model_label_for(&self, model: &str) -> String {
@@ -2360,9 +2367,40 @@ static GPT_5_6_PROFILE: LazyLock<ModelProfile> = LazyLock::new(|| {
     profile
 });
 
-fn profile_default_reasoning_effort(provider_type: &DriverId, model: &str) -> Option<String> {
+/// The reasoning-effort scale for a model, merged across every source that
+/// knows something about it:
+///
+/// 1. the curated profile registry (plus yolop's local overrides), which is
+///    authoritative wherever it describes the model;
+/// 2. what the provider itself advertised at discovery, which is how a gateway
+///    catalog covers models the registry has never seen
+///    ([`discovered_profiles`]);
+/// 3. yolop's own metadata for reasoning-required families
+///    ([`reasoning::fallback_reasoning_effort_config`]), so a model whose
+///    endpoint rejects a turn without reasoning has a scale and a default even
+///    before any discovery call has run.
+fn merged_reasoning_effort_config(
+    provider_type: &DriverId,
+    model: &str,
+) -> Option<ReasoningEffortConfig> {
+    profile_reasoning_effort_config(provider_type, model)
+        .or_else(|| discovered_profiles::reasoning_effort_config(provider_type, model))
+}
+
+/// The two layers yolop will act on by itself: the curated profile registry,
+/// then the reasoning-required families. What a provider merely advertises is
+/// not here — see [`ProviderChoice::auto_reasoning_effort_for_model`].
+fn profile_reasoning_effort_config(
+    provider_type: &DriverId,
+    model: &str,
+) -> Option<ReasoningEffortConfig> {
     model_profile(provider_type, model)
-        .and_then(|profile| profile.reasoning_effort.clone())
+        .and_then(|profile| profile.reasoning_effort)
+        .or_else(|| reasoning::fallback_reasoning_effort_config(provider_type, model))
+}
+
+fn profile_default_reasoning_effort(provider_type: &DriverId, model: &str) -> Option<String> {
+    profile_reasoning_effort_config(provider_type, model)
         .and_then(|config| reasoning_effort_value(&config.default))
 }
 
@@ -2996,6 +3034,13 @@ impl ModelState {
         )
             .await
             .map_err(|_| anyhow!("{provider_name} model availability check timed out; the turn was not started and is safe to resume"))??;
+
+        // The catalog this check already paid for is also where a gateway
+        // describes models the curated registry has never seen, so keep it
+        // rather than reading it once for an availability answer.
+        if let Some(models) = discovered.as_deref() {
+            discovered_profiles::remember(&resolved.provider_type, models);
+        }
 
         if let Some(models) = discovered
             && !models.iter().any(|model| model.model_id == model_id)
@@ -7172,8 +7217,9 @@ mod tests {
             };
             let next = provider.resolve_model_spec(model).unwrap();
 
-            let profile = next.model_profile().expect("gpt-5.6 variant profile");
-            let efforts = profile.reasoning_effort.expect("reasoning effort config");
+            let efforts = next
+                .reasoning_effort_config()
+                .expect("gpt-5.6 variant reasoning effort config");
             assert_eq!(
                 reasoning_effort_value(&efforts.default).as_deref(),
                 Some("medium")
@@ -8615,6 +8661,117 @@ mod tests {
                 .and_then(|controls| controls.reasoning)
                 .and_then(|reasoning| reasoning.effort),
             Some(ReasoningEffort::Medium)
+        );
+    }
+
+    /// The report that started this: `openrouter/meta/muse-spark-1.3-contributor`
+    /// is in no profile registry, so the turn went out with no reasoning at all
+    /// and OpenRouter answered "Reasoning is mandatory for this endpoint and
+    /// cannot be disabled", while `/effort` had nothing to offer as a fix.
+    #[test]
+    fn reasoning_required_openrouter_model_selects_and_sends_an_effort() {
+        let next = ProviderChoice::default_openrouter()
+            .resolve_model_spec("meta/muse-spark-1.3-contributor")
+            .unwrap();
+
+        assert_eq!(next.reasoning_effort(), Some("medium"));
+        assert_eq!(
+            next.input_message("hello")
+                .controls
+                .and_then(|controls| controls.reasoning)
+                .and_then(|reasoning| reasoning.effort),
+            Some(ReasoningEffort::Medium)
+        );
+        let options = next
+            .reasoning_effort_options()
+            .into_iter()
+            .map(|option| option.value)
+            .collect::<Vec<_>>();
+        assert_eq!(options, vec!["low", "medium", "high"]);
+    }
+
+    /// An explicit effort still wins over the family default, and an effort the
+    /// scale does not carry is still rejected.
+    #[test]
+    fn reasoning_required_model_accepts_an_explicit_effort() {
+        let base = ProviderChoice::default_openrouter();
+        let next = base
+            .resolve_model_spec("meta/muse-spark-1.3-contributor high")
+            .unwrap();
+        assert_eq!(next.reasoning_effort(), Some("high"));
+
+        let err = base
+            .resolve_model_spec("meta/muse-spark-1.3-contributor turbo")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("low, medium, high"), "unexpected error: {err}");
+    }
+
+    /// What the provider advertised at discovery covers models no registry
+    /// describes, and it is what `/effort` offers for them — without becoming
+    /// an effort yolop sends on its own.
+    #[test]
+    fn discovered_provider_metadata_fills_the_effort_scale_it_does_not_choose_one() {
+        discovered_profiles::remember(
+            &DriverId::OpenRouter,
+            &[everruns_provider::DiscoveredModel {
+                model_id: "test-vendor/gateway-reasoner".to_string(),
+                display_name: None,
+                created_at: None,
+                owned_by: None,
+                capabilities: vec!["chat".to_string()],
+                // Advertises High only, so an answer from this layer is
+                // unmistakable.
+                discovered_profile: Some(discovered_profiles::advertised_profile_for_test()),
+            }],
+        );
+        let base = ProviderChoice::default_openrouter();
+
+        let gateway = base
+            .resolve_model_spec("test-vendor/gateway-reasoner")
+            .unwrap();
+        assert_eq!(
+            gateway
+                .reasoning_effort_options()
+                .into_iter()
+                .map(|option| option.value)
+                .collect::<Vec<_>>(),
+            vec!["high"],
+            "the picker offers what the provider advertised"
+        );
+        assert_eq!(
+            gateway.reasoning_effort(),
+            None,
+            "a catalog says the model accepts efforts, not that yolop should choose one"
+        );
+
+        // The advertised scale is also what an explicit choice is checked
+        // against.
+        assert_eq!(
+            base.resolve_model_spec("test-vendor/gateway-reasoner high")
+                .unwrap()
+                .reasoning_effort(),
+            Some("high")
+        );
+        let err = base
+            .resolve_model_spec("test-vendor/gateway-reasoner minimal")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("supports reasoning efforts: high"), "{err}");
+    }
+
+    /// A model the curated registry does describe keeps the registry's answer.
+    #[test]
+    fn the_registry_still_owns_the_models_it_describes() {
+        let registry_default = get_model_profile(&DriverId::OpenAI, "gpt-5.5")
+            .and_then(|profile| profile.reasoning_effort)
+            .map(|config| config.default.as_str().to_string());
+        let openai = ProviderChoice::default_openai()
+            .resolve_model_spec("gpt-5.5")
+            .unwrap();
+        assert_eq!(
+            openai.reasoning_effort().map(str::to_string),
+            registry_default
         );
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8762,6 +8762,27 @@ mod tests {
         );
     }
 
+    /// A retried turn leaves two attempts in history. The answer is the second
+    /// one; the first is an apology for an error the host repaired.
+    #[test]
+    fn a_retried_turn_reads_its_answer_from_the_re_sent_input() {
+        use everruns_core::Message;
+
+        let messages = vec![
+            Message::user("say pong"),
+            Message::assistant("I encountered an error while processing your request."),
+            Message::user("say pong"),
+            Message::assistant("pong"),
+        ];
+
+        assert_eq!(agent_output_start(&messages, 0, true), 3);
+        // No retry: the host's own pre-turn mark stands.
+        assert_eq!(agent_output_start(&messages, 0, false), 0);
+        // Nothing to anchor on degrades to that same mark rather than hiding
+        // the turn's output.
+        assert_eq!(agent_output_start(&[], 7, true), 7);
+    }
+
     /// The reported failure, end to end at the turn seam: OpenRouter rejects a
     /// muse turn that carries no reasoning
     /// ("Reasoning is mandatory for this endpoint and cannot be disabled"), and

--- a/src/runtime/reasoning.rs
+++ b/src/runtime/reasoning.rs
@@ -1,0 +1,286 @@
+//! Reasoning-effort metadata the shared model-profile registry does not carry,
+//! and recovery from endpoints that mandate reasoning.
+//!
+//! Two gaps show up on gateways, where a model id can name an endpoint the
+//! profile registry has never seen (`meta/muse-spark-1.3-contributor` on
+//! OpenRouter):
+//!
+//!   - the effort picker has nothing to offer, because both the options and the
+//!     default come from the profile, so `/effort` reports "current model
+//!     profile does not expose reasoning efforts";
+//!   - the turn is then sent with no reasoning control at all, and an endpoint
+//!     that mandates reasoning rejects it with
+//!     `400 Reasoning is mandatory for this endpoint and cannot be disabled`.
+//!
+//! The registry is upstream data and only grows on release cadence, so families
+//! known to require reasoning are listed here by family prefix: a new point
+//! release (`muse-spark-1.3`) or tier (`-contributor`) is covered the day it
+//! ships instead of erroring until the next dependency bump. When the registry
+//! does carry an effort config it wins; this is a fallback, never an override.
+
+use everruns_core::{InputMessage, ReasoningConfig};
+use everruns_provider::{DriverId, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue};
+
+/// A model family whose endpoints reject a request that carries no reasoning
+/// effort, and the provider surfaces where that is true.
+struct ReasoningRequirement {
+    /// Matched as a prefix of the bare model id, so every point release and
+    /// pricing tier of the family is covered.
+    family: &'static str,
+    /// Driver ids ([`DriverId::as_str`]) whose endpoint mandates reasoning for
+    /// this family. Scoped rather than global because mandating reasoning is a
+    /// property of the endpoint, not of the weights: Meta's own API documents a
+    /// model-determined default for Muse, while OpenRouter's Muse endpoint
+    /// rejects a turn that names no effort at all.
+    drivers: &'static [&'static str],
+}
+
+const REASONING_REQUIREMENTS: &[ReasoningRequirement] = &[ReasoningRequirement {
+    family: "muse-spark",
+    drivers: &["openrouter"],
+}];
+
+/// The effort to fall back to when an endpoint demands reasoning and neither
+/// the user nor a profile has named a level. Mid-scale on purpose: the point is
+/// to make the turn legal, not to pick a spend level on the user's behalf.
+pub(crate) const DEFAULT_REQUIRED_EFFORT: &str = "medium";
+
+/// The bare model id: no vendor prefix (`meta/muse-spark-1.3` -> `muse-spark-1.3`)
+/// and no OpenRouter variant suffix (`:free`, `:nitro`), lowercased.
+fn bare_model_id(model: &str) -> String {
+    let model = model.rsplit('/').next().unwrap_or(model);
+    let model = model.split(':').next().unwrap_or(model);
+    model.trim().to_ascii_lowercase()
+}
+
+/// Whether this model's endpoint on this provider mandates reasoning, so a turn
+/// without a reasoning effort is rejected before it starts.
+pub(crate) fn requires_reasoning(provider_type: &DriverId, model: &str) -> bool {
+    let bare = bare_model_id(model);
+    REASONING_REQUIREMENTS.iter().any(|requirement| {
+        bare.starts_with(requirement.family)
+            && requirement
+                .drivers
+                .iter()
+                .any(|driver| *driver == provider_type.as_str())
+    })
+}
+
+/// Effort options for a model the profile registry and the provider's own
+/// catalog leave undescribed. `None` for anything but the reasoning-required
+/// surfaces: guessing a scale for an endpoint that is happy without reasoning
+/// would offer levels the provider may reject.
+pub(crate) fn fallback_reasoning_effort_config(
+    provider_type: &DriverId,
+    model: &str,
+) -> Option<ReasoningEffortConfig> {
+    if !requires_reasoning(provider_type, model) {
+        return None;
+    }
+    Some(ReasoningEffortConfig {
+        values: vec![
+            effort(ReasoningEffort::Low, "Low"),
+            effort(ReasoningEffort::Medium, "Medium"),
+            effort(ReasoningEffort::High, "High"),
+        ],
+        default: ReasoningEffort::Medium,
+    })
+}
+
+fn effort(value: ReasoningEffort, name: &str) -> ReasoningEffortValue {
+    ReasoningEffortValue {
+        value,
+        name: name.to_string(),
+    }
+}
+
+/// Whether a failed turn failed because the endpoint mandates reasoning.
+///
+/// Matched on the provider's message rather than a status code: the drivers
+/// flatten provider errors into text, and 400 alone says nothing about the
+/// cause. Kept deliberately loose (`reasoning` plus a mandate word) so a
+/// reworded upstream message still routes to the same recovery.
+pub(crate) fn is_reasoning_required_error(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    if !message.contains("reasoning") {
+        return false;
+    }
+    message.contains("mandatory")
+        || message.contains("cannot be disabled")
+        || message.contains("can not be disabled")
+        || message.contains("is required")
+}
+
+/// The effort to retry a mandatory-reasoning failure with, or `None` when the
+/// failure is not one this can fix.
+///
+/// A turn that already carried an effort is not retried: the endpoint rejected
+/// a request that named a level, so sending another one only spends a second
+/// turn on the same error. The user is pointed at the picker instead.
+pub(crate) fn recovery_effort(
+    error: &str,
+    current_effort: Option<&str>,
+    profile_default: Option<&str>,
+) -> Option<String> {
+    if current_effort.is_some() || !is_reasoning_required_error(error) {
+        return None;
+    }
+    Some(
+        profile_default
+            .unwrap_or(DEFAULT_REQUIRED_EFFORT)
+            .to_string(),
+    )
+}
+
+/// Set `effort` on an already-built input message, so a turn can be retried
+/// with reasoning without rebuilding its content (images, provenance metadata
+/// and tags are what a wake or a resumed turn carries, and are not
+/// reconstructible from the prompt text).
+pub(crate) fn apply_reasoning_effort(input: &mut InputMessage, effort: &str) {
+    let Some(effort) = ReasoningEffort::parse(effort) else {
+        return;
+    };
+    let mut controls = input.controls.take().unwrap_or_default();
+    controls.reasoning = Some(ReasoningConfig {
+        effort: Some(effort),
+    });
+    input.controls = Some(controls);
+}
+
+/// What to tell the user when a mandatory-reasoning failure cannot be repaired
+/// automatically, i.e. the turn already named an effort the endpoint rejected.
+pub(crate) fn reasoning_error_hint(error: &str, current_effort: Option<&str>) -> Option<String> {
+    if !is_reasoning_required_error(error) {
+        return None;
+    }
+    match current_effort {
+        Some(effort) => Some(format!(
+            "this endpoint rejected reasoning effort `{effort}`; run /effort to pick another level, or /model to switch models"
+        )),
+        None => Some(
+            "this endpoint requires reasoning; run /effort to pick a level, or /model to switch models"
+                .to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn muse_requires_reasoning_on_the_gateway_across_tiers_and_releases() {
+        let openrouter = DriverId::OpenRouter;
+        assert!(requires_reasoning(&openrouter, "meta/muse-spark-1.2"));
+        // The id that started this: an OpenRouter-prefixed point release the
+        // profile registry has never seen.
+        assert!(requires_reasoning(
+            &openrouter,
+            "meta/muse-spark-1.3-contributor"
+        ));
+        assert!(requires_reasoning(&openrouter, "meta/muse-spark-1.3:free"));
+        assert!(!requires_reasoning(&openrouter, "openai/gpt-5.5"));
+        assert!(!requires_reasoning(
+            &openrouter,
+            "anthropic/claude-opus-4-8"
+        ));
+        // Meta's own API documents a model-determined default, so its surface
+        // keeps upstream's answer rather than being given one here.
+        assert!(!requires_reasoning(&DriverId::Meta, "muse-spark-1.2"));
+    }
+
+    #[test]
+    fn fallback_config_offers_a_scale_only_where_reasoning_is_required() {
+        let config = fallback_reasoning_effort_config(
+            &DriverId::OpenRouter,
+            "meta/muse-spark-1.3-contributor",
+        )
+        .expect("reasoning-required models expose an effort scale");
+        assert_eq!(config.default, ReasoningEffort::Medium);
+        assert_eq!(
+            config
+                .values
+                .iter()
+                .map(|value| value.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["low", "medium", "high"]
+        );
+        assert!(
+            fallback_reasoning_effort_config(&DriverId::OpenRouter, "qwen/qwen3.7-max").is_none()
+        );
+    }
+
+    #[test]
+    fn openrouter_mandatory_reasoning_error_is_recognized() {
+        let error = "LLM error: provider 'openrouter': OpenAI Responses API error (400 Bad Request): \
+             {\"error\":{\"message\":\"Reasoning is mandatory for this endpoint and cannot be disabled.\",\"code\":400}}";
+        assert!(is_reasoning_required_error(error));
+        assert!(!is_reasoning_required_error(
+            "LLM error: provider 'openrouter': 401 Unauthorized"
+        ));
+        // A rate-limit message that happens to mention a mandatory field must
+        // not be routed into reasoning recovery.
+        assert!(!is_reasoning_required_error(
+            "provider error: field `model` is mandatory"
+        ));
+    }
+
+    #[test]
+    fn recovery_uses_the_profile_default_then_falls_back_to_medium() {
+        let error = "Reasoning is mandatory for this endpoint and cannot be disabled.";
+        assert_eq!(
+            recovery_effort(error, None, Some("high")).as_deref(),
+            Some("high")
+        );
+        assert_eq!(
+            recovery_effort(error, None, None).as_deref(),
+            Some(DEFAULT_REQUIRED_EFFORT)
+        );
+    }
+
+    #[test]
+    fn a_turn_that_already_named_an_effort_is_not_retried() {
+        let error = "Reasoning is mandatory for this endpoint and cannot be disabled.";
+        assert_eq!(recovery_effort(error, Some("low"), Some("medium")), None);
+        let hint = reasoning_error_hint(error, Some("low")).expect("rejected effort earns a hint");
+        assert!(
+            hint.contains("/effort"),
+            "hint should point at the picker: {hint}"
+        );
+    }
+
+    #[test]
+    fn applying_an_effort_keeps_the_rest_of_the_message() {
+        use everruns_core::{ContentPart, MessageRole};
+
+        let mut input = InputMessage {
+            role: MessageRole::User,
+            content: vec![ContentPart::text("hello")],
+            controls: None,
+            metadata: None,
+            tags: vec!["wake".to_string()],
+        };
+
+        apply_reasoning_effort(&mut input, "medium");
+
+        assert_eq!(
+            input
+                .controls
+                .as_ref()
+                .and_then(|controls| controls.reasoning.as_ref())
+                .and_then(|reasoning| reasoning.effort),
+            Some(ReasoningEffort::Medium)
+        );
+        assert_eq!(input.content.len(), 1);
+        assert_eq!(input.tags, vec!["wake".to_string()]);
+    }
+
+    #[test]
+    fn unrelated_failures_are_left_alone() {
+        assert_eq!(
+            recovery_effort("connection reset by peer", None, None),
+            None
+        );
+        assert_eq!(reasoning_error_hint("connection reset by peer", None), None);
+    }
+}

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -244,13 +244,19 @@ impl Session {
             let turn_handles = handles.clone();
             let turn_model = model.clone();
             let notices = tx.clone();
+            let retried = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let turn_retried = retried.clone();
             let mut turn = tokio::spawn(async move {
-                run_with_reasoning_recovery(&turn_model, input, &notices, move |input| {
-                    let handles = turn_handles.clone();
-                    let prompt = prompt.clone();
-                    async move { handles.run_checkpointed_turn(&prompt, input).await }
-                })
-                .await
+                let notice = move |text: String| {
+                    turn_retried.store(true, std::sync::atomic::Ordering::SeqCst);
+                    let _ = notices.send(TurnEvent::Lines(vec![ChatLine {
+                        author: Author::System,
+                        text,
+                    }]));
+                };
+                turn_handles
+                    .run_turn_with_reasoning_recovery(&turn_model, &prompt, input, &notice)
+                    .await
             });
 
             let mut emitted_events = HashSet::new();
@@ -371,7 +377,16 @@ impl Session {
                 .unwrap_or_default();
 
             // Assistant text from the turn.
-            let mut out = assistant_lines_since(&messages, before);
+            // After a reasoning retry the failed attempt is in history too;
+            // its apology is not this turn's answer.
+            let mut out = assistant_lines_since(
+                &messages,
+                crate::runtime::agent_output_start(
+                    &messages,
+                    before,
+                    retried.load(std::sync::atomic::Ordering::SeqCst),
+                ),
+            );
             if out.is_empty() && !response.response.is_empty() {
                 out.push(ChatLine {
                     author: Author::Assistant,
@@ -468,69 +483,6 @@ impl Session {
 /// Drain any persisted events (from `runtime.events()`) that the broadcast
 /// receiver may have missed — used after a `Lagged` recv error and once more at
 /// end-of-turn so the transcript is never missing tool/reason completion lines.
-/// Run a turn, and repair the one provider rejection the host can repair
-/// itself: an endpoint that mandates reasoning refusing a turn that carried no
-/// reasoning effort.
-///
-/// The repair is to select the model's default effort (from the merged profile
-/// metadata, else a mid-scale level) and send the same input again — the model
-/// keeps the effort afterwards, so the next turn is legal too, and the user is
-/// told what changed rather than finding a setting they never chose. Exactly
-/// one retry: a rejection of a turn that *did* name an effort is a choice only
-/// the user can make, and is left to surface with its hint.
-///
-/// `run` is the turn itself, taken as an argument so the recovery is testable
-/// without a live provider.
-async fn run_with_reasoning_recovery<F, Fut>(
-    model: &ModelState,
-    input: InputMessage,
-    notices: &mpsc::UnboundedSender<TurnEvent>,
-    run: F,
-) -> Result<everruns_host::TurnResult>
-where
-    F: Fn(InputMessage) -> Fut,
-    Fut: std::future::Future<Output = Result<everruns_host::TurnResult>>,
-{
-    let first = run(input.clone()).await;
-    let Some(error) = turn_failure(&first) else {
-        return first;
-    };
-    let Some(effort) = reasoning::recovery_effort(
-        &error,
-        model.reasoning_effort().as_deref(),
-        model.default_reasoning_effort().as_deref(),
-    ) else {
-        return first;
-    };
-
-    if let Err(err) = model.select_reasoning_effort(&effort).await {
-        tracing::warn!("could not apply reasoning effort {effort} after {error}: {err:#}");
-        return first;
-    }
-    let _ = notices.send(TurnEvent::Lines(vec![ChatLine {
-        author: Author::System,
-        text: format!(
-            "{} requires reasoning; reasoning effort set to {effort} and the turn retried.",
-            model.model_id()
-        ),
-    }]));
-
-    let mut retry = input;
-    reasoning::apply_reasoning_effort(&mut retry, &effort);
-    run(retry).await
-}
-
-/// The provider-facing error of a finished turn, whether it failed by `Err` or
-/// by an unsuccessful [`everruns_host::TurnResult`]. `None` for a turn that
-/// succeeded.
-fn turn_failure(result: &Result<everruns_host::TurnResult>) -> Option<String> {
-    match result {
-        Err(error) => Some(format!("{error:#}")),
-        Ok(turn) if !turn.success => turn.error.clone(),
-        Ok(_) => None,
-    }
-}
-
 async fn catch_up_events(
     handles: &RuntimeHandles,
     session_id: SessionId,
@@ -718,99 +670,6 @@ mod tests {
                 .expect("messages")
                 .is_empty(),
             "the rejected ask must remain resumable instead of entering history"
-        );
-    }
-
-    /// The reported failure, end to end at the turn seam: OpenRouter rejects a
-    /// muse turn that carries no reasoning
-    /// ("Reasoning is mandatory for this endpoint and cannot be disabled"), and
-    /// the host repairs it instead of handing the user a dead turn.
-    #[tokio::test]
-    async fn mandatory_reasoning_rejection_is_retried_with_an_effort() {
-        let workspace = tempfile::tempdir().expect("workspace");
-        let sessions = tempfile::tempdir().expect("sessions");
-        let settings = Arc::new(crate::config::SettingsStore::open(
-            sessions.path().join("settings.toml"),
-        ));
-        settings
-            .set_token("openrouter".to_string(), "test-key".to_string())
-            .expect("store an openrouter token");
-        let built = crate::runtime::build_with_options(
-            workspace.path().to_path_buf(),
-            crate::runtime::ProviderChoice::OpenRouter {
-                model: "meta/muse-spark-1.3-contributor".to_string(),
-                base_url: "https://openrouter.ai/api/v1".to_string(),
-                // The state the report was filed from: a model the profile
-                // registry has never seen, with no effort selected.
-                reasoning_effort: None,
-            },
-            None,
-            sessions.path().to_path_buf(),
-            settings,
-            crate::runtime::BuildOptions::default(),
-        )
-        .await
-        .expect("build runtime");
-        let model = built.model;
-
-        let seen = Arc::new(std::sync::Mutex::new(Vec::<Option<String>>::new()));
-        let recorded = seen.clone();
-        let run = move |input: InputMessage| {
-            let recorded = recorded.clone();
-            async move {
-                let effort = input
-                    .controls
-                    .as_ref()
-                    .and_then(|controls| controls.reasoning.as_ref())
-                    .and_then(|reasoning| reasoning.effort)
-                    .map(|effort| effort.as_str().to_string());
-                recorded.lock().expect("recorded").push(effort.clone());
-                Ok(everruns_host::TurnResult {
-                    response: String::new(),
-                    iterations: 1,
-                    tool_calls_count: 0,
-                    success: effort.is_some(),
-                    error: effort.is_none().then(|| {
-                        "LLM error: provider 'openrouter': OpenAI Responses API error \
-                         (400 Bad Request): {\"error\":{\"message\":\"Reasoning is mandatory for \
-                         this endpoint and cannot be disabled.\",\"code\":400}}"
-                            .to_string()
-                    }),
-                    stop_reason: if effort.is_some() {
-                        everruns_core::turn::TurnStopReason::EndTurn
-                    } else {
-                        everruns_core::turn::TurnStopReason::Error
-                    },
-                    turn_id: everruns_provider::typed_id::TurnId::new(),
-                })
-            }
-        };
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let result = run_with_reasoning_recovery(&model, model.input_message("hello"), &tx, run)
-            .await
-            .expect("the retried turn");
-
-        assert!(result.success, "the retry must be the turn the user gets");
-        assert_eq!(
-            *seen.lock().expect("recorded"),
-            vec![None, Some("medium".to_string())],
-            "the first turn is the one the user asked for; only the retry adds reasoning"
-        );
-        assert_eq!(
-            model.reasoning_effort().as_deref(),
-            Some("medium"),
-            "the effort sticks, so the next turn is legal too"
-        );
-        let mut lines = Vec::new();
-        while let Ok(TurnEvent::Lines(batch)) = rx.try_recv() {
-            lines.extend(batch.into_iter().map(|line| line.text));
-        }
-        assert!(
-            lines
-                .iter()
-                .any(|line| line.contains("requires reasoning") && line.contains("medium")),
-            "the user is told what changed: {lines:?}"
         );
     }
 

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -396,20 +396,7 @@ impl Session {
             if !response.success
                 && let Some(err) = &response.error
             {
-                out.push(ChatLine {
-                    author: Author::System,
-                    text: format!("turn error: {err}"),
-                });
-                // A provider that mandates reasoning states it in prose the
-                // user cannot act on. Say which control fixes it.
-                if let Some(hint) =
-                    reasoning::reasoning_error_hint(err, model.reasoning_effort().as_deref())
-                {
-                    out.push(ChatLine {
-                        author: Author::System,
-                        text: hint,
-                    });
-                }
+                out.extend(turn_failure_lines(err, model.reasoning_effort().as_deref()));
             }
             let _ = tx.send(TurnEvent::Lines(out));
             let success = response.success;
@@ -483,6 +470,23 @@ impl Session {
 /// Drain any persisted events (from `runtime.events()`) that the broadcast
 /// receiver may have missed — used after a `Lagged` recv error and once more at
 /// end-of-turn so the transcript is never missing tool/reason completion lines.
+/// How a failed turn reads in the transcript: the provider's own message, plus,
+/// when the failure is one a control can fix, the control that fixes it. A
+/// provider that mandates reasoning states it in prose the user cannot act on.
+fn turn_failure_lines(error: &str, current_effort: Option<&str>) -> Vec<ChatLine> {
+    let mut lines = vec![ChatLine {
+        author: Author::System,
+        text: format!("turn error: {error}"),
+    }];
+    if let Some(hint) = reasoning::reasoning_error_hint(error, current_effort) {
+        lines.push(ChatLine {
+            author: Author::System,
+            text: hint,
+        });
+    }
+    lines
+}
+
 async fn catch_up_events(
     handles: &RuntimeHandles,
     session_id: SessionId,
@@ -670,6 +674,34 @@ mod tests {
                 .expect("messages")
                 .is_empty(),
             "the rejected ask must remain resumable instead of entering history"
+        );
+    }
+
+    /// The transcript a mandated-reasoning failure leaves behind when the host
+    /// could not repair it, asserted on the presentation model rather than a
+    /// terminal buffer.
+    #[test]
+    fn an_unfixable_reasoning_failure_names_the_control_that_fixes_it() {
+        let error = "LLM error: provider 'openrouter': OpenAI Responses API error \
+             (400 Bad Request): {\"error\":{\"message\":\"Reasoning is mandatory for this \
+             endpoint and cannot be disabled.\",\"code\":400}}";
+
+        let lines = turn_failure_lines(error, Some("low"));
+
+        assert_eq!(lines.len(), 2, "the error, then the way out: {lines:?}");
+        assert!(lines.iter().all(|line| line.author == Author::System));
+        assert!(lines[0].text.starts_with("turn error: "));
+        assert!(
+            lines[1].text.contains("rejected reasoning effort `low`")
+                && lines[1].text.contains("/effort"),
+            "the hint names the rejected level and the control: {}",
+            lines[1].text
+        );
+
+        // Failures nothing in the UI can fix stay one line.
+        assert_eq!(
+            turn_failure_lines("connection reset by peer", None).len(),
+            1
         );
     }
 

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -22,7 +22,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::exec::tools::{BashTool, Workspace};
 use crate::runtime::background_wake::WakeMessage;
-use crate::runtime::{ModelState, RuntimeHandles};
+use crate::runtime::{ModelState, RuntimeHandles, reasoning};
 use crate::tui::transcript::{
     Author, ChatLine, DeltaRouter, TurnEvent, assistant_lines_since, handle_live_event,
     lines_for_event_with_router, lines_for_replayed_event, remember_write_todos_args,
@@ -242,10 +242,16 @@ impl Session {
             };
 
             let turn_handles = handles.clone();
-            let mut turn =
-                tokio::spawn(
-                    async move { turn_handles.run_checkpointed_turn(&prompt, input).await },
-                );
+            let turn_model = model.clone();
+            let notices = tx.clone();
+            let mut turn = tokio::spawn(async move {
+                run_with_reasoning_recovery(&turn_model, input, &notices, move |input| {
+                    let handles = turn_handles.clone();
+                    let prompt = prompt.clone();
+                    async move { handles.run_checkpointed_turn(&prompt, input).await }
+                })
+                .await
+            });
 
             let mut emitted_events = HashSet::new();
             let mut delta_router = DeltaRouter::default();
@@ -379,6 +385,16 @@ impl Session {
                     author: Author::System,
                     text: format!("turn error: {err}"),
                 });
+                // A provider that mandates reasoning states it in prose the
+                // user cannot act on. Say which control fixes it.
+                if let Some(hint) =
+                    reasoning::reasoning_error_hint(err, model.reasoning_effort().as_deref())
+                {
+                    out.push(ChatLine {
+                        author: Author::System,
+                        text: hint,
+                    });
+                }
             }
             let _ = tx.send(TurnEvent::Lines(out));
             let success = response.success;
@@ -452,6 +468,69 @@ impl Session {
 /// Drain any persisted events (from `runtime.events()`) that the broadcast
 /// receiver may have missed — used after a `Lagged` recv error and once more at
 /// end-of-turn so the transcript is never missing tool/reason completion lines.
+/// Run a turn, and repair the one provider rejection the host can repair
+/// itself: an endpoint that mandates reasoning refusing a turn that carried no
+/// reasoning effort.
+///
+/// The repair is to select the model's default effort (from the merged profile
+/// metadata, else a mid-scale level) and send the same input again — the model
+/// keeps the effort afterwards, so the next turn is legal too, and the user is
+/// told what changed rather than finding a setting they never chose. Exactly
+/// one retry: a rejection of a turn that *did* name an effort is a choice only
+/// the user can make, and is left to surface with its hint.
+///
+/// `run` is the turn itself, taken as an argument so the recovery is testable
+/// without a live provider.
+async fn run_with_reasoning_recovery<F, Fut>(
+    model: &ModelState,
+    input: InputMessage,
+    notices: &mpsc::UnboundedSender<TurnEvent>,
+    run: F,
+) -> Result<everruns_host::TurnResult>
+where
+    F: Fn(InputMessage) -> Fut,
+    Fut: std::future::Future<Output = Result<everruns_host::TurnResult>>,
+{
+    let first = run(input.clone()).await;
+    let Some(error) = turn_failure(&first) else {
+        return first;
+    };
+    let Some(effort) = reasoning::recovery_effort(
+        &error,
+        model.reasoning_effort().as_deref(),
+        model.default_reasoning_effort().as_deref(),
+    ) else {
+        return first;
+    };
+
+    if let Err(err) = model.select_reasoning_effort(&effort).await {
+        tracing::warn!("could not apply reasoning effort {effort} after {error}: {err:#}");
+        return first;
+    }
+    let _ = notices.send(TurnEvent::Lines(vec![ChatLine {
+        author: Author::System,
+        text: format!(
+            "{} requires reasoning; reasoning effort set to {effort} and the turn retried.",
+            model.model_id()
+        ),
+    }]));
+
+    let mut retry = input;
+    reasoning::apply_reasoning_effort(&mut retry, &effort);
+    run(retry).await
+}
+
+/// The provider-facing error of a finished turn, whether it failed by `Err` or
+/// by an unsuccessful [`everruns_host::TurnResult`]. `None` for a turn that
+/// succeeded.
+fn turn_failure(result: &Result<everruns_host::TurnResult>) -> Option<String> {
+    match result {
+        Err(error) => Some(format!("{error:#}")),
+        Ok(turn) if !turn.success => turn.error.clone(),
+        Ok(_) => None,
+    }
+}
+
 async fn catch_up_events(
     handles: &RuntimeHandles,
     session_id: SessionId,
@@ -639,6 +718,99 @@ mod tests {
                 .expect("messages")
                 .is_empty(),
             "the rejected ask must remain resumable instead of entering history"
+        );
+    }
+
+    /// The reported failure, end to end at the turn seam: OpenRouter rejects a
+    /// muse turn that carries no reasoning
+    /// ("Reasoning is mandatory for this endpoint and cannot be disabled"), and
+    /// the host repairs it instead of handing the user a dead turn.
+    #[tokio::test]
+    async fn mandatory_reasoning_rejection_is_retried_with_an_effort() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(crate::config::SettingsStore::open(
+            sessions.path().join("settings.toml"),
+        ));
+        settings
+            .set_token("openrouter".to_string(), "test-key".to_string())
+            .expect("store an openrouter token");
+        let built = crate::runtime::build_with_options(
+            workspace.path().to_path_buf(),
+            crate::runtime::ProviderChoice::OpenRouter {
+                model: "meta/muse-spark-1.3-contributor".to_string(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                // The state the report was filed from: a model the profile
+                // registry has never seen, with no effort selected.
+                reasoning_effort: None,
+            },
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            crate::runtime::BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let model = built.model;
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<Option<String>>::new()));
+        let recorded = seen.clone();
+        let run = move |input: InputMessage| {
+            let recorded = recorded.clone();
+            async move {
+                let effort = input
+                    .controls
+                    .as_ref()
+                    .and_then(|controls| controls.reasoning.as_ref())
+                    .and_then(|reasoning| reasoning.effort)
+                    .map(|effort| effort.as_str().to_string());
+                recorded.lock().expect("recorded").push(effort.clone());
+                Ok(everruns_host::TurnResult {
+                    response: String::new(),
+                    iterations: 1,
+                    tool_calls_count: 0,
+                    success: effort.is_some(),
+                    error: effort.is_none().then(|| {
+                        "LLM error: provider 'openrouter': OpenAI Responses API error \
+                         (400 Bad Request): {\"error\":{\"message\":\"Reasoning is mandatory for \
+                         this endpoint and cannot be disabled.\",\"code\":400}}"
+                            .to_string()
+                    }),
+                    stop_reason: if effort.is_some() {
+                        everruns_core::turn::TurnStopReason::EndTurn
+                    } else {
+                        everruns_core::turn::TurnStopReason::Error
+                    },
+                    turn_id: everruns_provider::typed_id::TurnId::new(),
+                })
+            }
+        };
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let result = run_with_reasoning_recovery(&model, model.input_message("hello"), &tx, run)
+            .await
+            .expect("the retried turn");
+
+        assert!(result.success, "the retry must be the turn the user gets");
+        assert_eq!(
+            *seen.lock().expect("recorded"),
+            vec![None, Some("medium".to_string())],
+            "the first turn is the one the user asked for; only the retry adds reasoning"
+        );
+        assert_eq!(
+            model.reasoning_effort().as_deref(),
+            Some("medium"),
+            "the effort sticks, so the next turn is legal too"
+        );
+        let mut lines = Vec::new();
+        while let Ok(TurnEvent::Lines(batch)) = rx.try_recv() {
+            lines.extend(batch.into_iter().map(|line| line.text));
+        }
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("requires reasoning") && line.contains("medium")),
+            "the user is told what changed: {lines:?}"
         );
     }
 


### PR DESCRIPTION
## What changed

A model the curated profile registry has never seen no longer loses the reasoning control.

- **The effort scale is merged.** `/effort` options, and the scale an explicit effort is validated against, resolve through the curated registry, then what the provider advertised at discovery (OpenRouter's `supported_parameters`, cached per process by the paths that already list models), then yolop's own list of reasoning-required families. Each layer fills only what the one above left empty.
- **Offering a level is not choosing one.** Only the registry and the required families supply an effort yolop sends unasked. A gateway saying a model *accepts* efforts does not make yolop pick one, so models whose own default is fine keep behaving as they did.
- **A mandated-reasoning rejection repairs itself once.** The model's default effort is selected, the user is told, and the same input is sent again; the effort sticks, so later turns are legal too. A turn that already named an effort is not retried, it surfaces with a hint naming the control that fixes it. The repair lives in the shared turn entry point, so the TUI, `--print` and ACP all get it (ACP also refreshes the client's effort selector).
- The repaired attempt's apology is no longer shown as the turn's answer.

## Why

`openrouter/meta/muse-spark-1.3-contributor` is in no profile registry. `/effort` answered "current model profile does not expose reasoning efforts", and every turn went out with no reasoning control, which the endpoint rejects:

```
Reasoning is mandatory for this endpoint and cannot be disabled.
```

Confirmed against the live endpoint, the rejection is narrower than its message: a request with no `reasoning` field is accepted, and so is one naming an effort. What it refuses is reasoning it reads as switched off, which is `effort: "none"` and, here, the bare `reasoning.exclude: true` the OpenRouter driver always sends to keep provider reasoning private. Naming an effort is the fix available to yolop, and `none` is never offered for such a surface.

| request to `meta/muse-spark-1.3-contributor` | result |
|---|---|
| `reasoning: {exclude: true}`, no effort (what yolop sent) | **400**, the message above |
| `reasoning: {exclude: true, effort: "medium"}` | 200 |
| no `reasoning` field | 200 |
| `reasoning: {effort: "none"}` | 400 |

## Before / After

Before, with the family entry removed to reproduce the pre-fix state:

```
$ yolop --provider openrouter -m meta/muse-spark-1.3-contributor -p "Reply with exactly: pong"
turn error: LLM error: provider 'openrouter': OpenAI Responses API error (400 Bad Request):
{"error":{"message":"Reasoning is mandatory for this endpoint and cannot be disabled.","code":400,...}}
I encountered an error while processing your request. Please try again later.
```

After, same pre-fix state, showing the repair:

```
meta/muse-spark-1.3-contributor requires reasoning; reasoning effort set to medium and the turn retried.
pong
```

After, on this branch as shipped (the first turn already carries `medium`, no retry needed):

```
$ yolop --provider openrouter -m meta/muse-spark-1.3-contributor -p "Reply with exactly: pong"
pong
```

The scale the `/effort` overlay reads is now known:

```
$ yolop --provider openrouter -m meta/muse-spark-1.3-contributor --reasoning-effort turbo -p "hi"
yolop: model override ignored: model openrouter/meta/muse-spark-1.3-contributor
supports reasoning efforts: low, medium, high
```

Unrelated failures are untouched: a live run that hit an upstream 429 on `nvidia/nemotron-3-super-120b-a12b` surfaced as before, with no hint and no retry.

## Risk

- Low / Medium
- The auto-applied effort is deliberately narrow (registry defaults, unchanged, plus muse-on-OpenRouter), so no model starts sending a level it did not send before. `meta` direct keeps upstream's model-determined default.
- The retry costs one extra request on a turn that had already failed, and is capped at one per turn.
- The discovered-profile cache is process-wide and in memory, bounded by the provider's catalog size (~500 entries for OpenRouter), keyed by driver + model id.
- Error matching is on provider prose. It is scoped by requiring "reasoning" plus a mandate word, and a false positive costs one retry with a valid effort, never a loop.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Tests: the family/driver scoping, error recognition, recovery choice and message patching (unit); muse resolving to a low/medium/high scale and carrying `medium` on the wire; discovery filling a scale without choosing one, and the registry keeping models it describes; the retry itself at the turn seam, driven by the real 400 body, asserting the second attempt carries `medium` and the effort persists; the failure transcript on the presentation model (`ChatLine`), and where a retried turn's answer starts.

Smoke: live OpenRouter runs above (pre-fix reproduction, repair, shipped behavior, control model `qwen/qwen3.7-max`), plus `--provider llmsim`. `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo test --workspace --features yolop-yep/schema` (1349 + 73 passing), and `scripts/validate_okf.py knowledge --check-links` are green on the rebased base (everruns 0.20).

## Knowledge

Added [`knowledge/specs/reasoning-effort.md`](knowledge/specs/reasoning-effort.md) (merge order, why offering a level is not choosing one, the one-shot repair and where it lives), listed in `knowledge/index.md`, with a `knowledge/log.md` entry including the wire-level finding.

## Security

Reviewed against the concentrated categories.

- **TM-FS** — no filesystem surface changed. The discovered-profile cache is in memory; the only persistence is the existing model-spec write already used by `/effort`.
- **TM-BASH** — untouched.
- **TM-LLM** — prompt construction gains one field, `controls.reasoning.effort`, on the retry and on models whose endpoint mandates it. No key handling changed, nothing new is logged, and provider error text is matched but never persisted anywhere it was not already shown. The retry is bounded to one per turn with no recursion, so a hostile or malformed provider error cannot drive a loop.
- **TM-TOOL** — no new capabilities registered.
- **TM-DEP** — no new dependencies.

## Follow-ups

- The reasoning-required family list is yolop-side data (`muse-spark` on `openrouter`). It is the right home while the curated registry lags, but the durable fix is upstream carrying an effort config for these models; the layering means this entry becomes inert rather than wrong once it does.
- `meta/muse-glimmer-*` also advertises reasoning on OpenRouter and was not tested for the same mandate; it is covered by the discovered-metadata layer and, if its endpoint mandates reasoning, by the one-shot repair.
- ACP streams the failed attempt's text before the retry, since chunks already sent cannot be retracted; the notice explains what happened. Print and the TUI drop it.

https://claude.ai/code/session_01GJ14Z3ocwnDWRzk8gzsiWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ14Z3ocwnDWRzk8gzsiWY)_