### PR TITLE
fix(approval): make a soft-approval pause a tool call, and let /ship merge

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -97,3 +97,17 @@ Merge with `gh pr merge --squash` after CI is green and a final comment sweep is
 clean; give async reviewer bots at least 2 minutes after CI turns green. Do not
 enable auto-merge — bots can post after the last push. After the merge lands,
 watch main CI for the merge commit and fix or revert promptly if it fails.
+
+## Approval
+
+Asking to ship is the approval for shipping. Pushing the branch, opening the
+PR, and squash-merging it once the bar above is met are what this workflow
+exists to do, so run them without a `request_approval` pause and note the
+grant once with `record_approval`. Soft approval otherwise treats those as
+outward-facing and stops in front of them, which is how a run ends on
+"Squash-merging." and waits for a "do this" that adds nothing: the gate that
+actually protects the merge is green CI and a clean sweep, not a second yes.
+
+The grant covers this change through its merge and nothing else. Anything
+destructive or outside that path — force-pushing, rewriting history, reverting
+on main, touching another PR — still needs the question.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,21 @@
 # Knowledge Log
 
+## 2026-09-10, A soft-approval pause is a tool call
+
+- [Approval](specs/approval.md): pausing before a critical action now means
+  calling `request_approval` and ending the turn there. Prose could not express
+  a pause: a turn ending on "Squash-merging." looks exactly like a turn that
+  finished, so the user reads a working gate as a broken agent and answers with
+  a "do this" that carries no information.
+- The call gives the host a fact to render and the audit log a record of what
+  was asked, not only of what was granted. The prompt names the announce-then-
+  stop failure directly, because it is the one models actually make.
+- A workflow the user invoked by name may pre-authorize the actions it exists
+  to perform. `/ship` does that for push, PR, and squash-merge: soft approval
+  treated all three as outward-facing and stopped in front of them, while the
+  skill told the model to merge once CI was green. The two instructions
+  contradicted each other and the model resolved it differently each run.
+
 ## 2026-09-10, A host-built turn carries reasoning too
 
 - [Reasoning effort](specs/reasoning-effort.md): background wakes, resumed turns

--- a/knowledge/specs/approval.md
+++ b/knowledge/specs/approval.md
@@ -64,6 +64,38 @@ contributes a `<soft_approval>` block to the system prompt:
   user-granted category exemption ("you don't need to ask for commits") is
   honored without re-asking.
 
+### The pause is a tool call
+
+Prose alone cannot express a pause. A model that ends its turn on
+"Squash-merging." has stopped, but the loop, the transcript, and the user all
+see the same thing they would see if it had finished: text, then nothing. The
+user is left to guess that yolop is waiting on them, and the usual guess is
+that the turn broke.
+
+So pausing means calling `request_approval` with the action and the question,
+and ending the turn there. The call is the pause. It gives the host a fact to
+render (`PendingApprovalStore`, read when a turn ends, surfaced as an explicit
+waiting line) and the audit log a record of what was *asked*, not only of what
+was granted. `record_approval` clears the pause, as does the user's next
+message: either way they have answered.
+
+The prompt names the failure directly, because it is the one models actually
+make: never announce a critical action and then stop without the call. Ask, or
+act; never narrate and halt.
+
+### Workflows carry their own grant
+
+A workflow the user invoked by name is the user asking for the actions that
+workflow exists to perform, so its instructions may pre-authorize them; the
+model honors that the same way it honors a spoken category exemption, and
+notes it once with `record_approval`. [`/ship`](../../.agents/skills/ship/SKILL.md)
+does this for pushing, opening the PR, and the squash-merge: soft approval
+otherwise stops in front of all three as outward-facing, and a ship run ends
+on "Squash-merging." waiting for a second yes that adds nothing. The gate that
+protects that merge is green CI and a clean comment sweep, not a confirmation.
+A grant reaches only the path its workflow covers; anything destructive or
+outside it still needs the question.
+
 Reading the level live means `/setup approval` and `set_approval_mode` take
 effect on the very next turn without a restart.
 

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -13,6 +13,14 @@
 //   * record each granted approval with `record_approval`, which lands a
 //     `tool.completed` line in the per-session `events.jsonl` audit log.
 //
