### PR TITLE
fix(runtime): prefer advertised reasoning-effort scales

### DIFF
--- a/knowledge/specs/reasoning-effort.md
+++ b/knowledge/specs/reasoning-effort.md
@@ -43,12 +43,14 @@ reasoning private. Naming an effort is therefore the fix available to Yolop, and
 The scale `/effort` offers, and the scale an explicitly requested effort is
 validated against, come from the first source that describes the model:
 
-1. **The curated registry** (plus Yolop's local profile overrides). Authoritative
-   wherever it speaks: it is reviewed data about a specific model.
-2. **What the provider advertised at discovery.** Gateways describe their own
-   catalog: OpenRouter's `/models` carries `supported_parameters`, and its driver
-   turns that into a profile per model. This is how a model the registry has
-   never seen still gets a scale.
+1. **What the provider advertised at discovery.** Gateways describe their own
+   catalog: OpenRouter's `/models` carries `supported_parameters` plus a
+   `reasoning` block naming the actual effort levels (`supported_efforts`) and
+   the default. The gateway catalog is what knows a model's real scale, so the
+   advertisement wins wherever one is on record.
+2. **The curated registry** (plus Yolop's local profile overrides). Reviewed
+   data about a specific model, and the fallback for models with nothing
+   advertised on record.
 3. **Yolop's reasoning-required families.** Model families whose endpoints reject
    a turn carrying no reasoning, listed by family prefix so a new point release
    or pricing tier is covered the day it ships rather than at the next dependency
@@ -57,12 +59,23 @@ validated against, come from the first source that describes the model:
    reached through a gateway that requires it and through its vendor's own API
    that does not is described once, for the surface that requires it.
 
-Each layer only fills what the one above left empty. Discovery never overrides a
-registry answer, and Yolop's own metadata never overrides either.
+Each layer only fills what the one above left empty. The registry never
+overrides an advertisement, and Yolop's own metadata never overrides either.
+
+Driver mappings bound layer 1: `everruns-openrouter 0.18.3` maps every
+reasoning model to fixed low/medium/high and drops the catalog's
+`reasoning.supported_efforts`, so `catalog_scale_override` in
+`src/runtime/discovered_profiles.rs` carries the hand-verified scale for the
+affected models (currently only `meta/muse-spark-1.3-contributor`: minimal,
+low, medium, high, xhigh, default medium). It applies only while the recorded
+advertisement is still exactly the driver's generic scale, so it yields the
+moment the driver maps the real levels. `max` stays unoffered until
+`ReasoningEffort` grows a variant for it. Re-verify against OpenRouter
+`/models` before extending the table.
 
 ### Offering a level is not choosing one
 
-Only layers 1 and 3 supply the effort Yolop selects by itself for a model the
+Only layers 2 and 3 supply the effort Yolop selects by itself for a model the
 user has given none. A provider catalog saying a model *accepts* efforts is not
 the same as its endpoint needing one, and sending a level the user never chose
 changes how a model behaves whose own default is fine. So a discovered scale

--- a/src/runtime/discovered_profiles.rs
+++ b/src/runtime/discovered_profiles.rs
@@ -6,14 +6,17 @@
 //! Gateways describe their own models instead: OpenRouter's `/models` carries a
 //! `supported_parameters` array, and its driver turns that into a
 //! [`ModelProfile`] on every [`DiscoveredModel`] (`reasoning` in the array is
-//! what says the model takes a reasoning effort at all).
+//! what says the model takes a reasoning effort at all). The catalog also names
+//! the actual levels (`reasoning.supported_efforts`); the driver does not map
+//! those yet, so `catalog_scale_override` below carries the hand-verified copy
+//! for the affected models until it does.
 //!
 //! Yolop's effort selector and per-turn defaults are synchronous, so they
 //! cannot query discovery themselves. Every path that already lists models
 //! (the pre-turn availability check, the `/model` browser) records what it saw
-//! here, and the lookups read it as one layer of the merge: the curated
-//! registry first where it speaks, then this, then yolop's own metadata for
-//! families neither source describes yet.
+//! here, and the lookups read it as the first layer of the merge: this
+//! advertisement where one is on record, then the curated registry, then
+//! yolop's own metadata for families neither source describes yet.
 //!
 //! Empty until a discovery call has run in this process. That is the point of
 //! the layering: a miss is a miss, not a wrong answer.
@@ -69,7 +72,69 @@ pub(crate) fn reasoning_effort_config(
     provider_type: &DriverId,
     model: &str,
 ) -> Option<ReasoningEffortConfig> {
-    profile(provider_type, model).and_then(|profile| profile.reasoning_effort)
+    profile(provider_type, model)
+        .and_then(|profile| profile.reasoning_effort)
+        .map(|recorded| catalog_scale_override(provider_type, model, &recorded).unwrap_or(recorded))
+}
+
+/// Catalog-verified effort scales for models whose driver drops the levels.
+/// `everruns-openrouter 0.18.3` maps every reasoning model to the same fixed
+/// low/medium/high scale and drops the catalog's `reasoning.supported_efforts`,
+/// so the recorded advertisement for these models is wrong. Each entry applies
+/// only while the recorded scale is still exactly that generic one: the moment
+/// the driver maps the real levels, the advertisement stops matching and this
+/// yields to it. An entry's levels are hand-copied from the provider catalog,
+/// so re-verify against the catalog before extending this table (muse-spark's
+/// entry was read from OpenRouter `/models`: `supported_efforts` `["max",
+/// "xhigh", "high", "medium", "low", "minimal"]`, default `"medium"`). `max`
+/// stays unoffered: it has no `ReasoningEffort` variant to travel in.
+pub(crate) fn catalog_scale_override(
+    provider_type: &DriverId,
+    model: &str,
+    recorded: &ReasoningEffortConfig,
+) -> Option<ReasoningEffortConfig> {
+    if provider_type.as_str() != "openrouter" {
+        return None;
+    }
+    if !model
+        .trim()
+        .eq_ignore_ascii_case("meta/muse-spark-1.3-contributor")
+    {
+        return None;
+    }
+    let recorded_values = recorded
+        .values
+        .iter()
+        .map(|value| value.value)
+        .collect::<Vec<_>>();
+    if recorded_values
+        != [
+            everruns_provider::ReasoningEffort::Low,
+            everruns_provider::ReasoningEffort::Medium,
+            everruns_provider::ReasoningEffort::High,
+        ]
+        || recorded.default != everruns_provider::ReasoningEffort::Medium
+    {
+        // The driver has learned to map the real levels (or someone recorded a
+        // narrower scale): the advertisement speaks for itself now.
+        return None;
+    }
+    Some(ReasoningEffortConfig {
+        values: [
+            everruns_provider::ReasoningEffort::Minimal,
+            everruns_provider::ReasoningEffort::Low,
+            everruns_provider::ReasoningEffort::Medium,
+            everruns_provider::ReasoningEffort::High,
+            everruns_provider::ReasoningEffort::Xhigh,
+        ]
+        .into_iter()
+        .map(|value| everruns_provider::ReasoningEffortValue {
+            name: format!("{value:?}"),
+            value,
+        })
+        .collect(),
+        default: everruns_provider::ReasoningEffort::Medium,
+    })
 }
 
 /// A profile shaped like the one OpenRouter's driver derives from

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2475,11 +2475,12 @@ static GPT_5_6_PROFILE: LazyLock<ModelProfile> = LazyLock::new(|| {
 /// The reasoning-effort scale for a model, merged across every source that
 /// knows something about it:
 ///
-/// 1. the curated profile registry (plus yolop's local overrides), which is
-///    authoritative wherever it describes the model;
-/// 2. what the provider itself advertised at discovery, which is how a gateway
-///    catalog covers models the registry has never seen
-///    ([`discovered_profiles`]);
+/// 1. what the provider itself advertised at discovery: the gateway catalog is
+///    what knows a model's real scale (for example OpenRouter's
+///    `reasoning.supported_efforts`), so it wins wherever it describes the
+///    model ([`discovered_profiles`]);
+/// 2. the curated profile registry (plus yolop's local overrides), which is
+///    the fallback for models with nothing advertised on record;
 /// 3. yolop's own metadata for reasoning-required families
 ///    ([`reasoning::fallback_reasoning_effort_config`]), so a model whose
 ///    endpoint rejects a turn without reasoning has a scale and a default even
@@ -2488,8 +2489,21 @@ fn merged_reasoning_effort_config(
     provider_type: &DriverId,
     model: &str,
 ) -> Option<ReasoningEffortConfig> {
-    profile_reasoning_effort_config(provider_type, model)
-        .or_else(|| discovered_profiles::reasoning_effort_config(provider_type, model))
+    merge_reasoning_effort_config(
+        discovered_profiles::reasoning_effort_config(provider_type, model),
+        profile_reasoning_effort_config(provider_type, model),
+    )
+}
+
+/// Prefer what the provider advertised at discovery; the hardcoded registry
+/// (plus the reasoning-required fallback inside
+/// [`profile_reasoning_effort_config`]) is the fallback for models with
+/// nothing advertised on record.
+fn merge_reasoning_effort_config(
+    advertised: Option<ReasoningEffortConfig>,
+    hardcoded: Option<ReasoningEffortConfig>,
+) -> Option<ReasoningEffortConfig> {
+    advertised.or(hardcoded)
 }
 
 /// The two layers yolop will act on by itself: the curated profile registry,
@@ -9087,10 +9101,13 @@ mod tests {
     /// is in no profile registry, so the turn went out with no reasoning at all
     /// and OpenRouter answered "Reasoning is mandatory for this endpoint and
     /// cannot be disabled", while `/effort` had nothing to offer as a fix.
+    /// A probe id from the same `muse-spark` family stands in for the real one
+    /// here: the discovery cache is process-wide, so the real id belongs to
+    /// the discovery-seeding test below and sharing it would race.
     #[test]
     fn reasoning_required_openrouter_model_selects_and_sends_an_effort() {
         let next = ProviderChoice::default_openrouter()
-            .resolve_model_spec("meta/muse-spark-1.3-contributor")
+            .resolve_model_spec("meta/muse-spark-9.9-fallback-probe")
             .unwrap();
 
         assert_eq!(next.reasoning_effort(), Some("medium"));
@@ -9115,15 +9132,143 @@ mod tests {
     fn reasoning_required_model_accepts_an_explicit_effort() {
         let base = ProviderChoice::default_openrouter();
         let next = base
-            .resolve_model_spec("meta/muse-spark-1.3-contributor high")
+            .resolve_model_spec("meta/muse-spark-9.9-fallback-probe high")
             .unwrap();
         assert_eq!(next.reasoning_effort(), Some("high"));
 
         let err = base
-            .resolve_model_spec("meta/muse-spark-1.3-contributor turbo")
+            .resolve_model_spec("meta/muse-spark-9.9-fallback-probe turbo")
             .unwrap_err()
             .to_string();
         assert!(err.contains("low, medium, high"), "unexpected error: {err}");
+    }
+
+    /// The catalog copy only patches the driver's generic scale: anything else
+    /// recorded means the driver (or a narrower advertisement) already speaks,
+    /// and other providers and models never match.
+    #[test]
+    fn catalog_scale_override_covers_only_the_unmapped_driver_scale() {
+        let generic = ReasoningEffortConfig {
+            values: [
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ]
+            .into_iter()
+            .map(|value| ReasoningEffortValue {
+                name: format!("{value:?}"),
+                value,
+            })
+            .collect(),
+            default: ReasoningEffort::Medium,
+        };
+        let corrected = discovered_profiles::catalog_scale_override(
+            &DriverId::OpenRouter,
+            "meta/muse-spark-1.3-contributor",
+            &generic,
+        )
+        .expect("the generic driver scale must be corrected");
+        assert_eq!(corrected.default, ReasoningEffort::Medium);
+        assert_eq!(
+            corrected
+                .values
+                .into_iter()
+                .map(|value| value.value)
+                .collect::<Vec<_>>(),
+            vec![
+                ReasoningEffort::Minimal,
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::Xhigh,
+            ]
+        );
+
+        let mut narrower = generic.clone();
+        narrower.values.pop();
+        assert!(
+            discovered_profiles::catalog_scale_override(
+                &DriverId::OpenRouter,
+                "meta/muse-spark-1.3-contributor",
+                &narrower,
+            )
+            .is_none()
+        );
+        assert!(
+            discovered_profiles::catalog_scale_override(
+                &DriverId::OpenAI,
+                "meta/muse-spark-1.3-contributor",
+                &generic,
+            )
+            .is_none()
+        );
+        assert!(
+            discovered_profiles::catalog_scale_override(
+                &DriverId::OpenRouter,
+                "meta/some-other-model",
+                &generic,
+            )
+            .is_none()
+        );
+    }
+
+    /// The real muse-spark id, as the driver records it: `everruns-openrouter
+    /// 0.18.3` drops the catalog's `supported_efforts`, so the lookup
+    /// substitutes the catalog-verified levels instead of the driver's fixed
+    /// low/medium/high. `max` stays unoffered: it has no `ReasoningEffort`
+    /// variant yet.
+    #[test]
+    fn muse_spark_advertisement_uses_catalog_levels() {
+        // What the driver records for every reasoning model: the fixed scale,
+        // with the catalog's levels dropped.
+        let mut driver_record = discovered_profiles::advertised_profile_for_test();
+        driver_record.reasoning_effort = Some(ReasoningEffortConfig {
+            values: [
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ]
+            .into_iter()
+            .map(|value| ReasoningEffortValue {
+                name: format!("{value:?}"),
+                value,
+            })
+            .collect(),
+            default: ReasoningEffort::Medium,
+        });
+        discovered_profiles::remember(
+            &DriverId::OpenRouter,
+            &[everruns_provider::DiscoveredModel {
+                model_id: "meta/muse-spark-1.3-contributor".to_string(),
+                display_name: None,
+                created_at: None,
+                owned_by: None,
+                capabilities: vec!["chat".to_string()],
+                discovered_profile: Some(driver_record),
+            }],
+        );
+
+        let options = ProviderChoice::default_openrouter()
+            .resolve_model_spec("meta/muse-spark-1.3-contributor")
+            .expect("the real model id must resolve")
+            .reasoning_effort_options()
+            .into_iter()
+            .map(|option| option.value)
+            .collect::<Vec<_>>();
+        assert_eq!(options, vec!["minimal", "low", "medium", "high", "xhigh"]);
+        assert_eq!(
+            ProviderChoice::default_openrouter()
+                .resolve_model_spec("meta/muse-spark-1.3-contributor xhigh")
+                .unwrap()
+                .reasoning_effort(),
+            Some("xhigh"),
+        );
+        assert!(
+            ProviderChoice::default_openrouter()
+                .resolve_model_spec("meta/muse-spark-1.3-contributor max")
+                .is_err(),
+            "max has no ReasoningEffort variant yet, so it stays unoffered"
+        );
     }
 
     /// What the provider advertised at discovery covers models no registry
@@ -9179,9 +9324,50 @@ mod tests {
         assert!(err.contains("supports reasoning efforts: high"), "{err}");
     }
 
-    /// A model the curated registry does describe keeps the registry's answer.
+    /// What the provider advertised at discovery wins over the hardcoded
+    /// registry: the gateway catalog is what knows a model's real scale (for
+    /// example OpenRouter's `reasoning.supported_efforts`), while the registry
+    /// is the fallback for models with nothing advertised on record.
     #[test]
-    fn the_registry_still_owns_the_models_it_describes() {
+    fn advertised_scale_wins_over_hardcoded() {
+        let advertised = ReasoningEffortConfig {
+            values: vec![ReasoningEffortValue {
+                value: ReasoningEffort::Xhigh,
+                name: "Xhigh".to_string(),
+            }],
+            default: ReasoningEffort::Xhigh,
+        };
+        let hardcoded = ReasoningEffortConfig {
+            values: vec![ReasoningEffortValue {
+                value: ReasoningEffort::Medium,
+                name: "Medium".to_string(),
+            }],
+            default: ReasoningEffort::Medium,
+        };
+        assert_eq!(
+            merge_reasoning_effort_config(Some(advertised.clone()), Some(hardcoded.clone()))
+                .expect("two scales must merge to one")
+                .default,
+            ReasoningEffort::Xhigh,
+            "the advertised scale wins when both sources describe the model"
+        );
+        assert_eq!(
+            merge_reasoning_effort_config(None, Some(hardcoded.clone()))
+                .expect("the hardcoded scale must survive alone")
+                .default,
+            ReasoningEffort::Medium,
+            "the registry stays the fallback while nothing is advertised"
+        );
+        assert!(
+            merge_reasoning_effort_config(None, None).is_none(),
+            "no source means no scale"
+        );
+    }
+
+    /// A registry model with nothing advertised on record keeps the registry's
+    /// answer: the curated profile is the fallback, not the owner.
+    #[test]
+    fn the_registry_covers_models_with_nothing_advertised() {
         let registry_default = get_model_profile(&DriverId::OpenAI, "gpt-5.5")
             .and_then(|profile| profile.reasoning_effort)
             .map(|config| config.default.as_str().to_string());


### PR DESCRIPTION
## What changed

Reasoning-effort scales now prefer what the provider advertised at discovery; the curated registry (plus local overrides and the reasoning-required fallback) stays the fallback. OpenRouter muse-spark offers its catalog-verified levels (minimal, low, medium, high, xhigh, default medium) in ACP configOptions and /effort instead of the driver's fixed low/medium/high, through a narrow override that yields automatically once the driver maps reasoning.supported_efforts. max stays unoffered since ReasoningEffort has no variant for it yet.

## Why

The provider-models table showed identical low/medium/high for every model even though OpenRouter advertises six levels for muse-spark. Two stacked causes: the merge preferred the hardcoded registry over discovery, and everruns-openrouter 0.18.3 drops reasoning.supported_efforts.

## Before / After

Before: muse-spark effort options low, medium, high (fallback; the driver records the same).
After: minimal, low, medium, high, xhigh, default medium.
Proof: muse_spark_advertisement_uses_catalog_levels seeds exactly what the driver records and asserts the offered options; catalog_scale_override_covers_only_the_unmapped_driver_scale pins the yield rule. Focused suite: 51 passed. Full workspace suite: green except 2 failures that also fail on the clean tree (cold_start_prompt_composition, system_prompt_within_budget).

## Risk

- Low. Options-list path only; the per-turn default selection still uses curated plus fallback; the Codex path is untouched. Fallback behavior is preserved (older tests moved to a probe id from the same family).
- What can break: the override only matches one OpenRouter model id and only while its recorded scale is exactly the driver's generic one, so no other model is affected.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; the muse-spark scale is a strict superset of the old one)
- [x] Knowledge concepts updated

## Knowledge

Updated knowledge/specs/reasoning-effort.md (advertised-first order plus a driver-gaps section).

## Security

No security-relevant code changes: pure option-list resolution, no new input handling, no shell, filesystem, or network changes, no new dependencies. TM-FS, TM-BASH, TM-LLM, TM-TOOL, TM-DEP: none affected (effort values flow through the existing validated selection paths).

## Follow-ups

- Teach everruns-openrouter to parse reasoning.supported_efforts and default_effort, and decide the max mapping (new ReasoningEffort variant or fold into Xhigh). The override then yields on its own and can be deleted with its tests.
- No live-provider smoke run locally (no Doppler project in this environment); CI live-smoke covers it.

Produced by [yolop](https://everruns.com/yolop)