### PR TITLE
fix(tui): support mouse clicks in setup option pickers

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2069,9 +2069,13 @@ impl App {
                     self.handle_key(key).await;
                 }
                 CrosstermEvent::Mouse(mouse) => {
+                    let area = terminal.get_frame().area();
                     if self.render_mode.is_fullscreen() {
                         if let Some(shape) = self.update_link_pointer(mouse) {
                             let _ = pointer::write(&mut std::io::stdout(), shape);
+                        }
+                        if self.setup.is_some() && self.handle_setup_mouse(mouse, area).await {
+                            continue;
                         }
                         if self.handle_fullscreen_scroll(mouse.kind) {
                             continue;
@@ -2080,7 +2084,6 @@ impl App {
                             continue;
                         }
                     }
-                    let area = terminal.get_frame().area();
                     if self.handle_mouse(mouse, area) {
                         return Ok(());
                     }
@@ -11479,6 +11482,59 @@ flowchart TD
                 .iter()
                 .any(|line| line.text == "setup complete: openai/gpt-5.4 high"),
             "effort modal should report completion: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn effort_picker_click_confirms_clicked_option() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.lines.clear();
+        app.setup = None;
+
+        app.handle_command("setup token openai sk-test").await;
+        app.run_setup_command(Some("provider openai"))
+            .await
+            .expect("set openai provider");
+        app.run_setup_command(Some("model gpt-5.4"))
+            .await
+            .expect("set openai model");
+        app.lines.clear();
+        app.dispatch_command_for_test("effort high").await;
+
+        assert!(matches!(
+            app.setup,
+            Some(SetupStep::PickEffort { selected: 3, .. })
+        ));
+        let options = app.model.reasoning_effort_options();
+        assert!(options.len() > 1);
+        let expected = options[0].value.clone();
+
+        // Click the first option row: one border line plus the header lines,
+        // mirroring the fullscreen SelectList layout.
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 120,
+            height: 36,
+        };
+        let picker = render::setup_picker(app).expect("effort picker renders");
+        let panel = render::setup_panel_rect(area);
+        let mouse = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: panel.x + 2,
+            row: panel.y + 1 + picker.header.len() as u16,
+            modifiers: KeyModifiers::empty(),
+        };
+
+        assert!(app.handle_setup_mouse(mouse, area).await);
+        assert!(app.setup.is_none());
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text == format!("setup complete: openai/gpt-5.4 {expected}")),
+            "click should confirm the clicked effort option: {:?}",
             app.lines
         );
     }

--- a/src/tui/setup.rs
+++ b/src/tui/setup.rs
@@ -800,6 +800,113 @@ impl App {
         }
     }
 
