### PR TITLE
fix(runtime): judge a repaired turn by the effort it sent

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-09-10, A repaired turn is judged by what it sent
+
+- [Reasoning effort](specs/reasoning-effort.md): the mandated-reasoning repair
+  keys off the effort the rejected *request* carried, not the effort the model
+  names, and retries with the level the model already chose.
+- A mid-turn `set_model` onto an endpoint that mandates reasoning is exactly the
+  case the two differ: turn controls are captured at turn start and cannot be
+  revised mid-turn (EVE-595), so the request goes out with no effort while the
+  model already names one. Reading the model made the repair decline on the one
+  failure it was built for.
+- All four levels (`minimal`, `low`, `medium`, `high`) are accepted by
+  OpenRouter's muse endpoint, so the rejection was never about the level.
+
 ## 2026-09-10, Reasoning effort is merged from every source that knows
 
 - [Reasoning effort](specs/reasoning-effort.md): the effort scale resolves

--- a/knowledge/specs/reasoning-effort.md
+++ b/knowledge/specs/reasoning-effort.md
@@ -89,10 +89,19 @@ The repair belongs to the turn, not to one surface: the TUI, `--print`, and ACP
 all start turns through the same entry point and all get it, ACP also refreshing
 the client's effort selector to the level now in force.
 
-Exactly one retry, and only for a turn that named no effort. A rejection of a
-turn that *did* name a level is a choice only the user can make, so it surfaces
-with the failure and a hint naming the control that fixes it (`/effort`, or
-`/model` to switch models). Every other provider failure is untouched.
+Exactly one retry, and only for a request that named no effort. What counts is
+what the *request* carried, not what the model names. A turn's controls are
+captured when it starts and a mid-turn `set_model` cannot revise them (see
+[`conversational-control.md`](./conversational-control.md), EVE-595), so
+switching onto an endpoint that mandates reasoning fails with no effort on the
+wire while the model already names one. Keying off the request repairs that
+turn, and the retry honors the level the model already names rather than
+overwriting it with a default.
+
+A rejection of a request that *did* name a level is a choice only the user can
+make, so it surfaces with the failure and a hint naming the control that fixes
+it (`/effort`, or `/model` to switch models). Every other provider failure is
+untouched.
 
 ## Ownership boundary
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2317,22 +2317,37 @@ where
     let Some(error) = turn_failure(&first) else {
         return first;
     };
+    // What the model names comes first: on a mid-turn `set_model` the level is
+    // already chosen and only the in-flight request missed it, so the retry
+    // honors that choice instead of overwriting it with a profile default.
+    let chosen = model.reasoning_effort();
     let Some(effort) = reasoning::recovery_effort(
         &error,
-        model.reasoning_effort().as_deref(),
-        model.default_reasoning_effort().as_deref(),
+        reasoning::sent_reasoning_effort(&input),
+        chosen
+            .as_deref()
+            .or(model.default_reasoning_effort().as_deref()),
     ) else {
         return first;
     };
 
