### PR TITLE
fix(runtime): give host-built turns the model's reasoning level

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,15 @@
 # Knowledge Log
 
+## 2026-09-10, A host-built turn carries reasoning too
+
+- [Reasoning effort](specs/reasoning-effort.md): background wakes, resumed turns
+  and child-session messages are assembled by the host, not by `input_message`,
+  so they went to the provider with no reasoning controls at all. They are now
+  given the model's level before the first attempt.
+- A wake onto a mandated-reasoning endpoint therefore failed the same way a
+  first turn once did, and the child-session runner reaches the runtime without
+  the host's turn entry point, so it needed the same treatment separately.
+
 ## 2026-09-10, A repaired turn is judged by what it sent
 
 - [Reasoning effort](specs/reasoning-effort.md): the mandated-reasoning repair

--- a/knowledge/specs/reasoning-effort.md
+++ b/knowledge/specs/reasoning-effort.md
@@ -76,6 +76,19 @@ pre-turn availability check and the `/model` browser. Before any discovery call
 has run the layer is simply empty, which is why layer 3 exists: a model whose
 endpoint mandates reasoning has a scale and a default from the first turn.
 
+### Every turn carries the level, however it was built
+
+A typed turn gets its controls from `ProviderChoice::input_message`, but a
+background wake, a resumed turn and a child-session message are assembled by the
+host and carry no controls at all. They used to reach the provider with nothing
+on the wire, so a wake on an endpoint that mandates reasoning failed exactly as
+a first turn once did. Any such message is now given the model's level before it
+is sent: at the shared turn entry point for the hosts, and in the child-session
+runner, which dispatches to the runtime without passing through it.
+
+The repair below is the backstop for what that cannot reach, not the mechanism
+by which a wake gets its reasoning.
+
 ### A mandated-reasoning rejection repairs itself once
 
 When a turn fails and the provider says reasoning is mandatory, and the turn
@@ -116,8 +129,11 @@ untouched.
   `ProviderChoice::auto_reasoning_effort_for_model` owns the narrower question of
   which effort Yolop selects unasked.
 - `RuntimeHandles::run_turn_with_reasoning_recovery` owns the one-shot retry and
-  is the entry point every host starts a turn through; it is the only place that
-  changes the model behind the user's back.
+  the level given to a host-built input; it is the entry point every host starts
+  a turn through, and the only place that changes the model behind the user's
+  back.
+- `background_wake::WakeRunner` owns the same for child-session messages, which
+  reach the runtime without that entry point.
 
 ## Related
 

