### PR TITLE
fix(runtime): surface OpenRouter account gates as labeled links

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-09-11, OpenRouter account gates get a labeled way out
+
+- [Presentation](specs/presentation.md): OpenRouter failures the user can fix
+  (18+ attestation, data-policy / guardrail blocks) no longer stop on a
+  generic "misconfiguration" or "try again later" plus a JSON blob whose URL
+  terminals cannot autolink. The transcript replaces that apology with an
+  Assistant hint naming the missing confirmation or policy and a labeled
+  markdown link (`OpenRouter preferences`, `OpenRouter privacy settings`).
+  Assistant authorship is what makes the link OSC 8 in the TUI and visible
+  under compact work; a System hint would sit in collapsed details. The raw
+  provider body remains a `turn error:` line. `--print` and ACP emit the same
+  hints. Mandated-reasoning hints already used this shared follow-up list.
+
 ## 2026-09-11, First-class environment context and Paseo detection
 
 Environment context entries now render as first-class tags

--- a/knowledge/specs/presentation.md
+++ b/knowledge/specs/presentation.md
@@ -92,6 +92,14 @@ macOS). The fullscreen host must not also launch the URL from the reported mouse
 event. While mouse capture is active, link hover may set the terminal pointer
 through OSC 22, and must restore the default pointer when the session ends.
 
+Provider failures the user can fix (an OpenRouter account confirmation, a
+data-policy / guardrail block, a mandated reasoning effort) append an
+Assistant hint naming the action and a labeled markdown link, or a slash
+control such as `/effort`. The generic everruns apology ("misconfiguration",
+"try again later") is dropped when a classified hint exists, because it hides
+the action. The raw provider JSON stays as a System `turn error:` line for
+diagnosis. TUI, `--print`, and ACP share the same hints.
+
 Fullscreen mouse text selection is application-owned (mouse capture replaces the
 terminal's native drag-select). A left-drag across the transcript highlights and
 copies via OSC 52 on release. Bare modifier key events, which arrive when the

--- a/src/editor/acp/server.rs
+++ b/src/editor/acp/server.rs
@@ -1697,7 +1697,7 @@ async fn run_prompt_once(
                         "turn error: {error}"
                     ))),
                 );