-    if let Err(err) = model.select_reasoning_effort(&effort).await {
-        tracing::warn!("could not apply reasoning effort {effort} after {error}: {err:#}");
-        return first;
+    // Only a model with no level of its own is given one; the rest of the time
+    // this is the model's own setting reaching a request that predated it.
+    if chosen.is_none() {
+        if let Err(err) = model.select_reasoning_effort(&effort).await {
+            tracing::warn!("could not apply reasoning effort {effort} after {error}: {err:#}");
+            return first;
+        }
+        notice(format!(
+            "{} requires reasoning; reasoning effort set to {effort} and the turn retried.",
+            model.model_id()
+        ));
+    } else {
+        notice(format!(
+            "{} requires reasoning; the turn was retried with reasoning effort {effort}.",
+            model.model_id()
+        ));
     }
-    notice(format!(
-        "{} requires reasoning; reasoning effort set to {effort} and the turn retried.",
-        model.model_id()
-    ));
 
     let mut retry = input;
     reasoning::apply_reasoning_effort(&mut retry, &effort);
@@ -8781,6 +8796,93 @@ mod tests {
         // Nothing to anchor on degrades to that same mark rather than hiding
         // the turn's output.
         assert_eq!(agent_output_start(&[], 7, true), 7);
+    }
+
+    /// A model switched *mid-turn* lands on an endpoint that mandates
+    /// reasoning while the in-flight turn's controls were captured before the
+    /// switch (mid-turn effort changes are EVE-595). The model state names an
+    /// effort, the request that failed did not, and the repair keys off the
+    /// request.
+    #[tokio::test]
+    async fn a_turn_sent_before_the_model_gained_an_effort_is_retried_with_it() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(crate::config::SettingsStore::open(
+            sessions.path().join("settings.toml"),
+        ));
+        settings
+            .set_token("openrouter".to_string(), "test-key".to_string())
+            .expect("store an openrouter token");
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::OpenRouter {
+                model: "meta/muse-spark-1.3-contributor".to_string(),
+                base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+                // What `set_model` left behind mid-turn: the level is on the
+                // model, but the turn already in flight never carried it.
+                reasoning_effort: Some("low".to_string()),
+            },
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let model = built.model;
+
+        let seen = Arc::new(StdMutex::new(Vec::<Option<String>>::new()));
+        let recorded = seen.clone();
+        let run = move |input: InputMessage| {
+            let recorded = recorded.clone();
+            async move {
+                let effort = input
+                    .controls
+                    .as_ref()
+                    .and_then(|controls| controls.reasoning.as_ref())
+                    .and_then(|reasoning| reasoning.effort)
+                    .map(|effort| effort.as_str().to_string());
+                recorded.lock().expect("recorded").push(effort.clone());
+                Ok(everruns_host::TurnResult {
+                    response: String::new(),
+                    iterations: 1,
+                    tool_calls_count: 1,
+                    success: effort.is_some(),
+                    error: effort.is_none().then(|| {
+                        "LLM error: provider 'openrouter': OpenAI Responses API error \
+                         (400 Bad Request): {\"error\":{\"message\":\"Reasoning is mandatory for \
+                         this endpoint and cannot be disabled.\",\"code\":400}}"
+                            .to_string()
+                    }),
+                    stop_reason: if effort.is_some() {
+                        everruns_core::turn::TurnStopReason::EndTurn
+                    } else {
+                        everruns_core::turn::TurnStopReason::Error
+                    },
+                    turn_id: everruns_provider::typed_id::TurnId::new(),
+                })
+            }
+        };
+
+        // The turn as the runtime captured it before the switch: no controls.
+        let stale = InputMessage {
+            role: MessageRole::User,
+            content: vec![ContentPart::text("switch model to muse")],
+            controls: None,
+            metadata: None,
+            tags: vec![],
+        };
+        let notice = |_: String| {};
+        let result = run_with_reasoning_recovery(&model, stale, &notice, run)
+            .await
+            .expect("the retried turn");
+
+        assert!(result.success);
+        assert_eq!(
+            *seen.lock().expect("recorded"),
+            vec![None, Some("low".to_string())],
+            "the retry carries the level the model already names, not a fresh guess"
+        );
     }
 
     /// The reported failure, end to end at the turn seam: OpenRouter rejects a