+    /// Click support for the setup overlay option lists: a left click on an
+    /// option row selects it and confirms, the same as moving to it with the
+    /// keyboard and pressing Enter. The click is fed through tuika's
+    /// [`SelectState`](tuika::components::SelectState) mouse handling against
+    /// the same list body the fullscreen renderer draws (panel border and
+    /// padding plus the picker header lines), with the scroll window derived
+    /// the same centered way the renderer derives it, so clicks map to rows
+    /// exactly as drawn, including windowed lists. Returns true when the click
+    /// was consumed; anything outside the option rows falls through so
+    /// transcript selection and status buttons keep working.
+    pub(crate) async fn handle_setup_mouse(&mut self, mouse: MouseEvent, area: Rect) -> bool {
+        if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return false;
+        }
+        let Some(picker) = setup_picker(self) else {
+            return false;
+        };
+        let len = picker.options.len();
+        if len == 0 {
+            return false;
+        }
+        // Mirror draw_setup_picker: bordered panel, one column of horizontal
+        // padding, header lines, then the option rows.
+        let panel = setup_panel_rect(area);
+        let list_top = panel
+            .y
+            .saturating_add(1)
+            .saturating_add(picker.header.len() as u16);
+        let content_bottom = panel.y.saturating_add(panel.height.saturating_sub(1));
+        let list_height = picker
+            .viewport
+            .unwrap_or(len as u16)
+            .min(content_bottom.saturating_sub(list_top));
+        if list_height == 0 {
+            return false;
+        }
+        let bounds = Rect {
+            x: panel.x.saturating_add(2),
+            y: list_top,
+            width: panel.width.saturating_sub(4),
+            height: list_height,
+        };
+        // The renderer centers the scroll window on the selection, so derive
+        // the same first visible row before hit-testing.
+        let first_visible = tuika::components::VirtualWindow::around(
+            len,
+            list_height as usize,
+            Some(picker.selected),
+        )
+        .start();
+        let Some(event) = tuika::translate_event(CrosstermEvent::Mouse(mouse)) else {
+            return false;
+        };
+        let mut state = tuika::components::SelectState::new();
+        state.select(Some(picker.selected));
+        if state.handle_mouse(&event, len, bounds, first_visible) != tuika::InputOutcome::Submitted
+        {
+            return false;
+        }
+        let index = state.selected().unwrap_or(picker.selected).min(len - 1);
+        enum Choice {
+            Provider,
+            Credential(String),
+            Model(String),
+            ListedModel,
+            Effort,
+        }
+        let choice = match &mut self.setup {
+            Some(SetupStep::Provider { selected }) => {
+                *selected = index;
+                Choice::Provider
+            }
+            Some(SetupStep::Credential {
+                provider, selected, ..
+            }) => {
+                *selected = index;
+                Choice::Credential(provider.clone())
+            }
+            Some(SetupStep::PickModel {
+                provider,
+                selected,
+                custom: None,
+                ..
+            }) => {
+                *selected = index;
+                Choice::Model(provider.clone())
+            }
+            Some(SetupStep::PickListedModel { selected, .. }) => {
+                *selected = index;
+                Choice::ListedModel
+            }
+            Some(SetupStep::PickEffort { selected, .. }) => {
+                *selected = index;
+                Choice::Effort
+            }
+            _ => return false,
+        };
+        match choice {
+            Choice::Provider => self.confirm_provider(index).await,
+            Choice::Credential(provider) => self.confirm_credential(provider, index).await,
+            Choice::Model(provider) => self.confirm_model(provider, index).await,
+            Choice::ListedModel => self.confirm_listed_model(index).await,
+            Choice::Effort => self.confirm_effort(index).await,
+        }
+        true
+    }
+
     pub(crate) async fn handle_provider_key(&mut self, key: KeyEvent, selected: usize) {
         match key.code {
             KeyCode::Esc => {


### PR DESCRIPTION
## Summary

Setup overlay pickers (provider, credential, model, effort) render through tuika's SelectList but never received mouse events: clicks fell through to transcript selection and status buttons, so the picker was keyboard-only.

Routes left clicks on option rows through tuika's SelectState mouse handling against the same list body and centered scroll window the renderer draws, and confirms the clicked option, mirroring Enter. Clicks outside the rows fall through unchanged.

## Motivation

The Select Reasoning Effort screen (and every other setup picker) ignored the mouse entirely; the user's guess was right, the missing piece was tuika's SelectState mouse handling.

## Risk

Low. Pure event routing plus the existing per-step confirm path. Wheel, drag, right-click, text-input steps, and non-setup mouse behavior are untouched; clicks outside option rows return false and fall through exactly as before. Row math uses saturating u16 arithmetic against the same SetupPicker the renderer draws.

## Testing

- New failing-first test effort_picker_click_confirms_clicked_option clicks the first effort row and asserts the clicked value is confirmed and setup completes.
- cargo fmt --check, cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings, cargo test --workspace --features yolop-yep/schema (1466 passed).
- Offline smoke: cargo run -- --provider llmsim -p hi starts and responds.

## Before / After

Before: clicking an option row did nothing (no handler consumed setup clicks).
After: clicking an option row selects and confirms it, same as keyboard plus Enter.
No screenshot attached; proof is the automated click test above driving the real handler, geometry, and async confirm path.

## Knowledge

No knowledge update required: bug fix restoring intended picker behavior, no architecture, policy, terminology, or process change.

## Security

No new filesystem, shell, prompt, key, capability, or dependency surface. Click coordinates are used only for hit-testing against the panel rect; the only action is selecting among the already-rendered options and running the same confirm path as Enter. No injection, exposure, or exhaustion vectors added.

## Follow-ups

- Wheel scrolling over windowed (viewport) setup lists is not wired: SelectState is rebuilt per frame, so a scroll offset would not persist. Clicks work regardless.
- Picker footers still read Enter confirm / arrows move with no mouse hint; copy update deferred to keep this change minimal.

Produced by [yolop](https://everruns.com/yolop)