+// The pause itself is a tool call, `request_approval`, not just prose. A model
+// that ends its turn on a sentence like "Squash-merging." has paused as far as
+// the loop is concerned, but nothing distinguishes that from a finished answer:
+// the user sees a turn that stopped mid-thought and has to guess that yolop is
+// waiting on them. Routing the pause through a tool gives the host a fact to
+// render, and the audit log a record of what was asked, not only of what was
+// granted.
+//
 // The paranoia level is central configuration (`approval_mode` in
 // settings.toml, see `crate::config::ApprovalMode`), surfaced in the status
 // bar, switchable with `/setup approval <level>` and — because users address
@@ -28,9 +36,53 @@ use everruns_core::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::{Tool, ToolExecutionResult};
 use everruns_provider::{BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition};
 use serde_json::{Value, json};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 pub(crate) const APPROVAL_CAPABILITY_ID: &str = "yolop_approval";
+
+/// A critical action yolop has stopped in front of, waiting for the user to
+/// say yes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingApproval {
+    /// What yolop will do once approved.
+    pub action: String,
+    /// The question put to the user, already phrased for display.
+    pub question: String,
+}
+
+/// The one pending approval a session can be holding.
+///
+/// Shared between the capability's tools and the host: `request_approval`
+/// sets it, `record_approval` clears it, and the host reads it when a turn
+/// ends so a pause is visible rather than looking like a turn that died.
+#[derive(Clone, Default)]
+pub struct PendingApprovalStore {
+    inner: Arc<Mutex<Option<PendingApproval>>>,
+}
+
+impl PendingApprovalStore {
+    /// Raise a pause. `request_approval` owns this in production; the TUI's
+    /// own tests use it to stand in for a model that paused.
+    pub(crate) fn set(&self, pending: PendingApproval) {
+        *self.inner.lock().expect("pending approval lock") = Some(pending);
+    }
+
+    fn clear(&self) {
+        *self.inner.lock().expect("pending approval lock") = None;
+    }
+
+    /// What the session is waiting on, without consuming it. A pause outlives
+    /// the turn that raised it: it is answered by the user's next message, not
+    /// by the turn ending.
+    pub fn peek(&self) -> Option<PendingApproval> {
+        self.inner.lock().expect("pending approval lock").clone()
+    }
+
+    /// Drop a pause the user has now answered, whichever way they answered.
+    pub fn resolve(&self) {
+        self.clear();
+    }
+}
 
 /// Render the `<soft_approval>` system-prompt block for a given level.
 /// Pure so the per-mode branch logic is unit-testable without a
@@ -61,23 +113,24 @@ Soft-approval is active at level {level}.\n\
 {threshold}\n\
 \n\
 How to operate:\n\