--- a/src/runtime/reasoning.rs
+++ b/src/runtime/reasoning.rs
@@ -114,22 +114,36 @@ pub(crate) fn is_reasoning_required_error(message: &str) -> bool {
 /// The effort to retry a mandatory-reasoning failure with, or `None` when the
 /// failure is not one this can fix.
 ///
-/// A turn that already carried an effort is not retried: the endpoint rejected
-/// a request that named a level, so sending another one only spends a second
-/// turn on the same error. The user is pointed at the picker instead.
+/// `sent_effort` is what the *rejected request* carried, which is not always
+/// what the model names. A turn's controls are captured when it starts and a
+/// mid-turn `set_model` cannot revise them (EVE-595), so a switch onto an
+/// endpoint that mandates reasoning fails with no effort on the wire while the
+/// model already names one. Keying off the request repairs that turn; keying
+/// off the model would decline, seeing a level the provider never received.
+///
+/// A request that did carry an effort is not retried: the endpoint rejected a
+/// level it was given, so sending another spends a second turn on the same
+/// error. The user is pointed at the picker instead.
 pub(crate) fn recovery_effort(
     error: &str,
-    current_effort: Option<&str>,
-    profile_default: Option<&str>,
+    sent_effort: Option<&str>,
+    preferred: Option<&str>,
 ) -> Option<String> {
-    if current_effort.is_some() || !is_reasoning_required_error(error) {
+    if sent_effort.is_some() || !is_reasoning_required_error(error) {
         return None;
     }
-    Some(
-        profile_default
-            .unwrap_or(DEFAULT_REQUIRED_EFFORT)
-            .to_string(),
-    )
+    Some(preferred.unwrap_or(DEFAULT_REQUIRED_EFFORT).to_string())
+}
+
+/// The reasoning effort a built message carries, i.e. what the provider
+/// actually received.
+pub(crate) fn sent_reasoning_effort(input: &InputMessage) -> Option<&'static str> {
+    input
+        .controls
+        .as_ref()
+        .and_then(|controls| controls.reasoning.as_ref())
+        .and_then(|reasoning| reasoning.effort)
+        .map(|effort| effort.as_str())
 }
 
 /// Set `effort` on an already-built input message, so a turn can be retried
@@ -148,7 +162,8 @@ pub(crate) fn apply_reasoning_effort(input: &mut InputMessage, effort: &str) {
 }
 
 /// What to tell the user when a mandatory-reasoning failure cannot be repaired
-/// automatically, i.e. the turn already named an effort the endpoint rejected.
+/// automatically, i.e. the request already named an effort the endpoint
+/// rejected.
 pub(crate) fn reasoning_error_hint(error: &str, current_effort: Option<&str>) -> Option<String> {
     if !is_reasoning_required_error(error) {
         return None;
@@ -239,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn a_turn_that_already_named_an_effort_is_not_retried() {
+    fn a_request_that_already_named_an_effort_is_not_retried() {
         let error = "Reasoning is mandatory for this endpoint and cannot be disabled.";
         assert_eq!(recovery_effort(error, Some("low"), Some("medium")), None);
         let hint = reasoning_error_hint(error, Some("low")).expect("rejected effort earns a hint");
@@ -247,6 +262,36 @@ mod tests {
             hint.contains("/effort"),
             "hint should point at the picker: {hint}"
         );
+    }
+
+    /// The gate is what the provider received, not what the model names: a
+    /// turn sent before a mid-turn `set_model` carries no effort even though
+    /// the model now has one, and that turn is exactly the one to repair.
+    #[test]
+    fn a_request_sent_without_an_effort_is_retried_with_the_level_the_model_names() {
+        let error = "Reasoning is mandatory for this endpoint and cannot be disabled.";
+
+        assert_eq!(
+            recovery_effort(error, None, Some("low")).as_deref(),
+            Some("low")
+        );
+    }
+
+    #[test]
+    fn the_effort_a_message_carries_is_readable() {
+        use everruns_core::{ContentPart, MessageRole};
+
+        let mut input = InputMessage {
+            role: MessageRole::User,
+            content: vec![ContentPart::text("hello")],
+            controls: None,
+            metadata: None,
+            tags: vec![],
+        };
+        assert_eq!(sent_reasoning_effort(&input), None);
+
+        apply_reasoning_effort(&mut input, "high");
+        assert_eq!(sent_reasoning_effort(&input), Some("high"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

The mandated-reasoning repair now keys off the effort the **rejected request** carried, not the effort the model currently names, and retries with the level the model already chose. It selects a level only when the model has none, so an existing choice is honored rather than overwritten.

## Why

#671 shipped the repair but gated it on `ModelState::reasoning_effort()`. A mid-turn `set_model` is where that reading is wrong: a turn's controls are captured when the turn starts and cannot be revised mid-turn (EVE-595, see `knowledge/specs/conversational-control.md`). Switching onto an endpoint that mandates reasoning therefore sends a request with **no effort on the wire** while the model already names one. The repair read the model, saw `low`, concluded "the provider rejected a level the user chose", and declined — on the one failure it exists for.

Reported from a live session:

```
you › swith model to muse via openrouter
you › muse 1.3 contributor
    ✓ Set model: meta/muse-spark-1.3-contributor
    system  turn error: LLM error: provider 'openrouter': OpenAI Responses API error (400 Bad Request):
    {"error":{"message":"Reasoning is mandatory for this endpoint and cannot be disabled.","code":400,...}}
    system  this endpoint rejected reasoning effort `low`; run /effort to pick another level, or /model to switch models
agent › I encountered an error while processing your request. Please try again later.
```

That hint was also misleading: the endpoint never saw `low`. Checked against the live endpoint, every level is accepted, so the rejection was never about which one:

| `reasoning` on `meta/muse-spark-1.3-contributor` | result |
|---|---|
| `{exclude: true, effort: "minimal" \| "low" \| "medium" \| "high"}` | 200 |
| `{exclude: true}` (no effort — what the in-flight turn sent) | **400** mandatory-reasoning |

## Before / After

Before: the transcript above — a dead turn after a model switch.

After, the same flow driven live through the binary:

```
$ yolop --provider openrouter -m qwen/qwen3.7-max \
    -p "Switch the model to openrouter meta/muse-spark-1.3-contributor with reasoning effort low, then reply with exactly: pong"
meta/muse-spark-1.3-contributor requires reasoning; the turn was retried with reasoning effort low.
pong
```

The notice also distinguishes the two cases now: "reasoning effort set to X" when yolop chose the level, "the turn was retried with reasoning effort X" when it used the level the model already named.

## Risk

- Low
- The gate only widens where a request carried no effort, which is precisely the repairable case; a request that named a level still surfaces with its hint, unchanged.
- One extra request on a turn that had already failed, still capped at one retry.
- A model that already names an effort is no longer written to during recovery, so the repair stops touching persisted settings in that path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Tests: a turn-seam test reproducing the mid-turn switch (model names `low`, the in-flight request carries nothing, the endpoint returns the real 400 body) asserting the retry carries `low`; unit tests for the request-keyed gate and for reading the effort off a built message. Written failing first, per `AGENTS.md`. Full `cargo test --workspace --features yolop-yep/schema` (1352 + 73), `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo fmt --check`, and `scripts/validate_okf.py knowledge --check-links` are green.

Smoke: the live OpenRouter run above, plus the four-level probe in the table.

## Knowledge

Updated [`knowledge/specs/reasoning-effort.md`](knowledge/specs/reasoning-effort.md) — the repair is keyed to the request, and the mid-turn switch is named as the case where request and model disagree — with a `knowledge/log.md` entry.

## Security

- **TM-LLM** — the only affected surface. The change reads `controls.reasoning.effort` off a message yolop built and narrows when a setting is persisted; no key handling, logging, or prompt content changes. The retry stays bounded to one per turn with no recursion.
- **TM-FS**, **TM-BASH**, **TM-TOOL**, **TM-DEP** — untouched; no new dependencies or capabilities.

## Follow-ups

- The underlying limitation is upstream: a mid-turn `set_model` cannot revise the in-flight turn's controls (EVE-595). This repairs the failure it causes on mandated-reasoning endpoints; other mid-turn control drift is unaffected.
- The same session showed `set_model` rejected once for "an argument has the wrong JSON type" before succeeding. The agent recovered on its own and it is unrelated to this failure, so it is not addressed here.

https://claude.ai/code/session_01GJ14Z3ocwnDWRzk8gzsiWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ14Z3ocwnDWRzk8gzsiWY)_