### PR TITLE
fix(capabilities): wrap attribution prompt in capability tags

### DIFF
--- a/src/capabilities/attribution.rs
+++ b/src/capabilities/attribution.rs
@@ -20,7 +20,7 @@ pub(crate) const YOLOP_PR_ATTRIBUTION: &str = "Produced by [yolop](https://everr
 /// without a `SystemPromptContext`.
 pub(crate) fn yolop_attribution_prompt() -> String {
     format!(
-        "\
+        "<capability id=\"{ATTRIBUTION_CAPABILITY_ID}\">\n\
 ## Attribution
 
 When you create or amend commits for changes you made, keep the user's
@@ -31,7 +31,7 @@ When creating or editing pull request descriptions with `gh`, add this
 footer once:
 {YOLOP_PR_ATTRIBUTION}
 
-Do not add duplicate attribution or session links."
+Do not add duplicate attribution or session links.\n</capability>"
     )
 }
 
@@ -88,6 +88,8 @@ mod tests {
             .await
             .expect("enabled attribution prompt");
         assert!(enabled.contains(YOLOP_ATTRIBUTION_TRAILER));
+        assert!(enabled.starts_with("<capability id=\"yolop_attribution\">\n"));
+        assert!(enabled.trim_end().ends_with("</capability>"));
         assert_eq!(
             YOLOP_PR_ATTRIBUTION,
             "Produced by [yolop](https://everruns.com/yolop)"


### PR DESCRIPTION
## Summary
Wraps the attribution capability's system-prompt contribution in `<capability id="yolop_attribution">` tags, matching every other capability's convention. The tag id is rendered from `ATTRIBUTION_CAPABILITY_ID` so it cannot drift from the registered capability id. Prompt guidance content is unchanged.

## Before / After
Before: contribution started with raw `## Attribution`, the only unwrapped capability block.
After: contribution is wrapped in `<capability id="yolop_attribution">…</capability>`. No observable behavior change; same guidance text reaches the model, now consistently tagged.

## Testing
- `cargo test --workspace --features yolop-yep/schema attribution`: 5 passed, including the extended `attribution_prompt_follows_settings` which now asserts the wrapper via the real entry point.
- `always_on_capability_prompts_within_budget` passes (extra ~50 bytes, headroom intact).
- `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.
- Smoke: `cargo run -- --provider llmsim -p "hi"` replies and exits 0.

## Security
Prompt-construction-only change (TM-LLM): wraps existing static guidance text in tags; no new interpolation, no key handling, no logging, no shell/FS/tool-registration/dependency surface. No injection or exfiltration vector introduced.

## Follow-ups
No follow-ups.

No knowledge update required: transient implementation detail, no durable behavior, intent, or terminology change.

## Intent / spec link
N/A (consistency fix, no spec change).

## Checklist
- [x] Branch rebased on `origin/main` or includes latest `main`
- [x] Relevant specs / knowledge updated, or N/A with reason above
- [x] Breaking change called out, or N/A (none)
- [x] Tests added or updated
- [x] Full test suite passes