### PR TITLE
fix(capabilities): remove duplicate capability tags from system prompt

### DIFF
--- a/knowledge/specs/system-prompt.md
+++ b/knowledge/specs/system-prompt.md
@@ -53,6 +53,15 @@ duplicating the tool description; delete it. `progress_guard` and `repo_map` are
 the reference cases for the second row: both emit their guidance inside the
 result, at the moment it applies, so neither needs a block.
 
+### Capability blocks wrap exactly once
+
+`system_prompt_addition` returns raw text and the host wraps it in
+`<capability>` tags once, so an addition that embeds its own tags renders
+twice. Override `system_prompt_contribution` only when custom wrapping is
+needed, and then wrap exactly once. Raw-text prompt constants carry a
+regression test asserting the addition holds no tags and the assembled
+contribution wraps exactly once.
+
 ### Discovery is always on; how-to is reveal-gated
 
 `tool_search` hides deferred tools' parameter schemas until the model asks for

--- a/src/capabilities/agent_commands.rs
+++ b/src/capabilities/agent_commands.rs
@@ -32,14 +32,14 @@ use std::sync::Arc;
 
 pub(crate) const AGENT_COMMANDS_CAPABILITY_ID: &str = "yolop_agent_commands";
 
-pub(crate) const AGENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_agent_commands">
-`run_command` runs any slash command this session registers, not a fixed subset:
+/// Raw text on purpose: the host wraps `system_prompt_addition` in `<capability>`
+/// tags once, so tags here would render twice.
+pub(crate) const AGENT_COMMANDS_PROMPT: &str = r#"`run_command` runs any slash command this session registers, not a fixed subset:
 `/setup status|login|reauthenticate <provider>`, `/background`, `/undo`,
 `/rewind`, `/goal`, and whatever else the host registers. Use `command: help`
 for the live list; an unknown name returns the available ones. Prefer running a
 command over telling the user to type it. Skill commands activate by prompt, so
-follow the skill instead. The result carries the command's own output.
-</capability>"#;
+follow the skill instead. The result carries the command's own output."#;
 
 /// Registry port for `run_command`: list the commands this session actually has
 /// and execute one through the runtime, the same path a typed slash command
