### PR TITLE
MCP mutations go through the CLI with auto-reload

### DIFF
--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -253,10 +253,11 @@ runtime's sandboxed execution boundary.
 
 Secret-entry tools are different. The connector `connect` tool is omitted in
 ACP because its arguments carry credentials through the transcript. Connector
-discovery and disconnection remain available. `upsert_mcp_server` accepts
-environment placeholders such as `${MCP_TOKEN}`, but rejects literal values in
-credential-bearing header and environment fields; browser OAuth remains
-available through `/mcp login`.
+discovery and disconnection remain available. MCP mutations are CLI-only: there are no mutation model
+tools, so servers are added, removed, enabled, or disabled with `yolop mcp ...` (files on disk) or
+`/mcp ...` via run_command (live session, which reloads by default and accepts `--no-reload` to defer).
+Secrets belong in environment placeholders such as `${MCP_TOKEN}`; literals at the CLI are the operator's
+explicit choice. Browser OAuth remains available through `yolop mcp login` and `/mcp login`.
 
 ACP cannot replace or retract the transcript already displayed by its client.
 Checkpoint commands and `manage_checkpoint` therefore expose workspace restore

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -34,7 +34,8 @@ pub(crate) const CLIENT_COMMANDS_PROMPT: &str = r#"Terminal commands, all runnab
 `/cwd`, `/status [compact|expanded|toggle]`, `/model [id]`, `/effort [level]`,
 `/clear`, `/quit` (`/exit` alias). Run them on prose requests such as "exit",
 "clear the screen", "show tools", "switch model", "restart MCP", "reconnect MCP",
-or "refresh MCP" (`/mcp reload`), "log in to an MCP server" (`/mcp login <name>`);
+or "refresh MCP" (`/mcp reload`), "log in to an MCP server" (`/mcp login <name>`),
+    "add/remove/enable/disable an MCP server" (`/mcp <verb> <name>`, reloads live unless `--no-reload`);
 never invent a manager window. `/shell` is typed-only; use `bash`."#;
 
 pub(crate) struct ClientCommandsCapability {
@@ -107,7 +108,7 @@ fn command_descriptors() -> Vec<CommandDescriptor> {
         cmd("tools", "list available tools", &[]),
         cmd(
             "mcp",
-            "list/reload/login or enable/disable/remove MCP servers live",
+            "add/list/reload/login or enable/disable/remove MCP servers live",
             &[opt("action")],
         ),
         cmd("cwd", "show workspace root", &[]),

--- a/src/capabilities/mcp.rs
+++ b/src/capabilities/mcp.rs
@@ -1,5 +1,5 @@
 use crate::capabilities::narration::stable_labeled;
-use crate::config::mcp::{McpConfigScope, McpConfigStore, McpServerEntry};
+use crate::config::mcp::McpConfigStore;
 use async_trait::async_trait;
 use everruns_core::tool_narration::ToolNarrationPhase;
 use everruns_core::{Capability, CapabilityStatus};
@@ -12,7 +12,6 @@ pub(crate) const MCP_CAPABILITY_ID: &str = "mcp";
 
 pub(crate) struct McpCapability {
     pub(crate) store: Arc<McpConfigStore>,
-    pub(crate) allow_literal_credentials: bool,
 }
 
 #[async_trait]
@@ -33,26 +32,16 @@ impl Capability for McpCapability {
         Some("Extensibility")
     }
 
-    // No system-prompt contribution: the four tool descriptions already name the
-    // verbs and the `/mcp reload` timing, and the file layout moved into
-    // `upsert_mcp_server`'s description where it is needed to fill in `scope`.
+    // No system-prompt contribution: mutations live on the command path
+    // (`yolop mcp ...`, `/mcp ...` via run_command), documented there.
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(ListMcpServersTool {
-                store: self.store.clone(),
-            }),
-            Box::new(UpsertMcpServerTool {
-                store: self.store.clone(),
-                allow_literal_credentials: self.allow_literal_credentials,
-            }),
-            Box::new(RemoveMcpServerTool {
-                store: self.store.clone(),
-            }),
-            Box::new(SetMcpServerEnabledTool {
-                store: self.store.clone(),
-            }),
-        ]
+        // Mutations are CLI-only (`yolop mcp ...` and `/mcp ...` reached through
+        // run_command). The model gets the read-only list; nothing here competes
+        // with the command path, so there is no second reload story to forget.
+        vec![Box::new(ListMcpServersTool {
+            store: self.store.clone(),
+        })]
     }
 }
 
@@ -96,336 +85,45 @@ impl Tool for ListMcpServersTool {
     }
 }
 