--- a/src/runtime/background_wake.rs
+++ b/src/runtime/background_wake.rs
@@ -29,7 +29,7 @@ use everruns_provider::{AgentLoopError, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use tokio::sync::{Mutex as AsyncMutex, mpsc};
 
 /// Sender half of a session's wake channel. The `LocalPlatformStore`'s
@@ -248,6 +248,11 @@ pub struct WakeRunner {
     sessions: Arc<dyn RuntimeSessionStore>,
     tasks: Option<Arc<dyn SessionTaskRegistry>>,
     child_turn_locks: Mutex<HashMap<SessionId, Arc<AsyncMutex<()>>>>,
+    /// The live model selection, read for its reasoning level. A child-session
+    /// message is assembled here rather than by `input_message` and does not
+    /// pass through the host's turn entry point, so this is the only place it
+    /// can learn the level an endpoint that mandates reasoning requires.
+    provider: Arc<RwLock<crate::runtime::ProviderChoice>>,
 }
 
 impl WakeRunner {
@@ -255,13 +260,25 @@ impl WakeRunner {
         runtime: Arc<OnceLock<Weak<InProcessRuntime>>>,
         sessions: Arc<dyn RuntimeSessionStore>,
         tasks: Option<Arc<dyn SessionTaskRegistry>>,
+        provider: Arc<RwLock<crate::runtime::ProviderChoice>>,
     ) -> Self {
         Self {
             runtime,
             sessions,
             tasks,
             child_turn_locks: Mutex::new(HashMap::new()),
+            provider,
         }
+    }
+
+    /// The reasoning level the session's model names, for messages this runner
+    /// builds itself.
+    fn reasoning_effort(&self) -> Option<String> {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .reasoning_effort()
+            .map(str::to_string)
     }
 
     fn runtime(&self) -> Result<Arc<InProcessRuntime>> {
@@ -597,10 +614,12 @@ impl LocalSessionRunner for WakeRunner {
         }
         let turn_lock = self.child_turn_lock(session_id);
         let _guard = turn_lock.lock().await;
-        let result = self
-            .runtime()?
-            .run_turn(session_id, input_for_wake(&wake))
-            .await?;
+        let mut input = input_for_wake(&wake);
+        crate::runtime::reasoning::ensure_reasoning_effort(
+            &mut input,
+            self.reasoning_effort().as_deref(),
+        );
+        let result = self.runtime()?.run_turn(session_id, input).await?;
         if result.success {
             Ok(())
         } else {
@@ -716,7 +735,45 @@ mod tests {
 
     fn runner() -> WakeRunner {
         let backends = HostBackends::in_memory();
-        WakeRunner::new(Arc::new(OnceLock::new()), backends.session_store, None)
+        WakeRunner::new(
+            Arc::new(OnceLock::new()),
+            backends.session_store,
+            None,
+            Arc::new(RwLock::new(crate::runtime::ProviderChoice::Sim)),
+        )
+    }
+
+    /// A child-session message is built here and never passes the host's turn
+    /// entry point, so this is where it has to pick up the model's level.
+    #[test]
+    fn a_child_session_message_carries_the_models_reasoning_level() {
+        let runner = WakeRunner::new(
+            Arc::new(OnceLock::new()),
+            HostBackends::in_memory().session_store,
+            None,
+            Arc::new(RwLock::new(crate::runtime::ProviderChoice::OpenRouter {
+                model: "meta/muse-spark-1.3-contributor".to_string(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                reasoning_effort: Some("medium".to_string()),
+            })),
+        );
+
+        let mut input = input_for_wake(&WakeMessage::coordination("[automatic] continue"));
+        assert!(input.controls.is_none(), "a wake is built without controls");
+
+        crate::runtime::reasoning::ensure_reasoning_effort(
+            &mut input,
+            runner.reasoning_effort().as_deref(),
+        );
+
+        assert_eq!(
+            input
+                .controls
+                .and_then(|controls| controls.reasoning)
+                .and_then(|reasoning| reasoning.effort)
+                .map(|effort| effort.as_str()),
+            Some("medium")
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2313,6 +2313,14 @@ where
     F: Fn(InputMessage) -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<everruns_host::TurnResult>>,
 {
+    // Inputs the host builds itself (a background wake, a resumed turn) do not
+    // come from `input_message`, so they carry no controls at all. Give them
+    // the model's level before the first attempt: the repair below is a
+    // backstop, not the mechanism by which a wake reaches a model that
+    // mandates reasoning.
+    let mut input = input;
+    reasoning::ensure_reasoning_effort(&mut input, model.reasoning_effort().as_deref());
+
     let first = run(input.clone()).await;
     let Some(error) = turn_failure(&first) else {
         return first;
@@ -3810,6 +3818,7 @@ pub async fn build_with_options(
             runtime_cell.clone(),
             local_backends.runtime_backends.session_store.clone(),
             Some(task_registry.clone()),
+            provider_state.clone(),
         ),
         everruns::local::WakeRoutes::new(),
     ));
@@ -8798,11 +8807,80 @@ mod tests {
         assert_eq!(agent_output_start(&[], 7, true), 7);
     }
 
+    /// A wake, a resumed turn, any input the host builds itself: none of them
+    /// go through `input_message`, so they used to reach the provider with no
+    /// reasoning at all. The first attempt now carries the model's level, and
+    /// the repair is left as a backstop rather than the mechanism.
+    #[tokio::test]
+    async fn a_host_built_input_carries_the_models_effort_on_the_first_attempt() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let sessions = tempfile::tempdir().expect("sessions");
+        let settings = Arc::new(crate::config::SettingsStore::open(
+            sessions.path().join("settings.toml"),
+        ));
+        settings
+            .set_token("openrouter".to_string(), "test-key".to_string())
+            .expect("store an openrouter token");
+        let built = build_with_options(
+            workspace.path().to_path_buf(),
+            ProviderChoice::OpenRouter {
+                model: "meta/muse-spark-1.3-contributor".to_string(),
+                base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+                reasoning_effort: Some("medium".to_string()),
+            },
+            None,
+            sessions.path().to_path_buf(),
+            settings,
+            BuildOptions::default(),
+        )
+        .await
+        .expect("build runtime");
+        let model = built.model;
+
+        // Exactly what `input_for_wake` produces: text, provenance tag, no
+        // controls.
+        let mut wake = InputMessage::user("a background task finished");
+        wake.tags.push("automatic_background_wake".to_string());
+
+        let seen = Arc::new(StdMutex::new(Vec::<Option<String>>::new()));
+        let recorded = seen.clone();
+        let run = move |input: InputMessage| {
+            let recorded = recorded.clone();
+            async move {
+                recorded
+                    .lock()
+                    .expect("recorded")
+                    .push(reasoning::sent_reasoning_effort(&input).map(str::to_string));
+                Ok(everruns_host::TurnResult {
+                    response: String::new(),
+                    iterations: 1,
+                    tool_calls_count: 0,
+                    success: true,
+                    error: None,
+                    stop_reason: everruns_core::turn::TurnStopReason::EndTurn,
+                    turn_id: everruns_provider::typed_id::TurnId::new(),
+                })
+            }
+        };
+
+        let notice = |_: String| {};
+        run_with_reasoning_recovery(&model, wake, &notice, run)
+            .await
+            .expect("the wake turn");
+
+        assert_eq!(
+            *seen.lock().expect("recorded"),
+            vec![Some("medium".to_string())],
+            "one attempt, already carrying the model's level"
+        );
+    }
+
     /// A model switched *mid-turn* lands on an endpoint that mandates
-    /// reasoning while the in-flight turn's controls were captured before the
-    /// switch (mid-turn effort changes are EVE-595). The model state names an
-    /// effort, the request that failed did not, and the repair keys off the
-    /// request.
+    /// reasoning. The turn started while the model still named no effort, so
+    /// nothing was on the wire, and the level only exists once the switch has
+    /// run — mid-turn control changes are EVE-595. The repair keys off the
+    /// request, so it sees the empty one and retries with the level the switch
+    /// left behind.
     #[tokio::test]
     async fn a_turn_sent_before_the_model_gained_an_effort_is_retried_with_it() {
         let workspace = tempfile::tempdir().expect("workspace");
@@ -8818,9 +8896,8 @@ mod tests {
             ProviderChoice::OpenRouter {
                 model: "meta/muse-spark-1.3-contributor".to_string(),
                 base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
-                // What `set_model` left behind mid-turn: the level is on the
-                // model, but the turn already in flight never carried it.
-                reasoning_effort: Some("low".to_string()),
+                // The turn starts here: no level, so no controls are built.
+                reasoning_effort: None,
             },
             None,
             sessions.path().to_path_buf(),
@@ -8833,16 +8910,22 @@ mod tests {
 
         let seen = Arc::new(StdMutex::new(Vec::<Option<String>>::new()));
         let recorded = seen.clone();
+        let switched = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let model_ref = &model;
         let run = move |input: InputMessage| {
             let recorded = recorded.clone();
+            let switched = switched.clone();
             async move {
-                let effort = input
-                    .controls
-                    .as_ref()
-                    .and_then(|controls| controls.reasoning.as_ref())
-                    .and_then(|reasoning| reasoning.effort)
-                    .map(|effort| effort.as_str().to_string());
+                let effort = reasoning::sent_reasoning_effort(&input).map(str::to_string);
                 recorded.lock().expect("recorded").push(effort.clone());
+                if !switched.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    // What `set_model` does from inside the turn: the level
+                    // lands on the model, too late for the request in flight.
+                    model_ref
+                        .select_reasoning_effort("low")
+                        .await
+                        .expect("apply the switch");
+                }
                 Ok(everruns_host::TurnResult {
                     response: String::new(),
                     iterations: 1,
@@ -8864,24 +8947,17 @@ mod tests {
             }
         };
 
-        // The turn as the runtime captured it before the switch: no controls.
-        let stale = InputMessage {
-            role: MessageRole::User,
-            content: vec![ContentPart::text("switch model to muse")],
-            controls: None,
-            metadata: None,
-            tags: vec![],
-        };
         let notice = |_: String| {};
-        let result = run_with_reasoning_recovery(&model, stale, &notice, run)
-            .await
-            .expect("the retried turn");
+        let result =
+            run_with_reasoning_recovery(&model, model.input_message("switch model"), &notice, run)
+                .await
+                .expect("the retried turn");
 
         assert!(result.success);
         assert_eq!(
             *seen.lock().expect("recorded"),
             vec![None, Some("low".to_string())],
-            "the retry carries the level the model already names, not a fresh guess"
+            "the retry carries the level the switch left behind, not a fresh guess"
         );
     }
 

--- a/src/runtime/reasoning.rs
+++ b/src/runtime/reasoning.rs
@@ -161,6 +161,22 @@ pub(crate) fn apply_reasoning_effort(input: &mut InputMessage, effort: &str) {
     input.controls = Some(controls);
 }
 
+/// Give a host-built message the model's reasoning level when it carries none.
+///
+/// A wake, a resumed turn and a child-session message are assembled by the host
+/// rather than by `ProviderChoice::input_message`, so they carry no controls at
+/// all and reach an endpoint that mandates reasoning with nothing on the wire.
+/// An effort already on the message is left alone: it is the more specific
+/// answer.
+pub(crate) fn ensure_reasoning_effort(input: &mut InputMessage, effort: Option<&str>) {
+    if sent_reasoning_effort(input).is_some() {
+        return;
+    }
+    if let Some(effort) = effort {
+        apply_reasoning_effort(input, effort);
+    }
+}
+
 /// What to tell the user when a mandatory-reasoning failure cannot be repaired
 /// automatically, i.e. the request already named an effort the endpoint
 /// rejected.
@@ -275,6 +291,34 @@ mod tests {
             recovery_effort(error, None, Some("low")).as_deref(),
             Some("low")
         );
+    }
+
+    #[test]
+    fn a_host_built_message_is_given_the_models_level_only_when_it_has_none() {
+        use everruns_core::{ContentPart, MessageRole};
+
+        let wake = || InputMessage {
+            role: MessageRole::User,
+            content: vec![ContentPart::text("a background task finished")],
+            controls: None,
+            metadata: None,
+            tags: vec!["automatic_background_wake".to_string()],
+        };
+
+        let mut input = wake();
+        ensure_reasoning_effort(&mut input, Some("medium"));
+        assert_eq!(sent_reasoning_effort(&input), Some("medium"));
+
+        // A level already on the message is the more specific answer.
+        let mut input = wake();
+        apply_reasoning_effort(&mut input, "high");
+        ensure_reasoning_effort(&mut input, Some("medium"));
+        assert_eq!(sent_reasoning_effort(&input), Some("high"));
+
+        // A model with no level of its own leaves the message as it was.
+        let mut input = wake();
+        ensure_reasoning_effort(&mut input, None);
+        assert_eq!(sent_reasoning_effort(&input), None);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Any input the host assembles itself — a background wake, a resumed turn, a child-session message — is now given the model's reasoning level before it is sent, in two places: the shared turn entry point that the TUI, `--print` and ACP go through, and `WakeRunner`, which dispatches child-session messages to the runtime without passing through it.

The one-shot repair from #671/#673 stays as the backstop for what neither can know in advance, such as a level that only exists once a mid-turn `set_model` has run.

## Why

A typed turn gets its controls from `ProviderChoice::input_message`. A wake does not: `input_for_wake` builds `InputMessage::user(...)` with provenance metadata and no controls at all. So a background wake reached the provider with **no reasoning on the wire**, and on an endpoint that mandates reasoning it failed exactly as a first turn once did:

```
↻ background task finished, waking agent to review
I encountered an error while processing your request. Please try again later.
turn error: LLM error: provider 'openrouter': OpenAI Responses API error (400 Bad Request):
{"error":{"message":"Reasoning is mandatory for this endpoint and cannot be disabled.","code":400,...}}
this endpoint rejected reasoning effort `medium`; run /effort to pick another level, or /model to switch models
```

That report is from a build predating #673, so the wake now gets repaired rather than killed — but repair was never the right answer here. The level is known before the turn starts; the wake simply never picked it up. The child-session path is worse: it calls `runtime.run_turn` directly, so it had neither the level nor the repair.

## Before / After

Before: a wake on `meta/muse-spark-1.3-contributor` sends `reasoning: {exclude: true}` with no effort — the 400 above, and (post-#673) a wasted round trip before the retry lands.

After, live on the same model with a background task in the turn:

```
$ yolop --provider openrouter -m "meta/muse-spark-1.3-contributor medium" \
    -p "Run 'sleep 2 && echo done' in the background, wait for it to finish, then reply with exactly: pong"
pong
```

No repair notice, because there is nothing to repair: the first attempt already carries `medium`.

## Risk

- Low
- Only fills a level in where the message carried none; an effort already on a message is left alone as the more specific answer, and a model with no level of its own changes nothing.
- `WakeRunner` gains a read-only handle to the live provider selection. It reads the same `Arc<RwLock<ProviderChoice>>` every other control surface reads.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Tests: a turn-seam test that a host-built wake input (text, provenance tag, no controls) reaches the provider carrying the model's level on the *first* attempt; a `WakeRunner` test that a child-session message picks the level up where it is built; unit tests for the fill-in helper (fills when absent, never overrides, no-ops with no level). The mid-turn switch test from #673 was rewritten to model the switch happening *during* the first attempt, which is what actually happens, so it still proves the repair rather than the new fill-in.

Full `cargo test --workspace --features yolop-yep/schema` (1355 + 73), `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo fmt --check`, `scripts/validate_okf.py knowledge --check-links`: green. Smoke: the live OpenRouter run above.

## Knowledge

Updated [`knowledge/specs/reasoning-effort.md`](knowledge/specs/reasoning-effort.md) with a section on host-built turns carrying the level, the repair reframed as the backstop, and the ownership boundary extended to `WakeRunner`; `knowledge/log.md` entry added.

## Security

- **TM-LLM** — the only affected surface. One field, `controls.reasoning.effort`, is filled in on messages yolop built; no key handling, logging, or prompt content changes.
- **TM-FS**, **TM-BASH**, **TM-TOOL**, **TM-DEP** — untouched; no new dependencies or capabilities. `WakeRunner`'s new field is a read handle to state the process already holds.

## Follow-ups

- Other per-turn controls a host-built input omits (verbosity, speed) are not addressed here; only reasoning has a failure mode that kills the turn today.
- The upstream limitation behind the mid-turn case (EVE-595) is unchanged; the repair still covers it.

https://claude.ai/code/session_01GJ14Z3ocwnDWRzk8gzsiWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ14Z3ocwnDWRzk8gzsiWY)_