-                if let Some(hint) = crate::runtime::reasoning::reasoning_error_hint(
+                for hint in crate::runtime::session::turn_failure_hints(
                     error,
                     session.model.reasoning_effort().as_deref(),
                 ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2472,9 +2472,7 @@ async fn collect_print_turn(
         && let Some(err) = &result.error
     {
         eprintln!("turn error: {err}");
-        if let Some(hint) =
-            runtime::reasoning::reasoning_error_hint(err, model.reasoning_effort().as_deref())
-        {
+        for hint in runtime::session::turn_failure_hints(err, model.reasoning_effort().as_deref()) {
             eprintln!("{hint}");
         }
     }

--- a/src/runtime/attestation.rs
+++ b/src/runtime/attestation.rs
@@ -1,18 +1,26 @@
-//! Guided hint for the OpenRouter account-attestation gate.
+//! Guided hints for OpenRouter account and data-policy gates.
 //!
-//! Some OpenRouter models refuse with HTTP 403 until the account completes a
-//! confirmation such as 18+ age verification. The provider body names the
-//! missing attestation types and points at the preferences page, but yolop
-//! surfaces the raw JSON inside `turn error:`, where the URL is glued to JSON
-//! punctuation and Ghostty cannot autolink it.
+//! Some OpenRouter models refuse until the account completes a confirmation
+//! (18+ age verification, HTTP 403) or until a data-policy setting allows the
+//! endpoint (paid-model training, HTTP 404). The provider body names the
+//! missing step and points at a settings page, but yolop used to surface the
+//! raw JSON inside `turn error:`, where the URL is glued to JSON punctuation
+//! and Ghostty cannot autolink it. The generic assistant apology
+//! ("misconfiguration", "try again later") is worse: it hides an action the
+//! user can take.
 //!
 //! Stopgap: classify the provider error text here and render a guided hint
-//! with a clean, standalone URL. Replace this with the upstream structured
-//! error once `everruns-openrouter` reports the gate as a first-class kind
-//! (attestation types plus confirm URL) instead of a JSON string.
+//! with a labeled markdown link. Assistant lines run through the tuika
+//! markdown renderer, so `[OpenRouter preferences](url)` becomes an OSC 8
+//! target. Compact work also shows Assistant lines, while a System hint would
+//! sit in collapsed details. Replace this with the upstream structured error
+//! once `everruns-openrouter` reports these gates as first-class kinds.
 
-/// Fallback confirm page when the provider body carries no usable URL.
+/// Fallback confirm page when an attestation body carries no usable URL.
 pub(crate) const OPENROUTER_PREFERENCES_URL: &str = "https://openrouter.ai/settings/preferences";
+
+/// Fallback data-policy page when a guardrail body carries no usable URL.
+pub(crate) const OPENROUTER_PRIVACY_URL: &str = "https://openrouter.ai/settings/privacy";
 
 /// An OpenRouter model gated behind account confirmations.
 pub(crate) struct AttestationRequirement {
@@ -20,6 +28,14 @@ pub(crate) struct AttestationRequirement {
     pub url: String,
     /// Raw `missing_attestation_types` entries, for example `age_18plus`.
     pub missing_types: Vec<String>,
+}
+
+/// An OpenRouter model blocked by the account's data-policy / guardrail filter.
+pub(crate) struct GuardrailBlock {
+    /// Clean settings URL safe to print on its own for terminal autolink.
+    pub url: String,
+    /// Humanized `ineligibility_reasons[].reason` entries.
+    pub reasons: Vec<String>,
 }
 
 /// Detect the OpenRouter attestation gate in a provider error message.
@@ -38,36 +54,150 @@ pub(crate) fn detect_openrouter_attestation(message: &str) -> Option<Attestation
     let message = message.replace("\\\"", "\"");
     Some(AttestationRequirement {
         url: first_clean_url(&message).unwrap_or_else(|| OPENROUTER_PREFERENCES_URL.to_string()),
-        missing_types: missing_attestation_types(&message),
+        missing_types: json_string_array(&message, "missing_attestation_types"),
     })
 }
 
-/// Guided follow-up line for [`detect_openrouter_attestation`].
+/// Detect the OpenRouter data-policy / guardrail filter.
 ///
-/// Kept as plain `Author::System` text with a bare URL: only
-/// `Author::Assistant` lines run through the tuika markdown renderer, so
-/// system lines rely on native terminal autolink, which needs the URL clean
-/// and separated from JSON punctuation.
+/// Matches `ineligibility_reasons`, the "guardrail restrictions and data policy"
+/// sentence, or `Filter by Guardrails`. Distinct from the attestation 403.
+pub(crate) fn detect_openrouter_guardrail(message: &str) -> Option<GuardrailBlock> {
+    if detect_openrouter_attestation(message).is_some() {
+        return None;
+    }
+    let blocked = message.contains("ineligibility_reasons")
+        || message.contains("guardrail restrictions")
+        || message.contains("Filter by Guardrails");
+    if !blocked {
+        return None;
+    }
+    let message = message.replace("\\\"", "\"");
+    let reasons = ineligibility_reasons(&message);
+    let url = json_string_values(&message, "configure_url")
+        .into_iter()
+        .find(|url| url.starts_with("https://"))
+        .or_else(|| first_clean_url(&message))
+        .unwrap_or_else(|| OPENROUTER_PRIVACY_URL.to_string());
+    Some(GuardrailBlock { url, reasons })
+}
+
+/// Guided follow-up for [`detect_openrouter_attestation`].
+///
+/// Assistant markdown so the confirm URL is a labeled OSC 8 link, not a
+/// URL glued to JSON punctuation on a System line.
 pub(crate) fn attestation_error_hint(message: &str) -> Option<String> {
     let requirement = detect_openrouter_attestation(message)?;
+    let link = markdown_link(openrouter_link_label(&requirement.url), &requirement.url);
     if requirement.missing_types.is_empty() {
         return Some(format!(
-            "This OpenRouter model needs an account confirmation before use. Complete it at {} and retry the turn.",
-            requirement.url
+            "This OpenRouter model needs an account confirmation before use. Complete it at {link} and retry the turn."
         ));
     }
+    let missing = requirement
+        .missing_types
+        .iter()
+        .map(|item| humanize_gate_token(item))
+        .collect::<Vec<_>>()
+        .join(", ");
     Some(format!(
-        "This OpenRouter model needs confirmation before use (missing: {}). Complete it at {} and retry the turn.",
-        requirement.missing_types.join(", "),
-        requirement.url
+        "This OpenRouter model needs confirmation before use (missing: {missing}). Complete it at {link} and retry the turn."
     ))
 }
 
-/// Collect the quoted entries of `"missing_attestation_types": [...]`.
-fn missing_attestation_types(message: &str) -> Vec<String> {
-    let field = "\"missing_attestation_types\"";
+/// Guided follow-up for [`detect_openrouter_guardrail`].
+pub(crate) fn guardrail_error_hint(message: &str) -> Option<String> {
+    let block = detect_openrouter_guardrail(message)?;
+    let link = markdown_link(openrouter_link_label(&block.url), &block.url);
+    if block.reasons.is_empty() {
+        return Some(format!(
+            "OpenRouter blocked this model under your data policy. Change the setting at {link} and retry the turn."
+        ));
+    }
+    Some(format!(
+        "OpenRouter blocked this model under your data policy ({}). Change the setting at {link} and retry the turn.",
+        block.reasons.join(", ")
+    ))
+}
+
+/// Actionable OpenRouter hints for a failed turn, attestation first.
+pub(crate) fn openrouter_error_hints(message: &str) -> Vec<String> {
+    if let Some(hint) = attestation_error_hint(message) {
+        return vec![hint];
+    }
+    if let Some(hint) = guardrail_error_hint(message) {
+        return vec![hint];
+    }
+    Vec::new()
+}
+
+/// Generic everruns apologies that hide a classified, user-fixable error.
+pub(crate) fn is_generic_provider_apology(text: &str) -> bool {
+    let text = text.trim();
+    text.eq_ignore_ascii_case(
+        "There is a misconfiguration with the AI provider. Please contact support.",
+    ) || text.starts_with("I encountered an error while processing your request.")
+}
+
+fn markdown_link(label: &str, url: &str) -> String {
+    format!("[{label}]({url})")
+}
+
+fn openrouter_link_label(url: &str) -> &'static str {
+    if url.contains("/settings/privacy") {
+        "OpenRouter privacy settings"
+    } else if url.contains("/settings/preferences") {
+        "OpenRouter preferences"
+    } else {
+        "OpenRouter settings"
+    }
+}
+
+fn humanize_gate_token(token: &str) -> String {
+    match token {
+        "age_18plus" => "18+ age confirmation".to_string(),
+        "paid-model-training-violation-by-account" => "paid-model training".to_string(),
+        other => {
+            let trimmed = other
+                .trim_end_matches("-by-account")
+                .trim_end_matches("_by_account");
+            trimmed.replace(['_', '-'], " ")
+        }
+    }
+}
+
+fn ineligibility_reasons(message: &str) -> Vec<String> {
+    let field = "\"ineligibility_reasons\"";
     let start = match message.find(field) {
         Some(index) => index + field.len(),
+        None => return Vec::new(),
+    };
+    json_string_values(&message[start..], "reason")
+        .into_iter()
+        .map(|reason| humanize_gate_token(&reason))
+        .collect()
+}
+
+/// Every `"field": "value"` occurrence. Does not walk into arrays of strings.
+fn json_string_values(message: &str, field: &str) -> Vec<String> {
+    let needle = format!("\"{field}\"");
+    let mut values = Vec::new();
+    let mut search = message;
+    while let Some(index) = search.find(&needle) {
+        let after = &search[index + needle.len()..];
+        if let Some(value) = json_string_value(after) {
+            values.push(value);
+        }
+        search = &search[index + needle.len()..];
+    }
+    values
+}
+
+/// Quoted entries of `"field": ["a", "b"]`.
+fn json_string_array(message: &str, field: &str) -> Vec<String> {
+    let needle = format!("\"{field}\"");
+    let start = match message.find(&needle) {
+        Some(index) => index + needle.len(),
         None => return Vec::new(),
     };
     let rest = &message[start..];
@@ -80,9 +210,22 @@ fn missing_attestation_types(message: &str) -> Vec<String> {
         Some(index) => index,
         None => return Vec::new(),
     };
-    let list = &rest[..end];
+    quoted_strings_in(&rest[..end])
+}
+
+fn json_string_value(after_field: &str) -> Option<String> {
+    let rest = after_field.trim_start();
+    let rest = rest.strip_prefix(':')?;
+    let rest = rest.trim_start();
+    if rest.starts_with('[') {
+        return None;
+    }
+    quoted_strings_in(rest).into_iter().next()
+}
+
+fn quoted_strings_in(list: &str) -> Vec<String> {
     let bytes = list.as_bytes();
-    let mut types = Vec::new();
+    let mut values = Vec::new();
     let mut index = 0;
     while index < bytes.len() {
         if bytes[index] != b'"' {
@@ -99,10 +242,13 @@ fn missing_attestation_types(message: &str) -> Vec<String> {
             index += 1;
         }
         if !value.is_empty() {
-            types.push(value);
+            values.push(value);
+        }
+        if index < bytes.len() {
+            index += 1;
         }
     }
-    types
+    values
 }
 
 /// First `https://` URL in the message, stripped of surrounding JSON
@@ -134,6 +280,8 @@ mod tests {
 
     const GATED_ERROR: &str = r#"provider 'openrouter': OpenAI Responses error (403 Forbidden): "{\"error\":{\"message\":\"This model requires you to complete the following before use: 18+ age confirmation. Confirm at https://openrouter.ai/settings/preferences.\",\"code\":403,\"metadata\":{\"missing_attestation_types\":[\"age_18plus\"],\"failed_routing_step\":\"Gate Endpoints with Attestations\"}}}"#;
 
+    const GUARDRAIL_ERROR: &str = r#"provider 'openrouter': OpenAI Responses API error (404 Not Found): {"error":{"message":"0 endpoints out of 1 requested are available matching your guardrail restrictions and data policy. We removed them for the following reasons (an endpoint may have matched multiple reasons):\nPaid model training violation (account settings): 1 endpoint excluded; configurable at https://openrouter.ai/settings/privacy","code":404,"metadata":{"input_endpoint_count":1,"ineligibility_reasons":[{"reason":"paid-model-training-violation-by-account","count":1,"configure_url":"https://openrouter.ai/settings/privacy"}],"routing_funnel":[{"step":"Initial Endpoints","endpoint_count":1}],"failed_routing_step":"Filter by Guardrails"}}}"#;
+
     #[test]
     fn detects_gate_with_types_and_clean_url() {
         let requirement =
@@ -148,12 +296,13 @@ mod tests {
     #[test]
     fn hint_names_gate_and_points_at_preferences() {
         let hint = attestation_error_hint(GATED_ERROR).expect("hint is produced");
-        assert!(hint.contains("age_18plus"), "hint: {hint}");
+        assert!(hint.contains("18+ age confirmation"), "hint: {hint}");
         assert!(
-            hint.contains("https://openrouter.ai/settings/preferences"),
-            "hint: {hint}"
+            hint.contains("[OpenRouter preferences](https://openrouter.ai/settings/preferences)"),
+            "hint is a labeled markdown link: {hint}"
         );
         assert!(!hint.contains('{'), "hint carries no JSON blob: {hint}");
+        assert!(!hint.contains("age_18plus"), "hint is humanized: {hint}");
     }
 
     #[test]
@@ -162,6 +311,7 @@ mod tests {
             {\"error\":{\"message\":\"Insufficient credits. Top up at https://openrouter.ai/account.\",\"code\":403}}";
         assert!(detect_openrouter_attestation(message).is_none());
         assert!(attestation_error_hint(message).is_none());
+        assert!(detect_openrouter_guardrail(message).is_none());
     }
 
     #[test]
@@ -185,5 +335,64 @@ mod tests {
             requirement.url,
             "https://openrouter.ai/settings/preferences"
         );
+    }
+
+    #[test]
+    fn detects_guardrail_block_with_reason_and_configure_url() {
+        let block =
+            detect_openrouter_guardrail(GUARDRAIL_ERROR).expect("guardrail error is detected");
+        assert_eq!(block.reasons, vec!["paid-model training"]);
+        assert_eq!(block.url, "https://openrouter.ai/settings/privacy");
+        assert!(detect_openrouter_attestation(GUARDRAIL_ERROR).is_none());
+    }
+
+    #[test]
+    fn guardrail_hint_is_a_labeled_privacy_link() {
+        let hint = guardrail_error_hint(GUARDRAIL_ERROR).expect("hint is produced");
+        assert!(hint.contains("paid-model training"), "hint: {hint}");
+        assert!(
+            hint.contains("[OpenRouter privacy settings](https://openrouter.ai/settings/privacy)"),
+            "hint is a labeled markdown link: {hint}"
+        );
+        assert!(!hint.contains('{'), "hint carries no JSON blob: {hint}");
+        assert!(
+            !hint.contains("paid-model-training-violation-by-account"),
+            "hint is humanized: {hint}"
+        );
+    }
+
+    #[test]
+    fn guardrail_falls_back_to_privacy_url_without_url_in_body() {
+        let message = "OpenAI Responses API error (404 Not Found): \
+            0 endpoints matching your guardrail restrictions and data policy";
+        let block =
+            detect_openrouter_guardrail(message).expect("guardrail without URL is detected");
+        assert_eq!(
+            block.url, OPENROUTER_PRIVACY_URL,
+            "falls back to the privacy page"
+        );
+    }
+
+    #[test]
+    fn openrouter_hints_prefer_attestation_over_guardrail() {
+        assert_eq!(openrouter_error_hints(GATED_ERROR).len(), 1);
+        assert_eq!(openrouter_error_hints(GUARDRAIL_ERROR).len(), 1);
+        assert!(openrouter_error_hints("connection reset by peer").is_empty());
+    }
+
+    #[test]
+    fn generic_provider_apologies_are_recognized() {
+        assert!(is_generic_provider_apology(
+            "There is a misconfiguration with the AI provider. Please contact support."
+        ));
+        assert!(is_generic_provider_apology(
+            "I encountered an error while processing your request. Please try again later."
+        ));
+        assert!(is_generic_provider_apology(
+            "I encountered an error while processing your request."
+        ));
+        assert!(!is_generic_provider_apology(
+            "OpenRouter blocked this model under your data policy."
+        ));
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -7,9 +7,9 @@
 pub mod background_wake;
 mod compaction_checkpoint;
 pub(crate) mod discovered_profiles;
-// Stopgap classifier for the OpenRouter account-attestation gate (403 with
-// `missing_attestation_types`). Replace with the upstream structured error
-// once `everruns-openrouter` reports the gate as a first-class kind.
+// Stopgap classifiers for OpenRouter account gates (403 attestation, 404
+// data-policy / guardrail). Replace with the upstream structured error once
+// `everruns-openrouter` reports those gates as first-class kinds.
 pub(crate) mod attestation;
 pub(crate) mod reasoning;
 pub mod session;

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -396,7 +396,7 @@ impl Session {
             if !response.success
                 && let Some(err) = &response.error
             {
-                out.extend(turn_failure_lines(err, model.reasoning_effort().as_deref()));
+                out = failed_turn_transcript(out, err, model.reasoning_effort().as_deref());
             }
             let _ = tx.send(TurnEvent::Lines(out));
             let success = response.success;
@@ -467,35 +467,48 @@ impl Session {
     }
 }
 
-/// Drain any persisted events (from `runtime.events()`) that the broadcast
-/// receiver may have missed — used after a `Lagged` recv error and once more at
-/// end-of-turn so the transcript is never missing tool/reason completion lines.
-/// How a failed turn reads in the transcript: the provider's own message, plus,
-/// when the failure is one a control can fix, the control that fixes it. A
-/// provider that mandates reasoning states it in prose the user cannot act on.
-fn turn_failure_lines(error: &str, current_effort: Option<&str>) -> Vec<ChatLine> {
-    let mut lines = vec![ChatLine {
+/// Actionable follow-ups for a failed turn: a control (`/effort`) or an
+/// OpenRouter account/policy page the user can open. Shared by the TUI,
+/// `--print`, and ACP so every host names the same way out.
+pub(crate) fn turn_failure_hints(error: &str, current_effort: Option<&str>) -> Vec<String> {
+    let mut hints = Vec::new();
+    if let Some(hint) = reasoning::reasoning_error_hint(error, current_effort) {
+        hints.push(hint);
+    }
+    // Stopgap classifiers for OpenRouter account gates. Move these behind
+    // the upstream structured error once everruns-openrouter reports the
+    // gates as first-class kinds instead of JSON strings.
+    hints.extend(attestation::openrouter_error_hints(error));
+    hints
+}
+
+/// How a failed turn reads in the transcript: drop a generic everruns
+/// apology when a real hint exists, then the way out (Assistant, so compact
+/// work and markdown links both see it), then the provider's own message.
+fn failed_turn_transcript(
+    assistant: Vec<ChatLine>,
+    error: &str,
+    current_effort: Option<&str>,
+) -> Vec<ChatLine> {
+    let hints = turn_failure_hints(error, current_effort);
+    let mut lines = assistant;
+    if !hints.is_empty() {
+        lines.retain(|line| !attestation::is_generic_provider_apology(&line.text));
+        lines.extend(hints.into_iter().map(|text| ChatLine {
+            author: Author::Assistant,
+            text,
+        }));
+    }
+    lines.push(ChatLine {
         author: Author::System,
         text: format!("turn error: {error}"),
-    }];
-    if let Some(hint) = reasoning::reasoning_error_hint(error, current_effort) {
-        lines.push(ChatLine {
-            author: Author::System,
-            text: hint,
-        });
-    }
-    // Stopgap guidance for the OpenRouter attestation gate. Move this behind
-    // the upstream structured error once everruns-openrouter reports the
-    // gate as a first-class kind instead of a JSON string.
-    if let Some(hint) = attestation::attestation_error_hint(error) {
-        lines.push(ChatLine {
-            author: Author::System,
-            text: hint,
-        });
-    }
+    });
     lines
 }
 
+/// Drain any persisted events (from `runtime.events()`) that the broadcast
+/// receiver may have missed — used after a `Lagged` recv error and once more at
+/// end-of-turn so the transcript is never missing tool/reason completion lines.
 async fn catch_up_events(
     handles: &RuntimeHandles,
     session_id: SessionId,
@@ -695,27 +708,28 @@ mod tests {
              (400 Bad Request): {\"error\":{\"message\":\"Reasoning is mandatory for this \
              endpoint and cannot be disabled.\",\"code\":400}}";
 
-        let lines = turn_failure_lines(error, Some("low"));
+        let lines = failed_turn_transcript(Vec::new(), error, Some("low"));
 
-        assert_eq!(lines.len(), 2, "the error, then the way out: {lines:?}");
-        assert!(lines.iter().all(|line| line.author == Author::System));
-        assert!(lines[0].text.starts_with("turn error: "));
+        assert_eq!(lines.len(), 2, "the way out, then the error: {lines:?}");
+        assert_eq!(lines[0].author, Author::Assistant);
+        assert_eq!(lines[1].author, Author::System);
         assert!(
-            lines[1].text.contains("rejected reasoning effort `low`")
-                && lines[1].text.contains("/effort"),
+            lines[0].text.contains("rejected reasoning effort `low`")
+                && lines[0].text.contains("/effort"),
             "the hint names the rejected level and the control: {}",
-            lines[1].text
+            lines[0].text
         );
+        assert!(lines[1].text.starts_with("turn error: "));
 
         // Failures nothing in the UI can fix stay one line.
         assert_eq!(
-            turn_failure_lines("connection reset by peer", None).len(),
+            failed_turn_transcript(Vec::new(), "connection reset by peer", None).len(),
             1
         );
     }
 
-    /// The transcript an OpenRouter attestation gate leaves behind: the raw
-    /// error, then the way out with a clean confirm URL.
+    /// The transcript an OpenRouter attestation gate leaves behind: a labeled
+    /// confirm link the TUI can render, then the raw error for diagnosis.
     #[test]
     fn an_attestation_gate_names_the_missing_confirmation() {
         let error = "LLM error: provider 'openrouter': OpenAI Responses error \
@@ -723,19 +737,74 @@ mod tests {
             complete the following before use: 18+ age confirmation. Confirm at \
             https://openrouter.ai/settings/preferences.\\\",\\\"code\\\":403,\\\"metadata\\\":{\\\"missing_attestation_types\\\":[\\\"age_18plus\\\"]}}}\"";
 
-        let lines = turn_failure_lines(error, None);
-
-        assert_eq!(lines.len(), 2, "the error, then the way out: {lines:?}");
-        assert!(lines.iter().all(|line| line.author == Author::System));
-        assert!(lines[0].text.starts_with("turn error: "));
-        assert!(
-            lines[1].text.contains("age_18plus")
-                && lines[1]
-                    .text
-                    .contains("https://openrouter.ai/settings/preferences"),
-            "the hint names the gate and the confirm page: {}",
-            lines[1].text
+        let lines = failed_turn_transcript(
+            vec![ChatLine {
+                author: Author::Assistant,
+                text: "There is a misconfiguration with the AI provider. Please contact support."
+                    .into(),
+            }],
+            error,
+            None,
         );
+
+        assert_eq!(
+            lines.len(),
+            2,
+            "the apology is replaced by the way out: {lines:?}"
+        );
+        assert_eq!(lines[0].author, Author::Assistant);
+        assert_eq!(lines[1].author, Author::System);
+        assert!(
+            lines[0].text.contains("18+ age confirmation")
+                && lines[0].text.contains(
+                    "[OpenRouter preferences](https://openrouter.ai/settings/preferences)"
+                ),
+            "the hint names the gate and a labeled confirm page: {}",
+            lines[0].text
+        );
+        assert!(lines[1].text.starts_with("turn error: "));
+    }
+
+    /// The transcript an OpenRouter data-policy block leaves behind: a labeled
+    /// privacy-settings link, not a generic "try again later".
+    #[test]
+    fn a_guardrail_block_names_the_privacy_setting() {
+        let error = "LLM error: provider 'openrouter': OpenAI Responses API error \
+            (404 Not Found): {\"error\":{\"message\":\"0 endpoints out of 1 requested are \
+            available matching your guardrail restrictions and data policy. We removed them \
+            for the following reasons:\\nPaid model training violation (account settings): 1 \
+            endpoint excluded; configurable at https://openrouter.ai/settings/privacy\",\"code\":404,\
+            \"metadata\":{\"ineligibility_reasons\":[{\"reason\":\"paid-model-training-violation-by-account\",\
+            \"count\":1,\"configure_url\":\"https://openrouter.ai/settings/privacy\"}],\
+            \"failed_routing_step\":\"Filter by Guardrails\"}}";
+
+        let lines = failed_turn_transcript(
+            vec![ChatLine {
+                author: Author::Assistant,
+                text:
+                    "I encountered an error while processing your request. Please try again later."
+                        .into(),
+            }],
+            error,
+            None,
+        );
+
+        assert_eq!(
+            lines.len(),
+            2,
+            "the apology is replaced by the way out: {lines:?}"
+        );
+        assert_eq!(lines[0].author, Author::Assistant);
+        assert_eq!(lines[1].author, Author::System);
+        assert!(
+            lines[0].text.contains("paid-model training")
+                && lines[0].text.contains(
+                    "[OpenRouter privacy settings](https://openrouter.ai/settings/privacy)"
+                ),
+            "the hint names the policy and a labeled settings page: {}",
+            lines[0].text
+        );
+        assert!(lines[1].text.starts_with("turn error: "));
     }
 
     #[tokio::test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4960,6 +4960,63 @@ mod tests {
     }
 
     #[test]
+    fn openrouter_policy_hint_renders_a_clickable_labeled_link() {
+        // Account/policy hints are Assistant markdown so compact work shows
+        // them and the labeled destination survives painting as OSC 8.
+        use ratatui::layout::Position;
+        let mut lines: Vec<Line> = Vec::new();
+        let links = append_chat_lines(
+            &mut lines,
+            &ChatLine {
+                author: Author::Assistant,
+                text: "OpenRouter blocked this model under your data policy (paid-model training). Change the setting at [OpenRouter privacy settings](https://openrouter.ai/settings/privacy) and retry the turn.".to_string(),
+            },
+            120,
+        );
+        let link = links
+            .iter()
+            .find(|item| item.url == "https://openrouter.ai/settings/privacy")
+            .expect("policy hint must yield a BufferLink");
+        let mut buffer = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 140, 4));
+        for (row, line) in lines.iter().enumerate() {
+            let mut x = 0u16;
+            for span in &line.spans {
+                x = buffer.set_span(x, row as u16, span, 140).0;
+            }
+        }
+        hyperlink::apply_buffer_links(
+            &mut buffer,
+            Position { x: 0, y: 0 },
+            &links,
+            hyperlink::LinkPolicy::WEB,
+        );
+        let mut event = tuika::Mouse::at(
+            tuika::MouseKind::Up(tuika::MouseButton::Left),
+            link.start_col + 1,
+            link.line,
+        );
+        event.ctrl = true;
+        assert_eq!(
+            hyperlink::ctrl_click_url(&event, &buffer, Rect::new(0, 0, 140, 4)).as_deref(),
+            Some("https://openrouter.ai/settings/privacy"),
+            "the privacy-settings label must preserve the destination"
+        );
+        let visible: String = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            visible.contains("privacy settings"),
+            "the clickable label is what the user sees: {visible:?}"
+        );
+        assert!(
+            !visible.contains("](https://"),
+            "markdown source must not leak: {visible:?}"
+        );
+    }
+
+    #[test]
     fn transcript_markdown_renders_commonmark_emphasis() {
         // Assistant transcript now flows through tuika's CommonMark renderer, so
         // inline **bold** / *italic* are resolved — the previous line-oriented


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

OpenRouter account and data-policy failures now tell the user what to do, with a clickable settings link, instead of a generic apology plus a JSON blob.

- 18+ attestation (403) already had a System hint. That hint is now an Assistant markdown link (`OpenRouter preferences`) so compact work shows it and the TUI can OSC 8 the destination.
- The 404 data-policy / guardrail case (`paid-model training`, `configure_url` to privacy settings) gets the same treatment.
- Generic everruns apologies ("misconfiguration, contact support", "try again later") are dropped when a classified hint exists.
- TUI, `--print`, and ACP emit the same hints.

The raw provider body stays as a System `turn error:` line for diagnosis.

## Why

Two OpenRouter failures were unusable in the transcript:

1. 403: "This model requires you to complete the following before use: 18+ age confirmation" with the confirm URL glued to JSON punctuation.
2. 404: "0 endpoints ... matching your guardrail restrictions and data policy" pointing at privacy settings the same way.

The first was partly classified already. The second was not, ACP and `--print` never saw the hint, and a System hint sits in collapsed compact-work details. The visible agent line was "Please contact support" or "Please try again later".

## Before / After

**Before (403):**
```
agent › There is a misconfiguration with the AI provider. Please contact support.
system › turn error: LLM error: provider 'openrouter': ... Confirm at https://openrouter.ai/settings/preferences.\",\"code\":403...
```

**After (403):**
```
agent › This OpenRouter model needs confirmation before use (missing: 18+ age confirmation). Complete it at OpenRouter preferences and retry the turn.
system › turn error: ...
```
The "OpenRouter preferences" label is an OSC 8 link to `https://openrouter.ai/settings/preferences`.

**Before (404):**
```
agent › I encountered an error while processing your request. Please try again later.
system › turn error: ... configurable at https://openrouter.ai/settings/privacy","code":404...
```

**After (404):**
```
agent › OpenRouter blocked this model under your data policy (paid-model training). Change the setting at OpenRouter privacy settings and retry the turn.
system › turn error: ...
```
The "OpenRouter privacy settings" label is an OSC 8 link to `https://openrouter.ai/settings/privacy`.

## Risk

- Low
- Presentation only. Unmatched errors render exactly as before. A false-positive classifier would replace a generic apology with a hint, which is still actionable if the URL is right.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0, additive classified hints)
- [x] Knowledge concepts updated

## Knowledge

Updated [Presentation](knowledge/specs/presentation.md): provider failures the user can fix append an Assistant hint with a labeled markdown link (or `/effort`), drop the generic apology, and keep `turn error:` for diagnosis. TUI, `--print`, and ACP share the same hints.

## Security

No security-relevant code changes. The classifiers are pure string matching over an already-displayed provider error. No new I/O, no shell, no filesystem access, no keys touched, no new dependencies. TM-LLM: error text is not logged or written to session JSONL by this change.

## Follow-ups

- Upstream everruns: report attestation and guardrail gates as structured `everruns-openrouter` error kinds, then delete the local stopgap in `src/runtime/attestation.rs`.
- ACP still rewrites `PROVIDER_MISCONFIGURED` to "OpenRouter authentication failed. Run `/setup`" before the turn-end hint arrives. Editors that cannot retract that chunk still show a misleading first line. Deferred because the translator does not have the raw provider body at `OutputMessageCompleted`.
- Optional: an explicit open-browser action once upstream classification exists.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4066c34-5906-43f9-82e9-897268ece149?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4066c34-5906-43f9-82e9-897268ece149&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

