### PR TITLE
feat(mcp): add yolop mcp login command

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Manage servers from the CLI with `yolop mcp`, or from a session with `/mcp`:
 yolop mcp list --scope effective
 yolop mcp add linear --scope global --type http --url https://mcp.linear.app/mcp --auth-mode oauth --oauth-provider-id linear
 yolop mcp enable linear --scope global
+yolop mcp login linear
 yolop mcp remove linear --scope global
 ```
 

--- a/knowledge/specs/mcp.md
+++ b/knowledge/specs/mcp.md
@@ -93,7 +93,7 @@ Credentials for a server are resolved per request by the runtime's
 3. Literal `headers` in the config (with `${VAR}` expansion), applied by the
    transport regardless of the provider.
 
-**OAuth login** (`/mcp login <name>`, remote HTTP servers) is discovery-based:
+**OAuth login** (`/mcp login <name>`, or `yolop mcp login <name>` headlessly, remote HTTP servers) is discovery-based:
 protected-resource metadata (RFC 9728) → authorization-server metadata
 (RFC 8414 / OpenID discovery) → dynamic client registration (RFC 7591) when the
 server offers it → authorization code + PKCE (RFC 7636) through the browser with

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,6 +319,14 @@ enum McpCommand {
         #[arg(short = 'C', long = "cwd")]
         cwd: Option<PathBuf>,
     },
+    /// Log in to a remote MCP server with the OAuth browser flow.
+    Login {
+        /// Server name.
+        name: String,
+        /// Workspace root for workspace/effective config.
+        #[arg(short = 'C', long = "cwd")]
+        cwd: Option<PathBuf>,
+    },
     /// Add or replace an MCP server.
     Add {
         /// Scope to write (`global` or `workspace`).
@@ -1129,7 +1137,7 @@ async fn run_models_pull(_spec: &str) -> Result<()> {
     ))
 }
 
-fn run_mcp_command(command: McpCommand) -> Result<()> {
+async fn run_mcp_command(command: McpCommand) -> Result<()> {
     use crate::config::mcp::{McpServerEntry, McpServerSummary};
     use everruns_core::{McpServerTransportType, ScopedMcpServer};
     use std::collections::HashMap;
@@ -1195,6 +1203,43 @@ fn run_mcp_command(command: McpCommand) -> Result<()> {
                     );
                 }
             }
+            Ok(())
+        }
+        McpCommand::Login { name, cwd } => {
+            let servers = store(cwd)?
+                .effective()
+                .map_err(anyhow::Error::msg)?
+                .servers
+                .into_iter()
+                .find(|server| server.name == *name && server.effective)
+                .with_context(|| format!("MCP server `{name}` was not found in effective scope"))?;
+            let scoped = &servers.server.server;
+            if scoped.transport_type != McpServerTransportType::Http {
+                return Err(anyhow::Error::msg(format!(
+                    "MCP server `{name}` is a stdio server; OAuth login only applies to remote HTTP servers"
+                )));
+            }
+            let provider_key = scoped
+                .oauth_provider_id
+                .clone()
+                .unwrap_or_else(|| name.clone());
+            println!("Opening the browser to log in to MCP server `{name}` ...");
+            let prepared = auth::mcp_oauth_login::prepare_login(&scoped.url, None, None).await?;
+            println!(
+                "If the browser did not open, visit this URL:\n{}\n",
+                prepared.authorize_url
+            );
+            if let Err(error) = auth::oauth_flow::open_browser(prepared.authorize_url.as_str()) {
+                eprintln!("warning: could not open the browser: {error:#}");
+            }
+            println!("Waiting for the browser login to complete ...");
+            let tokens = auth::mcp_oauth_login::complete_login(prepared).await?;
+            let fallback = PathBuf::from("/dev/null/yolop");
+            let connections_path = connectors::default_connections_path()
+                .unwrap_or_else(|| fallback.join("connections.toml"));
+            let connections = connectors::ConnectionStore::open(connections_path);
+            auth::mcp_oauth::save_tokens(&connections, &provider_key, tokens)?;
+            println!("Logged in to MCP server `{name}`.");
             Ok(())
         }
         McpCommand::Show { name, scope, cwd } => {
@@ -1351,7 +1396,7 @@ async fn run_command(command: Commands) -> Result<()> {
             println!("{}", version::VERSION_LINE);
             Ok(())
         }
-        Commands::Mcp(args) => run_mcp_command(args.command),
+        Commands::Mcp(args) => run_mcp_command(args.command).await,
         Commands::Weights(args) => run_weights_command(args.command).await,
         Commands::TuikaGallery => run_tuika_gallery(),
         #[cfg(target_os = "linux")]
@@ -2452,6 +2497,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mcp_login_unknown_server_errors() {
+        let cwd = std::env::temp_dir().join("yolop-mcp-login-unknown-server");
+        std::fs::create_dir_all(&cwd).expect("create temp cwd");
+        let error = run_mcp_command(McpCommand::Login {
+            name: "definitely-not-a-server".to_string(),
+            cwd: Some(cwd),
+        })
+        .await
+        .expect_err("unknown server errors");
+        assert!(
+            error
+                .to_string()
+                .contains("was not found in effective scope"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn detached_management_commands_dispatch() {
         let registry = detached_cli_registry().expect("build detached CLI registry");
         for argv in [
@@ -2480,6 +2543,7 @@ mod tests {
             vec!["yolop", "mcp", "show", "demo"],
             vec!["yolop", "mcp", "enable", "demo"],
             vec!["yolop", "mcp", "disable", "demo"],
+            vec!["yolop", "mcp", "login", "demo"],
         ] {
             Cli::try_parse_from(argv).expect("parse MCP command");
         }


### PR DESCRIPTION
Remote MCP servers had no CLI path to OAuth: the browser flow only existed inside the TUI (`/mcp login`). This adds `yolop mcp login <name>`, which resolves the effective server entry, prints the authorize URL, opens the browser (warning and continuing when headless), waits on the loopback callback, and saves tokens to the connections store. Unknown names and stdio servers fail fast with explicit errors.

## Validation

- `cargo fmt --check`, clippy with `-D warnings`, and the full suite (`cargo test --workspace --features yolop-yep/schema`) are green: 1362 passed, 0 failed.
- New tests: CLI parse coverage for `mcp login` in `mcp_cli_exposes_management_and_runtime_commands`, plus async `mcp_login_unknown_server_errors`.
- Offline smoke: `--provider llmsim` starts and answers.

## Before / After

Before: `yolop mcp --help` listed list, show, add, remove, enable, disable, and Linear OAuth sat unauthenticated with no CLI way to log in.

After: `yolop mcp login linear` completed a real login end to end (authorize URL, browser approval, `Logged in to MCP server 'linear'`, tokens stored under `mcp-oauth:linear`), and the stored token successfully listed Linear tools and the OSS project's issues.

## Security

- Filesystem: writes go only through the existing `ConnectionStore` to connections.toml, the same sink the TUI login and provider setup use. No new paths are built from user input.
- Shell: no new command execution; browser launch reuses the existing `open_browser` helper.
- Secrets: tokens are never printed or logged; only the authorize URL (state plus PKCE S256 challenge, public by design) is shown. The temp login log was deleted after use.
- Trust boundaries: server name is used for config lookup and display only; the OAuth URL comes from the user's own configured server entry.
- No new dependencies, no capability registration changes.

## Follow-ups

- No follow-ups.
- Device-code OAuth flow stays out of scope per knowledge/specs/mcp.md (browser plus loopback now covers the CLI case).

## Knowledge

Updated `knowledge/specs/mcp.md` (CLI equivalent of `/mcp login`) and `README.md` (login example) in this change.

Produced by [yolop](https://everruns.com/yolop)