### PR TITLE
chore(release): prepare v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,47 @@
 # Changelog
 
+All notable user-visible changes to yolop are recorded here.
+
+The format follows the [release spec](./knowledge/specs/release.md): one section per
+released version, newest first, with a `### Highlights` summary, an optional
+`### Breaking Changes` block (required for MINOR/MAJOR with breakage), and a
+mechanical `### What's Changed` list of merged PRs.
+
+Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
+tags the version and publishes to crates.io and the Homebrew tap.
+
+## [0.17.3] - 2026-09-10
+
+### Highlights
+
+- Fullscreen turns compact their activity by default. `--no-compact-work` keeps the expanded narration and tool rows for anyone who prefers the old projection.
+- `yolop mcp` is a complete configuration surface: `mcp show <name>` inspects global, workspace, or effective scope, and `disable` is its own command instead of `enable --disable`.
+- Fresh `cargo install yolop` works again. Every `everruns-*` requirement is pinned exactly, so a from-scratch resolve picks the set that was actually built and reviewed, and that set is now the everruns 0.20 facade release.
+- Reasoning effort resolves from every source that knows about it, curated registry, then provider-advertised parameters, then the reasoning-required families, so a model the registry has never seen keeps its `/effort` control and repairs a mandated-reasoning rejection once on its own.
+- The runtime stops doing work twice: a background task the foreground turn already reported no longer wakes a duplicate turn, and the environment context reports the shell's real network access instead of a stale no-network claim.
+- `web_fetch` reaches public URLs again, and MCP restart/reconnect/reload land on the typed `mcp reload` command.
+
+### What's Changed
+
+* fix(runtime): resolve reasoning effort from every source that knows ([#671](https://github.com/everruns/yolop/pull/671)) by @chaliy
+* chore(deps): adopt the everruns 0.20 facade release ([#670](https://github.com/everruns/yolop/pull/670)) by @chaliy
+* fix(deps): pin the everruns family to exact versions ([#666](https://github.com/everruns/yolop/pull/666)) by @chaliy
+* fix(runtime): align execution guidance ([#664](https://github.com/everruns/yolop/pull/664)) by @chaliy
+* test(evals): add native agent comparison ([#663](https://github.com/everruns/yolop/pull/663)) by @chaliy
+* fix(runtime): dedupe background completion wakes ([#662](https://github.com/everruns/yolop/pull/662)) by @chaliy
+* feat(mcp): complete configuration CLI ([#661](https://github.com/everruns/yolop/pull/661)) by @chaliy
+* chore(deps): bump jsonschema from 0.51.0 to 0.52.1 ([#660](https://github.com/everruns/yolop/pull/660)) by @dependabot
+* chore(deps): bump the cargo-minor-and-patch group with 2 updates ([#659](https://github.com/everruns/yolop/pull/659)) by @dependabot
+* feat(tui): enable compact work by default ([#658](https://github.com/everruns/yolop/pull/658)) by @chaliy
+* fix(tui): remove agent status tool ([#657](https://github.com/everruns/yolop/pull/657)) by @chaliy
+* fix: restore web fetch and direct MCP reload ([#656](https://github.com/everruns/yolop/pull/656)) by @chaliy
+* fix(config): reduce repeated model help probes ([#655](https://github.com/everruns/yolop/pull/655)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.17.2...v0.17.3
+
 ## [0.17.2] - 2026-08-31
+
+### What's Changed
 
 * feat(config): unify configuration commands ([#639](https://github.com/everruns/yolop/pull/639)) by @chaliy
 * feat(worktree): make auto initialization model-driven ([#640](https://github.com/everruns/yolop/pull/640)) by @chaliy
@@ -16,15 +57,7 @@
 * feat(cli): manage hooks and skills with commands ([#650](https://github.com/everruns/yolop/pull/650)) by @chaliy
 * feat(cli): add realistic help examples ([#651](https://github.com/everruns/yolop/pull/651)) by @chaliy
 
-All notable user-visible changes to yolop are recorded here.
-
-The format follows the [release spec](./knowledge/specs/release.md): one section per
-released version, newest first, with a `### Highlights` summary, an optional
-`### Breaking Changes` block (required for MINOR/MAJOR with breakage), and a
-mechanical `### What's Changed` list of merged PRs.
-
-Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
-tags the version and publishes to crates.io and the Homebrew tap.
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.17.1...v0.17.2
 
 ## [0.17.1] - 2026-08-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9985,7 +9985,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.17.2"
+version = "0.17.3"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts v0.17.3, a PATCH release over v0.17.2 carrying 13 merged PRs.

- `CHANGELOG.md` gains the `[0.17.3]` section with `### Highlights` and the mechanical `### What's Changed` list.
- `Cargo.toml` and `Cargo.lock` move to `0.17.3`.
- Repairs the `[0.17.2]` section, which the previous cut inserted *above* the file preamble and left without a `### What's Changed` heading or a `**Full Changelog**` line. It now sits below the preamble in the documented shape, with its PR list unchanged.

No crate other than `yolop` is bumped: nothing under `crates/` or `extensions/` changed since v0.17.2, so `yolop-yep` stays at 0.4.0 and `yolop-extension-logfire` at 0.2.0. Both are already live on crates.io, so `publish.yml` skips them.

### Release contents

| Highlight | PRs |
|---|---|
| Fullscreen turns compact activity by default; `--no-compact-work` keeps the expanded projection | [#658](https://github.com/everruns/yolop/pull/658) |
| `yolop mcp` completes its configuration surface: `mcp show <name>` by scope, `disable` as its own command | [#661](https://github.com/everruns/yolop/pull/661) |
| Fresh `cargo install yolop` works again: every `everruns-*` requirement pinned exactly, then moved as one set to the everruns 0.20 facade | [#666](https://github.com/everruns/yolop/pull/666), [#670](https://github.com/everruns/yolop/pull/670) |
| Reasoning effort resolves from registry, then provider-advertised parameters, then reasoning-required families; a mandated-reasoning rejection repairs itself once | [#671](https://github.com/everruns/yolop/pull/671) |
| Runtime stops duplicating work: no second turn for a background task the foreground already reported; environment context reports the shell's real network access | [#662](https://github.com/everruns/yolop/pull/662), [#664](https://github.com/everruns/yolop/pull/664) |
| `web_fetch` reaches public URLs again; MCP restart/reconnect/reload land on the typed `mcp reload` command | [#656](https://github.com/everruns/yolop/pull/656) |
| Model help probes reduced; the agent status tool removed; native-agent eval comparison added | [#655](https://github.com/everruns/yolop/pull/655), [#657](https://github.com/everruns/yolop/pull/657), [#663](https://github.com/everruns/yolop/pull/663) |
| Dependency bumps | [#659](https://github.com/everruns/yolop/pull/659), [#660](https://github.com/everruns/yolop/pull/660) |

`feat(tui): enable compact work by default` ([#658](https://github.com/everruns/yolop/pull/658)) flips a default rather than removing a capability: `--no-compact-work` restores the previous projection. Called out in Highlights rather than under `### Breaking Changes`, which the spec requires for MINOR/MAJOR only.

## Why

Thirteen PRs have merged since v0.17.2 on 2026-08-31, including two fixes that users cannot get any other way: fresh `cargo install yolop` is broken on the published 0.17.2 until the exact `everruns-*` pins ship, and `web_fetch` is dead on that release.

## Before / After

Packaging change only; no yolop behavior changes in this diff. The released behavior is what the 13 listed PRs already merged.

```
Before:  crates.io serves yolop 0.17.2   Cargo.toml 0.17.2   Cargo.lock 0.17.2
After:   crates.io serves yolop 0.17.3   Cargo.toml 0.17.3   Cargo.lock 0.17.3
```

## Publish-readiness

Run on this branch's commit against a clean working tree.

| Check | Result |
|---|---|
| `cargo publish --dry-run -p yolop-yep` | Pass. Packages and compiles; `0.4.0` already on the index, so `publish.yml` skips it. |
| `cargo publish --dry-run -p yolop` | Pass. Resolved `yolop-yep 0.4.0` from crates.io and compiled the packaged crate, so the publish path is proven locally rather than deferred to CI. |
| `cargo search yolop --limit 1` | `yolop = "0.17.2"` — less than `0.17.3`. |
| `cargo search yolop-yep` | `0.4.0`, matches in-tree. |
| `cargo search yolop-extension-` | `yolop-extension-logfire = "0.2.0"`, matches in-tree. |
| `Cargo.toml` / `Cargo.lock` agree | Both read `0.17.3`. |
| `python3 scripts/publish_order.py` | `yolop-yep`, `yolop-extension-logfire`, `yolop` — first two already live, so only `yolop` publishes. |
| Changed crates bumped | `git log v0.17.2..HEAD -- extensions/ crates/` is empty; no other crate needs a bump, and no `plugin.json` drifts. |

## Local checks

```
cargo fmt --check                                                        clean
cargo clippy --workspace --all-targets --features yolop-yep/schema       clean, -D warnings
cargo test --workspace --features yolop-yep/schema                       1349 + 73 + 35 passed, 0 failed
python3 scripts/validate_okf.py knowledge --check-links                  44 concepts, 0 errors
cargo run -- --provider llmsim -p '...'                                  offline smoke passes
```

## Terminal verification

- **Tier 1** — green on the release base `f81e8a4` via CI [run 1661](https://github.com/everruns/yolop/actions/runs/34433011208): `tests/tuika_pty.rs` and the gated tmux gallery capture both pass.
- **Tier 3** — not walked. This diff touches no renderer code; the TUI change being released ([#658](https://github.com/everruns/yolop/pull/658)) is a projection default, not a paint change, and its PTY coverage is in Tier 1.

## Risk

- Low
- The publish path is proven for both crates, including `yolop` itself, so the usual "validated only by CI" gap does not apply here.
- What can still break is downstream of the merge: `cli-binaries.yml` builds three CLI targets plus the accelerated `metal`/`cuda` builds, and pushes the tap formula. `scripts/check_release_matrix.py` guards the quiet-matrix failure mode that shipped Linux-only extension servers in v0.17.0. The `cuda` leg is deliberately outside the formula job's `needs`, so a failure there cannot hold back the tap.

## Post-merge verification

Unchecked; I will work these after the squash and report.

- [ ] `release.yml` succeeds and creates tag `v0.17.3` with the changelog section as release notes
- [ ] `publish.yml` succeeds
- [ ] `cli-binaries.yml` succeeds, including `build-accelerated`
- [ ] crates.io serves `yolop 0.17.3`
- [ ] GitHub Release `v0.17.3` carries the three `yolop-<target>.tar.gz` tarballs, the two accelerated tarballs, and their `.sha256` files
- [ ] `Formula/yolop.rb` in `everruns/homebrew-tap` points at `download/v0.17.3`

No extension release tag is expected this cut: `yolop-extension-logfire` is unchanged at 0.2.0 and `yolop-extension-logfire-v0.2.0` already exists.

## Checklist

- [x] Tests added or updated — none needed; packaging-only diff, and the release contents ship their own tests
- [x] Backward compatibility considered — pre-1.0 PATCH, no API or CLI surface changes in this diff
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — each of the 13 PRs updated the concepts it touched (`background.md`, `maintenance.md`, `presentation.md`, `reasoning-effort.md`, `sandboxing.md`, `system-prompt.md`, plus `index.md` and `log.md`), and cutting a release changes no durable behavior, intent, architecture, policy, or process. `validate_okf.py --check-links` is clean.

## Security

No security-relevant code changed. The diff is a version string, a lockfile entry, and changelog prose; it registers no capability, touches no filesystem, shell, or LLM path, and adds no dependency. The release's own secret surface is unchanged: `CARGO_REGISTRY_TOKEN` for `publish.yml` and `DOPPLER_TOKEN` for `cli-binaries.yml`, with the tap PAT still scoped to `everruns/homebrew-tap` only.

## Follow-ups

- The v0.17.2 changelog section landed above the file preamble and without its headings, and nothing caught it for ten days. Worth a `scripts/` check that asserts the newest `## [X.Y.Z]` sits below the preamble and carries `### What's Changed` and a `**Full Changelog**` line, so the next cut cannot repeat it.

Do not enable auto-merge — a human clicks squash so a reviewer reads the changelog.

https://claude.ai/code/session_0195yuiAXYZQC28A1ZRnrFS2