-- Plan first, then BATCH the safe steps and run them without pausing. Do NOT \
-ask for approval before every tool call — that defeats the purpose. Read-only \
-inspection (reading, listing, grepping, status checks) never needs approval.\n\
-- When you reach a critical action, STOP before running it. Briefly justify it \
-to the user (what you will do, why, and what is at risk — the \"proof\"), then \
-ask for approval in one short question and wait.\n\
-- A plain affirmative reply (\"yes\", \"approved\", \"go ahead\", \"do it\") is \
-the approval; a negative or hesitant reply is not. There is no separate \
-approval UI — consent is spoken in chat.\n\
-- Immediately after the user approves, call `record_approval` with a concise \
-description of exactly what was approved, then carry it out. This writes the \
-approval to the session audit log.\n\
-- One approval covers the specific action described, not unrelated later \
-actions. If the user pre-authorizes a category (\"you don't need to ask for \
-git commits\"), honor it for that category without re-asking.\n\
-- If the user asks to change how cautious you are (\"be more careful\", \"stop \
-asking\", \"yolo mode\"), call `set_approval_mode` to update the level.\n\
+- Plan, then BATCH the safe steps and run them without pausing. Do NOT ask \
+before every tool call; read-only inspection never needs approval.\n\
+- At a critical action, STOP: say briefly what you will do, why, and what is \
+at risk, then call `request_approval` with that action and one short question, \
+and end your turn. That call IS the pause, and the only signal to the user \
+that you are waiting.\n\
+- NEVER announce a critical action and then stop without it. \"Squash-merging.\" \
+as your last words reads as a turn that died, not as a question. Ask, or act; \
+never narrate and halt.\n\
+- A plain affirmative (\"yes\", \"go ahead\", \"do it\") is the approval; a \
+negative or hesitant reply is not. Consent is spoken in chat.\n\
+- Immediately after they approve, call `record_approval` with what was \
+approved, then carry it out. This writes it to the session audit log.\n\
+- One approval covers that action, not later ones. Honor a pre-authorized \
+category (\"no need to ask for commits\") without re-asking, and a workflow the \
+user invoked by name pre-authorizes the actions it exists to perform: run \
+those without pausing and note the grant once with `record_approval`.\n\
+- If the user asks you to be more or less cautious, call `set_approval_mode`.\n\
 </soft_approval>",
         level = mode.as_str(),
     ))
@@ -88,6 +141,8 @@ pub(crate) struct ApprovalCapability {
     pub(crate) config: Arc<dyn ConfigService>,
     /// Concrete store for the `set_approval_mode` write tool.
     pub(crate) settings: Arc<SettingsStore>,
+    /// Shared with the host so a pause is rendered, not merely spoken.
+    pub(crate) pending: PendingApprovalStore,
 }
 
 #[async_trait]
@@ -122,7 +177,12 @@ impl Capability for ApprovalCapability {
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
-            Box::new(RecordApprovalTool),
+            Box::new(RequestApprovalTool {
+                pending: self.pending.clone(),
+            }),
+            Box::new(RecordApprovalTool {
+                pending: self.pending.clone(),
+            }),
             Box::new(SetApprovalModeTool {
                 settings: self.settings.clone(),
             }),
@@ -136,7 +196,9 @@ impl Capability for ApprovalCapability {
 /// tool itself only echoes the record back; the durable audit entry is the
 /// `tool.completed` event this call produces in the per-session `events.jsonl`
 /// log, which captures the arguments, output, and timestamp.
-struct RecordApprovalTool;
+struct RecordApprovalTool {
+    pending: PendingApprovalStore,
+}
 
 const FALLBACK_APPROVAL_ACTION: &str = "the pending critical action approved in the conversation";
 
@@ -224,12 +286,100 @@ impl Tool for RecordApprovalTool {
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let action = approval_action(&arguments);
         let detail = non_empty_str(arguments.get("detail"));
+        // Consent has been given, so the session is no longer waiting on the
+        // user. Clearing here rather than on the next turn keeps the host from
+        // showing a pause that has already been answered.
+        self.pending.resolve();
         ToolExecutionResult::success(json!({
             "ok": true,
             "recorded": true,
             "action": action,
             "detail": detail,
             "message": format!("approval recorded: {action}"),
+        }))
+    }
+}
+
+/// Pauses in front of a critical action and asks the user for approval.
+///
+/// Calling this is what makes the pause legible: the host reads
+/// [`PendingApprovalStore`] when the turn ends and tells the user it is
+/// waiting on them, instead of leaving a turn that stopped mid-sentence.
+struct RequestApprovalTool {
+    pending: PendingApprovalStore,
+}
+
+const FALLBACK_APPROVAL_QUESTION: &str = "Go ahead?";
+
+#[async_trait]
+impl Tool for RequestApprovalTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let _ = locale;
+        let action = arg_str(&tool_call.arguments, &["action"]).map(|value| truncate(value, 48));
+        Some(stable_labeled("Ask approval", action, phase))
+    }
+
+    fn name(&self) -> &str {
+        "request_approval"
+    }
+    fn display_name(&self) -> Option<&str> {
+        Some("Ask approval")
+    }
+    fn description(&self) -> &str {
+        // Deliberately terse: this tool can never be deferred behind
+        // `tool_search` (the model has to find it at the instant it decides to
+        // pause), so every byte here is paid on every turn.
+        "Pause before a critical action and ask the user to approve it. Call this INSTEAD of \
+         announcing it and stopping: the call is what tells the user you are waiting. End your \
+         turn right after. Logged; no secrets."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "The action awaiting approval, e.g. \"squash-merge PR #677\"."
+                },
+                "question": {
+                    "type": "string",
+                    "description": "One short question for the user, e.g. \"CI is green. Merge it?\""
+                }
+            },
+            "required": ["action"],
+            "additionalProperties": false
+        })
+    }
+
+    fn to_definition(&self) -> ToolDefinition {
+        non_deferrable_builtin(self)
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let action = approval_action(&arguments).to_string();
+        let question = arguments
+            .get("question")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(FALLBACK_APPROVAL_QUESTION)
+            .to_string();
+        self.pending.set(PendingApproval {
+            action: action.clone(),
+            question: question.clone(),
+        });
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "awaiting_approval": true,
+            "action": action,
+            "question": question,
+            "message": "waiting for the user to approve; end your turn now",
         }))
     }
 }