@@ -346,7 +346,9 @@ impl CommandDispatch for EmptyCommandDispatch {
 mod tests {
     use super::*;
     use crate::tui::host_ui::{RecordingUi, UiCommand};
+    use everruns_core::SystemPromptContext;
     use everruns_core::command::CommandArg;
+    use everruns_provider::typed_id::SessionId;
     use std::sync::Mutex;
 
     /// Registry stand-in: records what was executed and answers from a fixed
@@ -455,6 +457,36 @@ mod tests {
                 .to_string(),
             other => panic!("expected Success, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn prompt_addition_is_raw_text_without_capability_wrapper() {
+        let capability = AgentCommandsCapability::new(Arc::new(EmptyCommandDispatch), None);
+        let addition = capability.system_prompt_addition().expect("prompt");
+        assert!(
+            !addition.contains("<capability"),
+            "system_prompt_addition must not embed <capability> tags: {addition:?}"
+        );
+        assert!(
+            !addition.contains("</capability>"),
+            "system_prompt_addition must not embed </capability>: {addition:?}"
+        );
+
+        let ctx = SystemPromptContext::without_file_store(SessionId::new());
+        let contribution = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("contribution");
+        assert_eq!(
+            contribution.matches("<capability").count(),
+            1,
+            "assembled prompt must wrap exactly once: {contribution:?}"
+        );
+        assert_eq!(
+            contribution.matches("</capability>").count(),
+            1,
+            "assembled prompt must close exactly once: {contribution:?}"
+        );
     }
 
     #[test]

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -28,14 +28,14 @@ use std::sync::Arc;
 
 pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
 
-pub(crate) const CLIENT_COMMANDS_PROMPT: &str = r#"<capability id="yolop_client_commands">
-Terminal commands, all runnable with `run_command`: `/help`, `/tools`, `/mcp`,
+/// Raw text on purpose: the host wraps `system_prompt_addition` in `<capability>`
+/// tags once, so tags here would render twice.
+pub(crate) const CLIENT_COMMANDS_PROMPT: &str = r#"Terminal commands, all runnable with `run_command`: `/help`, `/tools`, `/mcp`,
 `/cwd`, `/status [compact|expanded|toggle]`, `/model [id]`, `/effort [level]`,
 `/clear`, `/quit` (`/exit` alias). Run them on prose requests such as "exit",
 "clear the screen", "show tools", "switch model", "restart MCP", "reconnect MCP",
 or "refresh MCP" (`/mcp reload`), "log in to an MCP server" (`/mcp login <name>`);
-never invent a manager window. `/shell` is typed-only; use `bash`.
-</capability>"#;
+never invent a manager window. `/shell` is typed-only; use `bash`."#;
 
 pub(crate) struct ClientCommandsCapability {
     ui: Arc<dyn HostUi>,
@@ -186,6 +186,7 @@ fn arg(name: &str, required: bool) -> CommandArg {
 mod tests {
     use super::*;
     use crate::tui::host_ui::RecordingUi;
+    use everruns_core::SystemPromptContext;
     use everruns_provider::typed_id::SessionId;
 
     #[test]
@@ -204,6 +205,36 @@ mod tests {
 
     /// The terminal commands are ordinary registry entries; `run_command` finds
     /// them there rather than in a list this capability hands the model.
+    #[tokio::test]
+    async fn prompt_addition_is_raw_text_without_capability_wrapper() {
+        let capability = ClientCommandsCapability::new(Arc::new(RecordingUi::default()));
+        let addition = capability.system_prompt_addition().expect("prompt");
+        assert!(
+            !addition.contains("<capability"),
+            "system_prompt_addition must not embed <capability> tags: {addition:?}"
+        );
+        assert!(
+            !addition.contains("</capability>"),
+            "system_prompt_addition must not embed </capability>: {addition:?}"
+        );
+
+        let ctx = SystemPromptContext::without_file_store(SessionId::new());
+        let contribution = capability
+            .system_prompt_contribution(&ctx)
+            .await
+            .expect("contribution");
+        assert_eq!(
+            contribution.matches("<capability").count(),
+            1,
+            "assembled prompt must wrap exactly once: {contribution:?}"
+        );
+        assert_eq!(
+            contribution.matches("</capability>").count(),
+            1,
+            "assembled prompt must close exactly once: {contribution:?}"
+        );
+    }
+
     #[test]
     fn capability_contributes_terminal_commands() {
         let capability = ClientCommandsCapability::new(Arc::new(RecordingUi::default()));

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -689,11 +689,11 @@ impl Capability for ModelsCapability {
 // Discovery, not how-to: without this the model does not know it may retune the
 // live session at all. When to escalate effort, and not thrashing the model
 // mid-task, are judgement calls left to the model.
-pub(crate) const MODELS_PROMPT: &str = "<capability id=\"models\">\n\
-    `set_reasoning_effort`, `set_model`, and `set_provider` apply next turn. For partial \
-    model names, call `search_models`, show ambiguous matches, and never guess an ID. \
-    Unknown effort levels return accepted values.\n\
-    </capability>";
+/// Raw text on purpose: the host wraps `system_prompt_addition` in `<capability>`
+/// tags once, so tags here would render twice.
+pub(crate) const MODELS_PROMPT: &str = "`set_reasoning_effort`, `set_model`, and `set_provider` apply \
+    next turn. For partial model names, call `search_models`, show ambiguous matches, \
+    and never guess an ID. Unknown effort levels return accepted values.";
 
 fn setup_command_arg() -> CommandArg {
     let mut suggestions = vec![
@@ -1867,6 +1867,10 @@ mod tests {
         // The agent is told these tools exist so it uses them instead of asking
         // the user to type a slash command.
         let prompt = capability.system_prompt_addition().expect("setup prompt");
+        // system_prompt_addition is raw text: the host wraps it once. Tags here
+        // would render twice (see agent_commands, client_commands).
+        assert!(!prompt.contains("<capability"));
+        assert!(!prompt.contains("</capability>"));
         assert!(prompt.contains("set_reasoning_effort"));
         assert!(prompt.contains("set_model"));
         assert!(prompt.contains("search_models"));


### PR DESCRIPTION
## What

Three capability prompt blocks rendered with doubled `<capability>` tags in the assembled system prompt (reported with screenshots for `yolop_agent_commands` and `models`). The prompt constants embedded their own wrapper tags while also going through `system_prompt_addition`, which the host wraps once, so each block rendered twice.

Removes the embedded tags from `AGENT_COMMANDS_PROMPT`, `CLIENT_COMMANDS_PROMPT`, and `MODELS_PROMPT`, leaving raw text for the host to wrap exactly once.

## Why

The double wrapping bloats the system prompt and risks confusing the model about capability boundaries. The root cause was a violated convention, not a renderer bug, so the fix also documents the rule: `system_prompt_addition` returns raw text, `system_prompt_contribution` wraps exactly once.

## Before / After

Before: each affected block rendered as nested pairs (see issue screenshots):
`<capability id="models"` > `<capability id="models"` > text > `</capability>` > `</capability>`.
After: single wrapping, proven by regression tests that assert the addition holds no tags and the assembled contribution (via the real `system_prompt_contribution(&ctx).await` entry point) contains exactly one opening and one closing tag.

No observable behavior change beyond the prompt text itself; no TUI or CLI surface changes.

## Validation

- New/extended regression tests: `prompt_addition_is_raw_text_without_capability_wrapper` (agent, client) and models no-tag assertions. Written to fail first, confirmed failing, then green after the fix.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, full `cargo test --workspace --features yolop-yep/schema` green (one timing-flaky scenario test passed in isolation and on suite rerun).
- Offline smoke: `cargo run -- --provider llmsim -p "hi"` starts cleanly.
- `python3 scripts/validate_okf.py knowledge --check-links` passes.

## Risks

Low. Static prompt strings only; removes duplicate tags. If any downstream snapshot asserted the doubled tags, it would fail, but no such snapshots exist (full suite green).

## Knowledge

Updated `knowledge/specs/system-prompt.md` with a "Capability blocks wrap exactly once" subsection, plus convention comments at each prompt constant.

## Security

Prompt-construction change (TM-LLM): removes duplicate XML tags from three static prompt strings. No user input interpolation, no new injection surface, no key handling or logging changes. No filesystem (TM-FS), shell (TM-BASH), capability-registration (TM-TOOL), or dependency (TM-DEP) changes.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)