-struct UpsertMcpServerTool {
-    store: Arc<McpConfigStore>,
-    allow_literal_credentials: bool,
-}
-
-#[async_trait]
-impl Tool for UpsertMcpServerTool {
-    fn narrate(
-        &self,
-        _tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        _locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        Some(stable_labeled("Upsert MCP server", None, phase))
-    }
-    fn name(&self) -> &str {
-        "upsert_mcp_server"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Upsert MCP server")
-    }
-    fn description(&self) -> &str {
-        "Create or replace one global or workspace MCP server. Global servers live in \
-         settings.toml under `[mcp.servers.<name>]`; workspace servers live in `.mcp.json` and \
-         override global servers by name. Changes take effect on the next `/mcp reload` or a \
-         new session."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": { "type": "string", "enum": ["global", "workspace"], "default": "global" },
-                "name": { "type": "string", "minLength": 1 },
-                "server": {
-                    "type": "object",
-                    "description": "MCP server config. Supports remote HTTP servers and OAuth-capable metadata such as auth_mode='oauth', oauth_provider_id, headers, and enabled=false.",
-                    "additionalProperties": true
-                }
-            },
-            "required": ["name", "server"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let scope = parse_scope(arguments.get("scope"));
-        let name = match arguments
-            .get("name")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-        {
-            Some(name) => name.to_string(),
-            None => return ToolExecutionResult::tool_error("name is required"),
-        };
-        let server_value = match arguments.get("server") {
-            Some(value) => value.clone(),
-            None => return ToolExecutionResult::tool_error("server is required"),
-        };
-        if !self.allow_literal_credentials
-            && let Some(field) = literal_credential_field(&server_value)
-        {
-            return ToolExecutionResult::tool_error(format!(
-                "ACP cannot enter credentials securely through model tools; replace literal `{field}` with an environment placeholder such as `${{MCP_TOKEN}}`, or use `/mcp login`"
-            ));
-        }
-        let entry: McpServerEntry = match serde_json::from_value(server_value) {
-            Ok(entry) => entry,
-            Err(err) => {
-                return ToolExecutionResult::tool_error(format!(
-                    "invalid MCP server config: {err}"
-                ));
-            }
-        };
-        match self.store.upsert(scope, &name, entry) {
-            Ok(summary) => ToolExecutionResult::success(json!({ "ok": true, "server": summary })),
-            Err(err) => ToolExecutionResult::tool_error(err),
-        }
-    }
-}
-
-struct RemoveMcpServerTool {
-    store: Arc<McpConfigStore>,
-}
-
-#[async_trait]
-impl Tool for RemoveMcpServerTool {
-    fn narrate(
-        &self,
-        _tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        _locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        Some(stable_labeled("Remove MCP server", None, phase))
-    }
-    fn name(&self) -> &str {
-        "remove_mcp_server"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Remove MCP server")
-    }
-    fn description(&self) -> &str {
-        "Remove one MCP server from global settings or workspace .mcp.json."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": { "type": "string", "enum": ["global", "workspace"], "default": "global" },
-                "name": { "type": "string", "minLength": 1 }
-            },
-            "required": ["name"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let scope = parse_scope(arguments.get("scope"));
-        let name = match arguments
-            .get("name")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-        {
-            Some(name) => name,
-            None => return ToolExecutionResult::tool_error("name is required"),
-        };
-        match self.store.remove(scope, name) {
-            Ok(removed) => ToolExecutionResult::success(json!({ "ok": true, "removed": removed })),
-            Err(err) => ToolExecutionResult::tool_error(err),
-        }
-    }
-}
-
-struct SetMcpServerEnabledTool {
-    store: Arc<McpConfigStore>,
-}
-
-#[async_trait]
-impl Tool for SetMcpServerEnabledTool {
-    fn narrate(
-        &self,
-        _tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        _locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        Some(stable_labeled("Set MCP server enabled", None, phase))
-    }
-    fn name(&self) -> &str {
-        "set_mcp_server_enabled"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Set MCP server enabled")
-    }
-    fn description(&self) -> &str {
-        "Enable or disable one MCP server without deleting it. Changes take effect on the next `/mcp reload` or a new session."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "scope": { "type": "string", "enum": ["global", "workspace"], "default": "global" },
-                "name": { "type": "string", "minLength": 1 },
-                "enabled": { "type": "boolean" }
-            },
-            "required": ["name", "enabled"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let scope = parse_scope(arguments.get("scope"));
-        let name = match arguments
-            .get("name")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-        {
-            Some(name) => name,
-            None => return ToolExecutionResult::tool_error("name is required"),
-        };
-        let enabled = match arguments.get("enabled").and_then(Value::as_bool) {
-            Some(enabled) => enabled,
-            None => return ToolExecutionResult::tool_error("enabled is required"),
-        };
-        match self.store.set_enabled(scope, name, enabled) {
-            Ok(summary) => ToolExecutionResult::success(json!({ "ok": true, "server": summary })),
-            Err(err) => ToolExecutionResult::tool_error(err),
-        }
-    }
-}
-
-fn parse_scope(value: Option<&Value>) -> McpConfigScope {
-    match value.and_then(Value::as_str) {
-        Some("workspace") | Some("local") => McpConfigScope::Workspace,
-        _ => McpConfigScope::Global,
-    }
-}
-
-fn literal_credential_field(server: &Value) -> Option<String> {
-    for container in ["headers", "env"] {
-        let Some(fields) = server.get(container).and_then(Value::as_object) else {
-            continue;
-        };
-        for (name, value) in fields {
-            let Some(value) = value.as_str() else {
-                continue;
-            };
-            if credential_field_name(name) && !credential_value_uses_placeholder(name, value) {
-                return Some(format!("{container}.{name}"));
-            }
-        }
-    }
-    None
-}
-
-fn credential_field_name(name: &str) -> bool {
-    let normalized = name.to_ascii_lowercase().replace('_', "-");
-    matches!(
-        normalized.as_str(),
-        "authorization"
-            | "proxy-authorization"
-            | "cookie"
-            | "set-cookie"
-            | "api-key"
-            | "x-api-key"
-            | "x-auth-token"
-    ) || normalized.contains("token")
-        || normalized.contains("secret")
-        || normalized.contains("api-key")
-        || normalized.contains("apikey")
-}
-
-fn credential_value_uses_placeholder(name: &str, value: &str) -> bool {
-    let value = value.trim();
-    if is_env_placeholder(value) {
-        return true;
-    }
-    let normalized = name.to_ascii_lowercase().replace('_', "-");
-    if matches!(normalized.as_str(), "authorization" | "proxy-authorization")
-        && let Some((scheme, credential)) = value.split_once(char::is_whitespace)
-    {
-        return matches!(scheme.to_ascii_lowercase().as_str(), "bearer" | "basic")
-            && is_env_placeholder(credential.trim());
-    }
-    false
-}
-
-fn is_env_placeholder(value: &str) -> bool {
-    value
-        .strip_prefix("${")
-        .and_then(|value| value.strip_suffix('}'))
-        .is_some_and(|name| {
-            !name.is_empty()
-                && name
-                    .chars()
-                    .all(|character| character == '_' || character.is_ascii_alphanumeric())
-        })
-}
+// MCP mutations live on the command path (`yolop mcp ...`, `/mcp ...`);
+// this capability intentionally exposes no mutation tools.
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn upsert_tool(root: &std::path::Path, allow_literal_credentials: bool) -> UpsertMcpServerTool {
-        UpsertMcpServerTool {
-            store: Arc::new(McpConfigStore::new(
-                root.join("settings.toml"),
-                root.to_path_buf(),
-            )),
-            allow_literal_credentials,
-        }
+    fn test_store() -> (tempfile::TempDir, Arc<McpConfigStore>) {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let store = Arc::new(McpConfigStore::new(
+            tmp.path().join("settings.toml"),
+            tmp.path().to_path_buf(),
+        ));
+        (tmp, store)
+    }
+
+    #[test]
+    fn tools_exposes_only_read_operations() {
+        let (_tmp, store) = test_store();
+        let capability = McpCapability { store };
+        let names: Vec<_> = capability
+            .tools()
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        assert_eq!(names, vec!["list_mcp_servers".to_string()]);
     }
 
     #[tokio::test]
-    async fn acp_rejects_literal_mcp_credentials() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let result = upsert_tool(tmp.path(), false)
-            .execute(json!({
-                "name": "docs",
-                "server": {
-                    "type": "http",
-                    "url": "https://example.com/mcp",
-                    "headers": { "Authorization": "Bearer secret" }
-                }
-            }))
-            .await;
-
-        match result {
-            ToolExecutionResult::ToolError(message) => {
-                assert!(message.contains("ACP cannot enter credentials securely"));
-                assert!(message.contains("headers.Authorization"));
-            }
-            other => panic!("expected credential rejection, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn acp_accepts_mcp_environment_placeholders() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let result = upsert_tool(tmp.path(), false)
-            .execute(json!({
-                "name": "docs",
-                "server": {
-                    "type": "http",
-                    "url": "https://example.com/mcp",
-                    "headers": { "Authorization": "Bearer ${DOCS_TOKEN}" }
-                }
-            }))
-            .await;
-
-        assert!(result.is_success(), "{result:?}");
-    }
-
-    #[tokio::test]
-    async fn acp_rejects_mixed_literal_and_placeholder_credentials() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let result = upsert_tool(tmp.path(), false)
-            .execute(json!({
-                "name": "docs",
-                "server": {
-                    "type": "http",
-                    "url": "https://example.com/mcp",
-                    "headers": {
-                        "Authorization": "Bearer literal-${DOCS_TOKEN}"
-                    }
-                }
-            }))
-            .await;
-
-        assert!(result.is_error(), "{result:?}");
+    async fn list_tool_reports_effective_configuration() {
+        let (_tmp, store) = test_store();
+        let tool = ListMcpServersTool {
+            store: store.clone(),
+        };
+        let result = tool.execute(json!({})).await;
+        let everruns_core::ToolExecutionResult::Success(value) = result else {
+            panic!("expected JSON success, got {result:?}");
+        };
+        assert_eq!(value["ok"], true);
+        assert!(value["servers"].is_array());
     }
 }

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -1,5 +1,5 @@
 use crate::config::{Settings, SettingsStore, default_settings_path};
-use everruns_core::{ScopedMcpServer, ScopedMcpServers};
+use everruns_core::{McpServerAuthMode, McpServerTransportType, ScopedMcpServer, ScopedMcpServers};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
@@ -217,6 +217,28 @@ impl McpConfigStore {
             .into_iter()
             .find(|summary| summary.scope == scope && summary.name == name)
             .ok_or_else(|| format!("MCP server '{name}' not found"))
+    }
+}
+
+/// Transport aliases shared by `yolop mcp add` and `/mcp add`: legacy SSE
+/// servers ride the streamable HTTP transport.
+pub(crate) fn parse_mcp_transport(value: &str) -> Result<McpServerTransportType, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "stdio" => Ok(McpServerTransportType::Stdio),
+        "http" | "sse" => Ok(McpServerTransportType::Http),
+        other => Err(format!("unknown transport `{other}` (stdio|http|sse)")),
+    }
+}
+
+/// Auth aliases shared by `yolop mcp add` and `/mcp add`.
+pub(crate) fn parse_mcp_auth(value: &str) -> Result<McpServerAuthMode, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "none" => Ok(McpServerAuthMode::None),
+        "bearer" | "api_key" | "api-key" => Ok(McpServerAuthMode::ApiKey),
+        "oauth" | "o_auth" => Ok(McpServerAuthMode::OAuth),
+        other => Err(format!(
+            "unknown auth mode `{other}` (none|bearer|api_key|oauth)"
+        )),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,7 @@ enum Commands {
 #[derive(Args, Debug)]
 struct McpArgs {
     #[command(subcommand)]
-    command: McpCommand,
+    command: Box<McpCommand>,
 }
 
 #[derive(Args, Debug)]
@@ -349,6 +349,14 @@ enum McpCommand {
         /// Header as KEY=VALUE. Repeat for multiple headers.
         #[arg(long = "header", value_parser = parse_key_value)]
         headers: Vec<(String, String)>,
+
+        /// Environment variable as KEY=VALUE. Repeat for multiple entries.
+        #[arg(long = "env", value_parser = parse_key_value)]
+        env: Vec<(String, String)>,
+
+        /// After saving, immediately start the OAuth browser login for the server.
+        #[arg(long = "login")]
+        login: bool,
         /// Auth mode (`bearer`, `oauth`, or `none`).
         #[arg(long)]
         auth_mode: Option<String>,
@@ -1150,6 +1158,44 @@ async fn run_mcp_command(command: McpCommand) -> Result<()> {
         Ok(McpConfigStore::default_for_workspace(&workspace_root))
     }
 
+    async fn login_mcp_server(cwd: Option<PathBuf>, name: &str) -> anyhow::Result<()> {
+        let servers = store(cwd)?
+            .effective()
+            .map_err(anyhow::Error::msg)?
+            .servers
+            .into_iter()
+            .find(|server| server.name == *name && server.effective)
+            .with_context(|| format!("MCP server `{name}` was not found in effective scope"))?;
+        let scoped = &servers.server.server;
+        if scoped.transport_type != McpServerTransportType::Http {
+            return Err(anyhow::Error::msg(format!(
+                "MCP server `{name}` is a stdio server; OAuth login only applies to remote HTTP servers"
+            )));
+        }
+        let provider_key = scoped
+            .oauth_provider_id
+            .clone()
+            .unwrap_or_else(|| name.to_string());
+        println!("Opening the browser to log in to MCP server `{name}` ...");
+        let prepared = auth::mcp_oauth_login::prepare_login(&scoped.url, None, None).await?;
+        println!(
+            "If the browser did not open, visit this URL:\n{}\n",
+            prepared.authorize_url
+        );
+        if let Err(error) = auth::oauth_flow::open_browser(prepared.authorize_url.as_str()) {
+            eprintln!("warning: could not open the browser: {error:#}");
+        }
+        println!("Waiting for the browser login to complete ...");
+        let tokens = auth::mcp_oauth_login::complete_login(prepared).await?;
+        let fallback = PathBuf::from("/dev/null/yolop");
+        let connections_path = connectors::default_connections_path()
+            .unwrap_or_else(|| fallback.join("connections.toml"));
+        let connections = connectors::ConnectionStore::open(connections_path);
+        auth::mcp_oauth::save_tokens(&connections, &provider_key, tokens)?;
+        println!("Logged in to MCP server `{name}`.");
+        Ok(())
+    }
+
     fn write_scope(scope: McpScopeArg) -> Result<McpConfigScope> {
         match scope {
             McpScopeArg::Global => Ok(McpConfigScope::Global),
@@ -1205,43 +1251,7 @@ async fn run_mcp_command(command: McpCommand) -> Result<()> {
             }
             Ok(())
         }
-        McpCommand::Login { name, cwd } => {
-            let servers = store(cwd)?
-                .effective()
-                .map_err(anyhow::Error::msg)?
-                .servers
-                .into_iter()
-                .find(|server| server.name == *name && server.effective)
-                .with_context(|| format!("MCP server `{name}` was not found in effective scope"))?;
-            let scoped = &servers.server.server;
-            if scoped.transport_type != McpServerTransportType::Http {
-                return Err(anyhow::Error::msg(format!(
-                    "MCP server `{name}` is a stdio server; OAuth login only applies to remote HTTP servers"
-                )));
-            }
-            let provider_key = scoped
-                .oauth_provider_id
-                .clone()
-                .unwrap_or_else(|| name.clone());
-            println!("Opening the browser to log in to MCP server `{name}` ...");
-            let prepared = auth::mcp_oauth_login::prepare_login(&scoped.url, None, None).await?;
-            println!(
-                "If the browser did not open, visit this URL:\n{}\n",
-                prepared.authorize_url
-            );
-            if let Err(error) = auth::oauth_flow::open_browser(prepared.authorize_url.as_str()) {
-                eprintln!("warning: could not open the browser: {error:#}");
-            }
-            println!("Waiting for the browser login to complete ...");
-            let tokens = auth::mcp_oauth_login::complete_login(prepared).await?;
-            let fallback = PathBuf::from("/dev/null/yolop");
-            let connections_path = connectors::default_connections_path()
-                .unwrap_or_else(|| fallback.join("connections.toml"));
-            let connections = connectors::ConnectionStore::open(connections_path);
-            auth::mcp_oauth::save_tokens(&connections, &provider_key, tokens)?;
-            println!("Logged in to MCP server `{name}`.");
-            Ok(())
-        }
+        McpCommand::Login { name, cwd } => login_mcp_server(cwd, &name).await,
         McpCommand::Show { name, scope, cwd } => {
             let store = store(cwd)?;
             let server = store
@@ -1269,24 +1279,29 @@ async fn run_mcp_command(command: McpCommand) -> Result<()> {
             args,
             url,
             headers,
+            env,
+            login,
             auth_mode,
             oauth_provider_id,
             disabled,
             cwd,
         } => {
-            let transport = transport_type.to_ascii_lowercase();
-            let server = match transport.as_str() {
-                "stdio" => ScopedMcpServer {
+            let env: HashMap<String, String> = env.into_iter().collect();
+            let transport_type = crate::config::mcp::parse_mcp_transport(&transport_type)
+                .map_err(anyhow::Error::msg)?;
+            let server = match transport_type {
+                McpServerTransportType::Stdio => ScopedMcpServer {
                     transport_type: McpServerTransportType::Stdio,
                     command: Some(command.context("--command is required for stdio MCP servers")?),
                     args,
-                    env: HashMap::new(),
+                    env,
                     ..ScopedMcpServer::default()
                 },
-                "http" | "sse" => ScopedMcpServer {
+                McpServerTransportType::Http => ScopedMcpServer {
                     transport_type: McpServerTransportType::Http,
                     url: url.context("--url is required for remote MCP servers")?,
                     headers: headers.into_iter().collect(),
+                    env,
                     auth_mode: auth_mode
                         .as_deref()
                         .map(parse_mcp_auth_mode)
@@ -1295,11 +1310,8 @@ async fn run_mcp_command(command: McpCommand) -> Result<()> {
                     oauth_provider_id,
                     ..ScopedMcpServer::default()
                 },
-                other => anyhow::bail!(
-                    "unsupported MCP transport `{other}`; expected stdio, http, or sse"
-                ),
             };
-            let store = store(cwd)?;
+            let store = store(cwd.clone())?;
             let _summary = store
                 .upsert(
                     write_scope(scope)?,
@@ -1318,6 +1330,9 @@ async fn run_mcp_command(command: McpCommand) -> Result<()> {
             println!(
                 "restart or start a new yolop session for MCP connection changes to take effect"
             );
+            if login {
+                login_mcp_server(cwd, &name).await?;
+            }
             Ok(())
         }
         McpCommand::Remove { scope, name, cwd } => {
@@ -1380,14 +1395,7 @@ fn mcp_scope_label(scope: McpConfigScope) -> &'static str {
 }
 
 fn parse_mcp_auth_mode(value: &str) -> Result<everruns_core::McpServerAuthMode> {
-    match value.to_ascii_lowercase().as_str() {
-        "none" => Ok(everruns_core::McpServerAuthMode::None),
-        "bearer" | "api_key" | "api-key" => Ok(everruns_core::McpServerAuthMode::ApiKey),
-        "oauth" | "o_auth" => Ok(everruns_core::McpServerAuthMode::OAuth),
-        other => anyhow::bail!(
-            "unsupported auth mode `{other}`; expected none, bearer/api_key, or oauth"
-        ),
-    }
+    crate::config::mcp::parse_mcp_auth(value).map_err(anyhow::Error::msg)
 }
 
 async fn run_command(command: Commands) -> Result<()> {
@@ -1396,7 +1404,7 @@ async fn run_command(command: Commands) -> Result<()> {
             println!("{}", version::VERSION_LINE);
             Ok(())
         }
-        Commands::Mcp(args) => run_mcp_command(args.command).await,
+        Commands::Mcp(args) => run_mcp_command(*args.command).await,
         Commands::Weights(args) => run_weights_command(args.command).await,
         Commands::TuikaGallery => run_tuika_gallery(),
         #[cfg(target_os = "linux")]
@@ -2497,6 +2505,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mcp_add_env_entries_persist() {
+        let dir = tempfile::tempdir().expect("temp cwd");
+        let cwd = dir.path().join("work");
+        std::fs::create_dir_all(&cwd).expect("create temp cwd");
+        run_mcp_command(McpCommand::Add {
+            scope: McpScopeArg::Workspace,
+            name: "env-demo".to_string(),
+            transport_type: "stdio".to_string(),
+            command: Some("true".to_string()),
+            args: Vec::new(),
+            url: None,
+            headers: Vec::new(),
+            env: vec![("TOKEN".to_string(), "abc".to_string())],
+            login: false,
+            auth_mode: None,
+            oauth_provider_id: None,
+            disabled: false,
+            cwd: Some(cwd.clone()),
+        })
+        .await
+        .expect("add persists env");
+        let servers = McpConfigStore::default_for_workspace(&cwd)
+            .effective()
+            .expect("read back effective config")
+            .servers;
+        let saved = servers
+            .iter()
+            .find(|server| server.name == "env-demo")
+            .expect("added server is present");
+        assert_eq!(
+            saved.server.server.env.get("TOKEN").map(String::as_str),
+            Some("abc")
+        );
+    }
+
+    #[tokio::test]
     async fn mcp_login_unknown_server_errors() {
         let cwd = std::env::temp_dir().join("yolop-mcp-login-unknown-server");
         std::fs::create_dir_all(&cwd).expect("create temp cwd");
@@ -2544,6 +2588,29 @@ mod tests {
             vec!["yolop", "mcp", "enable", "demo"],
             vec!["yolop", "mcp", "disable", "demo"],
             vec!["yolop", "mcp", "login", "demo"],
+            vec![
+                "yolop",
+                "mcp",
+                "add",
+                "demo",
+                "--type",
+                "stdio",
+                "--command",
+                "true",
+            ],
+            vec![
+                "yolop",
+                "mcp",
+                "add",
+                "demo",
+                "--type",
+                "http",
+                "--url",
+                "https://example.test/mcp",
+                "--env",
+                "TOKEN=abc",
+                "--login",
+            ],
         ] {
             Cli::try_parse_from(argv).expect("parse MCP command");
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4275,7 +4275,6 @@ pub async fn build_with_options(
     capabilities.register(YolopCapability);
     capabilities.register(YolopMcpCapability {
         store: Arc::new(McpConfigStore::default_for_workspace(&canonical_root)),
-        allow_literal_credentials: !matches!(options.client_ui, ClientUiContext::Acp),
     });
     // `progress_guard` — runtime-visible warnings when tool use stops making
     // observable progress.

--- a/src/tui/host_ui.rs
+++ b/src/tui/host_ui.rs
@@ -173,7 +173,7 @@ impl HostUi for RecordingUi {
             UiCommand::ManageMcp { .. } => {
                 vec![
                     "active MCP servers: none".into(),
-                    "usage: /mcp [reload | login <name> | enable|disable|remove <name> [global|workspace]]"
+                    "usage: /mcp [reload | login <name> | add <name> ... | enable|disable|remove <name> [global|workspace]] [--no-reload]"
                         .into(),
                 ]
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3454,8 +3454,7 @@ impl App {
         }
     }
 
-    const MCP_USAGE: &'static str =
-        "usage: /mcp [reload | login <name> | enable|disable|remove <name> [global|workspace]]";
+    const MCP_USAGE: &'static str = "usage: /mcp [reload | login <name> | add <name> [global|workspace] --type <stdio|http|sse> [options] [--login] | enable|disable|remove <name> [global|workspace]] [--no-reload]";
 
     async fn manage_mcp_command(&mut self, raw: Option<&str>) {
         let Some(raw) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
@@ -3464,7 +3463,7 @@ impl App {
                     .map(|p| p.display().to_string())
                     .unwrap_or_else(|| "the yolop config dir".to_string());
                 self.push_system(format!(
-                    "no MCP servers configured (add them with `yolop mcp add`, .mcp.json in the workspace root, or {global})"
+                    "no MCP servers configured (add them with `/mcp add`, `yolop mcp add`, .mcp.json in the workspace root, or {global})"
                 ));
             } else {
                 self.push_system(format!(
@@ -3476,11 +3475,13 @@ impl App {
             return;
         };
 
-        let mut parts = raw.split_whitespace();
+        let raw_parts: Vec<&str> = raw.split_whitespace().collect();
+        let no_reload = raw_parts.contains(&"--no-reload");
+        let mut parts = raw_parts.into_iter().filter(|part| *part != "--no-reload");
         let action = parts.next().unwrap_or_default();
 
         // `reload` re-reads config from disk (picking up `yolop mcp add`,
-        // hand edits, or the agent's own config tools) and applies it live.
+        // hand edits, or `/mcp add`) and applies it live.
         if action == "reload" {
             if parts.next().is_some() {
                 self.push_system(Self::MCP_USAGE.into());
@@ -3501,6 +3502,11 @@ impl App {
                 Some(name) => self.mcp_login(name).await,
                 None => self.push_system(Self::MCP_USAGE.into()),
             }
+            return;
+        }
+
+        if action == "add" {
+            self.mcp_add_command(parts.collect(), no_reload).await;
             return;
         }
 
@@ -3544,7 +3550,15 @@ impl App {
             }
         };
         match result {
-            Ok(message) => self.reload_mcp_and_report(Some(message)).await,
+            Ok(message) => {
+                if no_reload {
+                    self.push_system(format!(
+                        "{message} (saved; live reload skipped: --no-reload)"
+                    ));
+                } else {
+                    self.reload_mcp_and_report(Some(message)).await;
+                }
+            }
             Err(error) => self.push_system(format!("failed to update MCP config: {error}")),
         }
     }
@@ -3554,6 +3568,148 @@ impl App {
     /// (so fullscreen and inline both stay conversational if the browser is
     /// invisible), best-effort opens the browser, and completes in the
     /// background — same pattern as Codex login.
+    async fn mcp_add_command(&mut self, args: Vec<&str>, no_reload: bool) {
+        use crate::config::mcp::{
+            McpConfigScope, McpServerEntry, parse_mcp_auth, parse_mcp_transport,
+        };
+        use everruns_core::{McpServerAuthMode, McpServerTransportType, ScopedMcpServer};
+
+        let mut args = args.into_iter();
+        let Some(name) = args.next() else {
+            self.push_system(Self::MCP_USAGE.into());
+            return;
+        };
+        let mut scope = McpConfigScope::Global;
+        let mut transport = McpServerTransportType::Stdio;
+        let mut command: Option<String> = None;
+        let mut command_args: Vec<String> = Vec::new();
+        let mut url: Option<String> = None;
+        let mut headers: Vec<(String, String)> = Vec::new();
+        let mut env: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let mut auth = McpServerAuthMode::None;
+        let mut provider: Option<String> = None;
+        let mut disabled = false;
+        let mut login = false;
+        let mut positional = 0;
+        let mut usage_error: Option<String> = None;
+        for arg in args {
+            if usage_error.is_some() {
+                break;
+            }
+            if arg == "--login" {
+                login = true;
+            } else if arg == "--disabled" || arg == "--disable" {
+                disabled = true;
+            } else if arg == "--no-reload" {
+                // Filtered before dispatch; accepted here so flag order never matters.
+            } else if let Some(value) = arg
+                .strip_prefix("--type=")
+                .or(arg.strip_prefix("--transport="))
+            {
+                match parse_mcp_transport(value) {
+                    Ok(parsed) => transport = parsed,
+                    Err(error) => usage_error = Some(format!("error: {error}")),
+                }
+            } else if let Some(value) = arg.strip_prefix("--command=") {
+                command = Some(value.to_string());
+            } else if let Some(value) = arg.strip_prefix("--arg=") {
+                command_args.push(value.to_string());
+            } else if let Some(value) = arg.strip_prefix("--url=") {
+                url = Some(value.to_string());
+            } else if let Some(value) = arg.strip_prefix("--header=") {
+                match value.split_once('=') {
+                    Some((key, val)) => {
+                        headers.push((key.to_string(), val.to_string()));
+                    }
+                    None => {
+                        usage_error = Some(format!("`{value}` is not KEY=VALUE (--header)"));
+                    }
+                }
+            } else if let Some(value) = arg.strip_prefix("--env=") {
+                match value.split_once('=') {
+                    Some((key, val)) => {
+                        env.insert(key.to_string(), val.to_string());
+                    }
+                    None => {
+                        usage_error = Some(format!("`{value}` is not KEY=VALUE (--env)"));
+                    }
+                }
+            } else if let Some(value) = arg.strip_prefix("--auth=") {
+                match parse_mcp_auth(value) {
+                    Ok(parsed) => auth = parsed,
+                    Err(error) => usage_error = Some(format!("error: {error}")),
+                }
+            } else if let Some(value) = arg.strip_prefix("--provider=") {
+                provider = Some(value.to_string());
+            } else if arg.starts_with("--") {
+                usage_error = Some(format!("unknown flag `{arg}`"));
+            } else if positional == 0 && (arg == "global" || arg == "workspace") {
+                scope = if arg == "global" {
+                    McpConfigScope::Global
+                } else {
+                    McpConfigScope::Workspace
+                };
+                positional += 1;
+            } else {
+                usage_error = Some(format!("unexpected `{arg}`"));
+            }
+        }
+        if let Some(error) = usage_error {
+            self.push_system(format!("error: {error}\n{}", Self::MCP_USAGE));
+            return;
+        }
+        let (transport_type, url) = match transport {
+            McpServerTransportType::Http => {
+                let Some(url) = url else {
+                    self.push_system("error: remote servers need `--url=<https-url>`".into());
+                    return;
+                };
+                (McpServerTransportType::Http, url)
+            }
+            McpServerTransportType::Stdio => {
+                if command.is_none() {
+                    self.push_system("error: stdio servers need `--command=<bin>`".into());
+                    return;
+                }
+                (McpServerTransportType::Stdio, url.unwrap_or_default())
+            }
+        };
+        let store =
+            crate::config::mcp::McpConfigStore::default_for_workspace(&self.startup.workspace_root);
+        let entry = McpServerEntry {
+            enabled: !disabled,
+            server: ScopedMcpServer {
+                transport_type,
+                command,
+                args: command_args,
+                env,
+                url,
+                headers: headers.into_iter().collect(),
+                auth_mode: auth,
+                oauth_provider_id: provider,
+                ..Default::default()
+            },
+        };
+        if let Err(error) = store.upsert(scope, name, entry) {
+            self.push_system(format!("error: {error}"));
+            return;
+        }
+        let scope_label = format!("{scope:?}").to_lowercase();
+        let message = format!("added MCP server `{name}` ({scope_label}), live");
+        // A requested login needs the live server, so it implies a reload.
+        if login || !no_reload {
+            self.reload_mcp_and_report(Some(message)).await;
+        } else {
+            self.push_system(format!(
+                "{message} (saved; live reload skipped: --no-reload)"
+            ));
+            return;
+        }
+        if login {
+            self.mcp_login(name).await;
+        }
+    }
+
     async fn mcp_login(&mut self, name: &str) {
         let servers = crate::config::mcp::load_mcp_servers(
             &self.settings.snapshot(),
@@ -3561,7 +3717,7 @@ impl App {
         );
         let Some(server) = servers.get(name) else {
             self.push_system(format!(
-                "MCP server `{name}` is not configured or is disabled; add it and run `/mcp reload` first"
+                "MCP server `{name}` is not configured or is disabled; add it with `/mcp add` first"
             ));
             return;
         };
@@ -9845,6 +10001,101 @@ flowchart TD
                 .any(|line| line.text.contains("stdio server")
                     && line.text.contains("OAuth login only applies")),
             "stdio server should be rejected before any browser flow: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_add_stdio_server_goes_live() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.dispatch_command_for_test("mcp add cli-add workspace --command=true")
+            .await;
+        // The slash add saves and reloads by default: the prelude plus the
+        // live report naming the new server.
+        assert!(
+            app.lines.iter().any(|line| line
+                .text
+                .contains("added MCP server `cli-add` (workspace), live")),
+            "missing add report: {:?}",
+            app.lines
+        );
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("active MCP servers")
+                    && line.text.contains("cli-add")),
+            "added server is not live: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_add_no_reload_defers_liveness() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.dispatch_command_for_test("mcp add cli-staged workspace --command=true --no-reload")
+            .await;
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("live reload skipped: --no-reload")),
+            "missing skip report: {:?}",
+            app.lines
+        );
+        // Saved on disk but never swapped into the session: no live report.
+        assert!(
+            !app.lines
+                .iter()
+                .any(|line| line.text.contains("active MCP servers")),
+            "reload happened despite --no-reload: {:?}",
+            app.lines
+        );
+        // Deferral, not denial: an explicit reload picks the staged server up.
+        app.lines.clear();
+        app.dispatch_command_for_test("mcp reload").await;
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("active MCP servers")
+                    && line.text.contains("cli-staged")),
+            "staged server never went live: {:?}",
+            app.lines
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_disable_no_reload_defers_until_reload() {
+        let mut fixture = app_with_llmsim().await;
+        let app = &mut fixture.app;
+        app.dispatch_command_for_test("mcp add cli-live workspace --command=true")
+            .await;
+        app.lines.clear();
+        app.dispatch_command_for_test("mcp disable cli-live workspace --no-reload")
+            .await;
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("live reload skipped: --no-reload")),
+            "missing skip report: {:?}",
+            app.lines
+        );
+        // No live swap happened for the disable either.
+        assert!(
+            !app.lines
+                .iter()
+                .any(|line| line.text.contains("active MCP servers")),
+            "reload happened despite --no-reload: {:?}",
+            app.lines
+        );
+        // The deferred disable applies on the next explicit reload.
+        app.lines.clear();
+        app.dispatch_command_for_test("mcp reload").await;
+        assert!(
+            app.lines
+                .iter()
+                .any(|line| line.text.contains("active MCP servers: none")),
+            "disabled server still live after reload: {:?}",
             app.lines
         );
     }


### PR DESCRIPTION
## Summary

MCP server mutations had two owners: model tools (`upsert/remove/set-enabled`) that wrote config but left the live session stale, and the slash/CLI path that reloads. The tools' own description told the model to ask the user to run `/mcp reload`, which is the ask in the report. This change kills the three mutation tools (read-only `list` stays) and routes everything through one command path:

- New slash `\/mcp add <name> [global|workspace] --type <stdio|http|sse> [--command\/--arg\/--url\/--header\/--env\/--auth\/--provider\/--disabled] [--login] [--no-reload]`, mirroring `yolop mcp add` validation.
- Slash mutations (`add/enable/disable/remove`) reload the live session by default; `--no-reload` defers the swap (a later explicit reload still applies it). `--login` implies a reload, then chains the existing OAuth flow.
- `yolop mcp add` gains `--env KEY=VALUE` (repeatable, previously only possible via the killed tool) and `--login` (chains the extracted login flow, shared with `yolop mcp login`).
- Transport/auth alias tables live once in `config::mcp` and both frontends delegate to them.
- Prompts point the model at `/mcp` via `run_command` (never ask the user to type it); knowledge updated (`knowledge/specs/acp.md`).

## Before / After

Before: after adding a server the agent replied "reload MCP so the tools load (/mcp reload ...)" and waited.
After: the agent runs `/mcp add ...` (via `run_command`) or `yolop mcp ...`, and the session reloads itself. CLI smoke: `mcp add --env` persists, `list/show/disable/enable/remove` all behave (verified with an isolated HOME).

## Testing

- New entry-point tests: `mcp_add_stdio_server_goes_live`, `mcp_add_no_reload_defers_liveness`, `mcp_disable_no_reload_defers_until_reload` (TUI dispatch), `mcp_add_env_entries_persist` + extended CLI parse coverage (binary), list-only tools pin (capability).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo test --workspace --features yolop-yep/schema` green locally except one pre-existing environment-sensitive assertion (see Follow-ups); `python3 scripts/validate_okf.py knowledge --check-links` passes.
- Smoke: full `yolop mcp` add/list/show/disable/enable/remove cycle against an isolated HOME, plus `--provider llmsim` startup. No live-provider smoke (no Doppler secrets in this environment).

## Security

- TM-FS: writes reuse the existing `McpConfigStore` paths and `upsert` validation; no new paths, names stay TOML keys, no traversal. TM-BASH: no shell changes. TM-LLM: prompt delta is routing text only, no keys; net removal of three tool definitions. TM-TOOL: capability surface shrinks to the read-only list; `/mcp add` is reachable through the existing `run_command` approvals. TM-DEP: no new crates.
- Secrets: CLI `--env`/`--header` are operator-typed like the pre-existing `--header`; knowledge documents `${VAR}` placeholders with `/yolop mcp login` to finish auth. The old tool-level literal-credential guard is gone with the tools; shell approval gates agent-driven CLI use.

## Follow-ups

- `runtime cold_start_prompt_composition` budget asserts fail on macOS (prompt 14505 vs 14496; tool bytes 26069 vs the 11% ratchet) byte-identically with and without this change (verified via stash) while main CI (linux) is green; needs an environment-sensitivity pass, tracked separately, not touched here.
- Live-provider smoke for the removed-tools surface once Doppler secrets are available.
- `add --login` browser flow verified manually only (OAuth needs interaction).

Knowledge decision: updated `knowledge/specs/acp.md` (CLI-only mutations, reload default, placeholders).