@@ -340,6 +490,13 @@ mod tests {
         // The core behaviors must be spelled out.
         assert!(normal.contains("BATCH"));
         assert!(normal.contains("record_approval"));
+        // The pause is a tool call, and announcing instead of asking is the
+        // failure this block exists to prevent.
+        assert!(normal.contains("request_approval"));
+        assert!(normal.contains("NEVER announce a critical action"));
+        // A workflow the user invoked can carry the pre-authorization, which
+        // is what keeps `/ship` from stopping in front of its own merge.
+        assert!(normal.contains("a workflow the user invoked by name"));
         assert!(normal.ends_with("</soft_approval>"));
 
         let protective = render_approval_block(ApprovalMode::Protective).expect("protective block");
@@ -348,15 +505,19 @@ mod tests {
     }
 
     #[test]
-    fn capability_exposes_both_tools() {
+    fn capability_exposes_its_tools() {
         let (_tmp, settings) = store_in_tmp();
         let cap = ApprovalCapability {
             config: settings.clone(),
             settings,
+            pending: PendingApprovalStore::default(),
         };
         let tools = cap.tools();
         let names: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
-        assert_eq!(names, vec!["record_approval", "set_approval_mode"]);
+        assert_eq!(
+            names,
+            vec!["request_approval", "record_approval", "set_approval_mode"]
+        );
         assert!(
             tools.iter().all(|tool| {
                 matches!(tool.to_definition().deferrable(), DeferrablePolicy::Never)
@@ -371,6 +532,7 @@ mod tests {
         let cap = ApprovalCapability {
             config: settings.clone(),
             settings: settings.clone(),
+            pending: PendingApprovalStore::default(),
         };
         let ctx =
             SystemPromptContext::without_file_store(everruns_provider::typed_id::SessionId::new());
@@ -387,7 +549,9 @@ mod tests {
 
     #[tokio::test]
     async fn record_approval_echoes_action() {
-        let tool = RecordApprovalTool;
+        let tool = RecordApprovalTool {
+            pending: PendingApprovalStore::default(),
+        };
 
         let res = tool
             .execute(json!({ "action": "force-push feature/x", "detail": "git push -f" }))
@@ -401,13 +565,76 @@ mod tests {
 
     #[tokio::test]
     async fn record_approval_accepts_empty_arguments_after_spoken_consent() {
-        let tool = RecordApprovalTool;
+        let tool = RecordApprovalTool {
+            pending: PendingApprovalStore::default(),
+        };
         let res = tool.execute(json!({})).await;
         let ToolExecutionResult::Success(value) = res else {
             panic!("expected success");
         };
         assert_eq!(value["action"], FALLBACK_APPROVAL_ACTION);
         assert!(value["detail"].is_null());
+    }
+
+    #[tokio::test]
+    async fn request_approval_publishes_the_pause_for_the_host() {
+        let pending = PendingApprovalStore::default();
+        let tool = RequestApprovalTool {
+            pending: pending.clone(),
+        };
+        assert_eq!(pending.peek(), None);
+
+        let res = tool
+            .execute(json!({
+                "action": "squash-merge PR #677",
+                "question": "CI is green and no comments are open. Merge it?",
+            }))
+            .await;
+        let ToolExecutionResult::Success(value) = res else {
+            panic!("expected success");
+        };
+        assert_eq!(value["awaiting_approval"], true);
+        assert_eq!(
+            pending.peek(),
+            Some(PendingApproval {
+                action: "squash-merge PR #677".into(),
+                question: "CI is green and no comments are open. Merge it?".into(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn request_approval_without_a_question_still_reads_as_a_question() {
+        let pending = PendingApprovalStore::default();
+        let tool = RequestApprovalTool {
+            pending: pending.clone(),
+        };
+        tool.execute(json!({ "action": "deploy to production" }))
+            .await;
+        assert_eq!(
+            pending.peek().map(|p| p.question),
+            Some(FALLBACK_APPROVAL_QUESTION.to_string())
+        );
+    }
+
+    /// Consent ends the pause: the host must not go on telling the user it is
+    /// waiting for an answer they have already given.
+    #[tokio::test]
+    async fn recording_an_approval_clears_the_pause() {
+        let pending = PendingApprovalStore::default();
+        RequestApprovalTool {
+            pending: pending.clone(),
+        }
+        .execute(json!({ "action": "squash-merge PR #677" }))
+        .await;
+        assert!(pending.peek().is_some());
+
+        RecordApprovalTool {
+            pending: pending.clone(),
+        }
+        .execute(json!({ "action": "squash-merge PR #677" }))
+        .await;
+        assert_eq!(pending.peek(), None);
     }
 
     #[tokio::test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -4,7 +4,9 @@
 // module boundary here small; capability implementations live in submodules.
 
 pub(crate) mod agent_commands;
-pub(crate) mod approval;
+// `pub` rather than `pub(crate)`: `BuiltRuntime` hands hosts the session's
+// pending soft-approval so a pause is visible in the UI.
+pub mod approval;
 pub(crate) mod ast_grep;
 pub(crate) mod attribution;
 pub(crate) mod background;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10242,7 +10242,12 @@ mod tests {
     /// silently.
     #[test]
     fn system_prompt_within_budget() {
-        const MAX_BYTES: usize = 1_360;
+        // 1_440 since #679 spent the previous 1_360 on the output guidance
+        // ("never use the word `seam` or other LLM-isms") and took system.md
+        // to 1_414 without moving the cap, leaving `main` red. Raised to that
+        // plus the ~20 bytes of headroom the cap has always carried, rather
+        // than trimming guidance that was added deliberately.
+        const MAX_BYTES: usize = 1_440;
         assert!(
             SYSTEM_PROMPT.len() <= MAX_BYTES,
             "SYSTEM_PROMPT is {} bytes (~{} tokens), cap is {} bytes",

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2759,6 +2759,10 @@ pub struct BuiltRuntime {
     pub model: ModelState,
     pub goal_store: Arc<GoalStore>,
     pub user_ask_store: Arc<UserAskStore>,
+    /// The critical action the session is waiting on the user to approve, if
+    /// any. Hosts read it when a turn ends so a soft-approval pause is shown
+    /// as a pause rather than as a turn that stopped mid-sentence.
+    pub pending_approval: crate::capabilities::approval::PendingApprovalStore,
     /// Whether the experimental `yolop_user_ask` capability was enabled.
     pub user_ask_enabled: bool,
     pub worktree: Arc<WorktreeManager>,
@@ -4274,9 +4278,11 @@ pub async fn build_with_options(
     ));
     // Soft approval — spoken-consent guidance + audit tool, gated by the
     // central `approval_mode` setting (read live each turn).
+    let pending_approval = crate::capabilities::approval::PendingApprovalStore::default();
     capabilities.register(ApprovalCapability {
         config: settings.clone(),
         settings: settings.clone(),
+        pending: pending_approval.clone(),
     });
     // Hard approval gate — the enforcement half of the same `approval_mode`.
     // Only registered when the host can service an interactive prompt (ACP);
@@ -4651,6 +4657,7 @@ pub async fn build_with_options(
         task_schedule_store,
         goal_store,
         user_ask_store,
+        pending_approval,
         user_ask_enabled,
         worktree,
     })

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -317,6 +317,12 @@ pub struct App {
     activity_scroll_metrics: (usize, usize),
     goal_store: Arc<GoalStore>,
     user_ask_store: Arc<UserAskStore>,
+    /// The critical action soft approval has stopped in front of, if any. Read
+    /// when a turn ends so the pause is shown as a pause.
+    pending_approval: crate::capabilities::approval::PendingApprovalStore,
+    /// The pause already announced, so a turn that ends without resolving it
+    /// does not repeat the notice.
+    awaiting_approval: Option<crate::capabilities::approval::PendingApproval>,
     user_ask_enabled: bool,
     completion_budget: crate::session_state::task_completion::CompletionBudget,
     worktree: Arc<WorktreeManager>,
@@ -708,6 +714,7 @@ impl App {
         let should_setup = runtime.startup.setup_recommended;
         let goal_store = runtime.goal_store.clone();
         let user_ask_store = runtime.user_ask_store.clone();
+        let pending_approval = runtime.pending_approval.clone();
         let user_ask_enabled = runtime.user_ask_enabled;
         let session_id = runtime.handles.session_id;
         let session_store = runtime.handles.session_store.clone();
@@ -791,6 +798,8 @@ impl App {
             activity_scroll_metrics: (0, 0),
             goal_store,
             user_ask_store,
+            pending_approval,
+            awaiting_approval: None,
             user_ask_enabled,
             completion_budget: Default::default(),
             worktree: runtime.worktree,
@@ -1411,6 +1420,27 @@ impl App {
         });
     }
 
+    /// Say out loud that the turn ended on a soft-approval pause.
+    ///
+    /// Without this the turn simply stops: the model's own last words are
+    /// whatever it chose to say, which reads the same whether it finished or
+    /// is waiting on a yes. `request_approval` is the fact that separates the
+    /// two, so surface it, and only once per pause — the answer arrives in the
+    /// user's next message, not at the end of this turn.
+    fn announce_pending_approval(&mut self) {
+        let Some(pending) = self.pending_approval.peek() else {
+            return;
+        };
+        if self.awaiting_approval.as_ref() == Some(&pending) {
+            return;
+        }
+        self.push_system(format!(
+            "⏸ waiting for your approval — {} · {} (reply \"yes\" to proceed)",
+            pending.action, pending.question
+        ));
+        self.awaiting_approval = Some(pending);
+    }
+
     fn begin_compact_turn(&mut self, started_at: Instant) {
         if self.work_display != WorkDisplayMode::Compact {
             return;
@@ -1909,6 +1939,7 @@ impl App {
                     if self.start_next_queued_turn() {
                         return Ok(());
                     }
+                    self.announce_pending_approval();
                     self.after_turn_goal_check().await;
                     if !self.busy {
                         self.after_turn_user_ask_check(result).await;
@@ -3009,6 +3040,11 @@ impl App {
         }
         let image_count = self.pending_images.len();
         let display = crate::tui::input::image_input::user_display_text(&display_text, image_count);
+        // The user has spoken, so whatever soft approval was waiting on is
+        // answered now — approved, refused, or overtaken by a new ask. Either
+        // way the session is no longer blocked on them.
+        self.pending_approval.resolve();
+        self.awaiting_approval = None;
         self.push_user(display.clone());
         let images = std::mem::take(&mut self.pending_images);
         if self.busy {
@@ -7174,6 +7210,52 @@ flowchart TD
         app: App,
         _workspace: tempfile::TempDir,
         _sessions: tempfile::TempDir,
+    }
+
+    /// A soft-approval pause is invisible unless the host says so: the
+    /// model's own last words read the same whether it finished or is waiting
+    /// on a yes. Announce it once, and stop announcing once the user answers.
+    #[tokio::test]
+    async fn a_soft_approval_pause_is_announced_once_and_cleared_by_the_reply() {
+        let mut test = app_with_llmsim().await;
+        let pending = test.app.pending_approval.clone();
+        assert!(pending.peek().is_none());
+
+        test.app.announce_pending_approval();
+        assert!(
+            !system_lines(&test.app).iter().any(|l| l.contains("⏸")),
+            "nothing is pending, so nothing should be announced"
+        );
+
+        // What `request_approval` leaves behind when the model pauses.
+        pending.set(crate::capabilities::approval::PendingApproval {
+            action: "squash-merge PR #677".into(),
+            question: "CI is green. Merge it?".into(),
+        });
+
+        test.app.announce_pending_approval();
+        test.app.announce_pending_approval();
+        let waiting: Vec<String> = system_lines(&test.app)
+            .into_iter()
+            .filter(|line| line.contains("waiting for your approval"))
+            .collect();
+        assert_eq!(waiting.len(), 1, "announced more than once: {waiting:?}");
+        assert!(waiting[0].contains("squash-merge PR #677"));
+        assert!(waiting[0].contains("CI is green. Merge it?"));
+
+        // The user answering ends the pause, whichever way they answered.
+        test.app.set_input_text("no, hold off".into());
+        test.app.submit_input().await;
+        assert!(test.app.pending_approval.peek().is_none());
+        assert!(test.app.awaiting_approval.is_none());
+    }
+
+    fn system_lines(app: &App) -> Vec<String> {
+        app.lines
+            .iter()
+            .filter(|line| matches!(line.author, Author::System))
+            .map(|line| line.text.clone())
+            .collect()
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Two things, both aimed at the same failure: a session that stops without the user knowing it is waiting on them.

**A pause is now a tool call.** `request_approval` takes the action and one short question, and the model ends its turn on it. The TUI reads the resulting pending approval when the turn ends and prints an explicit waiting line — once per pause, cleared by `record_approval` or by the user's next message, whichever way they answered. The `<soft_approval>` block now names the announce-then-stop failure outright, because it is the one models actually make.

**`/ship` pre-authorizes its own push, PR, and squash-merge.** The block also learns that a workflow the user invoked by name can carry that grant, scoped to the actions that workflow exists to perform.

It also carries a one-line fix for a `main` breakage that was blocking every PR — see *Base-branch fix* below.

## Why

From a real session (`session_01a08bf35cde74c0a72515d582b765ec`), turn ending at 17:11:32:

> CI is fully green, no comments to sweep, mergeable. Squash-merging.

Then nothing, for eight minutes, until the user typed "Do this" and the merge ran. OpenRouter's trace for that generation confirms `finish_reason: stop` with `tool_name: null` — the model genuinely chose to end the turn. Soft approval was working: `gh pr merge --squash` is outward-facing, and the block says to stop and ask.

Two problems with how it worked.

Prose cannot express a pause. A turn ending on "Squash-merging." is indistinguishable from a turn that finished — text, then nothing — so the user reads a working gate as a broken agent, and answers it with a "do this" that carries no information. The same session never called `record_approval` either, so the audit half was skipped too.

And the instructions contradicted each other. `.agents/skills/ship/SKILL.md` said to merge once CI was green; the approval block said to stop before pushing, opening PRs, and anything outward-facing. Nothing reconciled them, so the model resolved it differently each time: that same run pushed the branch and opened the PR with no pause at all, then halted at the merge. The gate that actually protects that merge is green CI and a clean comment sweep, not a second yes.

## Before / After

**Before** — the turn simply ends. Nothing on screen says yolop is waiting:

```
CI is fully green, no comments to sweep, mergeable. Squash-merging.
```

**After** — the pause is a fact the host can render:

```
CI is green and no comments are open. Squash-merge PR #677?
⏸ waiting for your approval — squash-merge PR #677 · CI is green. Merge it? (reply "yes" to proceed)
```

Covered by `a_soft_approval_pause_is_announced_once_and_cleared_by_the_reply`, which also pins the once-per-pause behaviour and that submitting any reply clears it.

Under `/ship`, the merge no longer pauses at all.

Verification on the current head: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, and `cargo test --workspace --features yolop-yep/schema` (**1369 passed, 0 failed**), plus the llmsim smoke:

```
$ cargo run --quiet --features yolop-yep/schema -- --provider llmsim -p "hi"
I'm running in offline mode (llmsim — no API key set). ...
```

## Base-branch fix

`main` has been red since [#679](https://github.com/everruns/yolop/pull/679), independently of this change. That PR added the output guidance ("never use the word `seam` or other LLM-isms"), taking `src/runtime/system.md` from 1,340 to 1,414 bytes, but left the 1,360-byte cap [#642](https://github.com/everruns/yolop/pull/642) set. `runtime::tests::system_prompt_within_budget` has failed on every commit since, reproduced on a clean `origin/main` worktree:

```
$ git worktree add /tmp/mainwt origin/main     # 4236273
SYSTEM_PROMPT is 1414 bytes (~353 tokens), cap is 1360 bytes
test result: FAILED. 0 passed; 1 failed
```

No PR branched off `main` can reach green while that stands, so [6dfd00b](https://github.com/everruns/yolop/commit/6dfd00b) ports the fix here: the cap goes to 1,440, the current size plus the ~20 bytes of headroom it has always carried. Bumping rather than trimming, since #679's guidance was deliberate and the cap is a ratchet meant to be moved on purpose — the step #679 missed. It no-ops once `main` carries the same fix. Reviewable as its own commit.

This branch is also merged up to `origin/main` (4236273).

## Risk

- Low
- `request_approval` is deliberately non-deferrable: the model has to find it at the instant it decides to pause, so it cannot sit behind `tool_search`. That makes it always provider-visible, and it had to pay for itself — its description and the `<soft_approval>` block are written tight so both `always_on_capability_prompts_within_budget` and `cold_start_prompt_composition_is_measured_by_component` still pass.
- The tool-definition guard now clears by 16 bytes (25,705 against a 25,721 ceiling). I trimmed to fit rather than move the ratchet, but the next eager tool will trip it and should re-baseline deliberately. Called out under Follow-ups.
- The `/ship` grant is scoped: it reaches push, PR, and the squash-merge for the change in hand. Force-pushing, history rewrites, reverting on main, and touching another PR still require the question.
- Soft approval remains prompt-engineering, not enforcement. Nothing here changes the hard `approval_policy` gate or the sandbox boundary.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

[`knowledge/specs/approval.md`](knowledge/specs/approval.md) gains two sections: *The pause is a tool call* and *Workflows carry their own grant*. `knowledge/log.md` records the entry.

## Security

TM-LLM (prompt construction) and TM-TOOL (capability registration) are the relevant categories.

`request_approval` mirrors `record_approval`: a non-deferrable builtin whose arguments land in the session's owner-only `events.jsonl`, with the same explicit no-secrets instruction in its description. It performs no side effect beyond setting an in-memory flag, so it cannot be used to reach anything. `PendingApprovalStore` is process-local shared state, never persisted and never sent to a provider.

Worth stating plainly: this PR *narrows* where yolop pauses, by pre-authorizing `/ship`'s push, PR, and merge. That is a deliberate policy change, argued above — those three are what the workflow exists to do, and the merge is already gated on green CI and a clean sweep. It does not touch the hard approval gate, the write blocklist, or the sandbox. No findings.

## Follow-ups

- `cold_start_prompt_composition_is_measured_by_component` now passes with 16 bytes of headroom. The next always-visible tool should re-baseline `BASELINE_TOOL_DEFINITION_BYTES` deliberately rather than shaving descriptions to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FwmauZkP2Gx9bq1aVgHWY