### PR TITLE
fix(mcp): stop advertising /mcp via run_command in ACP

### DIFF
--- a/knowledge/specs/acp.md
+++ b/knowledge/specs/acp.md
@@ -254,10 +254,12 @@ runtime's sandboxed execution boundary.
 Secret-entry tools are different. The connector `connect` tool is omitted in
 ACP because its arguments carry credentials through the transcript. Connector
 discovery and disconnection remain available. MCP mutations are CLI-only: there are no mutation model
-tools, so servers are added, removed, enabled, or disabled with `yolop mcp ...` (files on disk) or
-`/mcp ...` via run_command (live session, which reloads by default and accepts `--no-reload` to defer).
+tools, so servers are added, removed, enabled, or disabled with `yolop mcp ...` (files on disk). In the
+terminal only, `/mcp ...` via run_command reaches the same path (live session, which reloads by default
+and accepts `--no-reload` to defer); ACP has no `/mcp` command, so the agent uses `command: help` to list
+the live set instead of assuming it exists.
 Secrets belong in environment placeholders such as `${MCP_TOKEN}`; literals at the CLI are the operator's
-explicit choice. Browser OAuth remains available through `yolop mcp login` and `/mcp login`.
+explicit choice. Browser OAuth remains available through `yolop mcp login` and, in the terminal only, `/mcp login`.
 
 ACP cannot replace or retract the transcript already displayed by its client.
 Checkpoint commands and `manage_checkpoint` therefore expose workspace restore

--- a/src/capabilities/agent_commands.rs
+++ b/src/capabilities/agent_commands.rs
@@ -243,13 +243,25 @@ impl Tool for RunCommandTool {
     }
 
     fn description(&self) -> &str {
-        "Execute any slash command this session registers, on behalf of a natural-language user \
-         request: `setup` (`command: setup`, `args: [reauthenticate, codex_browser]`), \
-         `background`, `undo`, `redo`, `rewind`, `goal`, and in the terminal also help, tools, \
-         mcp, cwd, status, model, effort, clear, and quit. Use `command: help` to list the live \
-         command set; an unknown name returns the available ones. Accepts command names with or \
-         without the leading slash; `exit` is an alias for `quit`. Skill commands activate by \
-         prompt and `shell` is typed-only, so neither runs here."
+        // Terminal-only commands (help, tools, mcp, ...) exist only when a host UI
+        // is attached. ACP and --print omit ClientCommandsCapability, so naming
+        // them here prompts a doomed run_command that fails with unknown command.
+        if self.ui.is_some() {
+            "Execute any slash command this session registers, on behalf of a natural-language user \
+             request: `setup` (`command: setup`, `args: [reauthenticate, codex_browser]`), \
+             `background`, `undo`, `redo`, `rewind`, `goal`, and in the terminal also `help`, `tools`, \
+             `mcp`, `cwd`, `status`, `model`, `effort`, `clear`, and `quit`. Use `command: help` to list the live \
+             command set; an unknown name returns the available ones. Accepts command names with or \
+             without the leading slash; `exit` is an alias for `quit`. Skill commands activate by \
+             prompt and `shell` is typed-only, so neither runs here."
+        } else {
+            "Execute any slash command this session registers, on behalf of a natural-language user \
+             request: `setup` (`command: setup`, `args: [reauthenticate, codex_browser]`), \
+             `background`, `undo`, `redo`, `rewind`, `goal`, and whatever else this session registers. \
+             Use `command: help` to list the live command set; an unknown name returns the available \
+             ones. Accepts command names with or without the leading slash. Skill commands activate \
+             by prompt and `shell` is typed-only, so neither runs here."
+        }
     }
 
     fn parameters_schema(&self) -> Value {
@@ -261,14 +273,23 @@ impl Tool for RunCommandTool {
                 // live registry validates the name at execution time.
                 "command": {
                     "type": "string",
-                    "description": "Slash command name, with or without the leading slash, \
-                                    e.g. `setup`, `background`, `mcp`, `model`. Use `help` to list them."
+                    "description": if self.ui.is_some() {
+                        "Slash command name, with or without the leading slash, \
+                         e.g. `setup`, `background`, `mcp`, `model`. Use `help` to list them."
+                    } else {
+                        "Slash command name, with or without the leading slash, \
+                         e.g. `setup`, `background`. Use `help` to list them."
+                    }
                 },
                 "args": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Ordered command arguments, e.g. [`reload`] for /mcp, \
-                                    [`openai/gpt-5.4`] for /model, or [`reauthenticate`, `codex_browser`] for /setup."
+                    "description": if self.ui.is_some() {
+                        "Ordered command arguments, e.g. [`reload`] for /mcp, \
+                         [`openai/gpt-5.4`] for /model, or [`reauthenticate`, `codex_browser`] for /setup."
+                    } else {
+                        "Ordered command arguments, e.g. [`reauthenticate`, `codex_browser`] for /setup."
+                    }
                 }
             },
             "required": ["command"],
@@ -719,5 +740,41 @@ mod tests {
         assert!(result.is_success(), "tool result: {result:?}");
         assert_eq!(dispatch.executed(), vec![("quit".to_string(), None)]);
         assert!(ui.take().is_empty());
+    }
+
+    /// Without a host UI (ACP, --print) ClientCommandsCapability is omitted, so
+    /// the tool description must not name terminal-only commands like /mcp.
+    /// Naming them prompts a doomed run_command that fails with unknown command.
+    #[tokio::test]
+    async fn run_command_description_is_host_aware() {
+        let headless = headless_tool(RecordingDispatch::registry());
+        let terminal = terminal_tool(
+            RecordingDispatch::registry(),
+            Arc::new(RecordingUi::default()),
+        );
+
+        for name in ["mcp", "/mcp", "/model", "/tools", "/cwd"] {
+            assert!(
+                !headless.description().contains(name),
+                "headless description must not advertise {name}: {}",
+                headless.description()
+            );
+        }
+        assert!(
+            headless.description().contains("Use `command: help`"),
+            "headless description must still point at the live list"
+        );
+        let schema = headless.parameters_schema();
+        let schema_text = serde_json::to_string(&schema).expect("schema serializes");
+        assert!(
+            !schema_text.contains("/mcp") && !schema_text.contains("`mcp`"),
+            "headless schema must not use /mcp examples: {schema_text}"
+        );
+
+        assert!(
+            terminal.description().contains("`mcp`"),
+            "terminal description keeps the /mcp path: {}",
+            terminal.description()
+        );
     }
 }

--- a/src/capabilities/mcp.rs
+++ b/src/capabilities/mcp.rs
@@ -32,12 +32,13 @@ impl Capability for McpCapability {
         Some("Extensibility")
     }
 
-    // No system-prompt contribution: mutations live on the command path
-    // (`yolop mcp ...`, `/mcp ...` via run_command), documented there.
+    // No system-prompt contribution: mutations live on the CLI command path
+    // (`yolop mcp ...` everywhere, `/mcp ...` terminal-only via run_command),
+    // documented there.
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        // Mutations are CLI-only (`yolop mcp ...` and `/mcp ...` reached through
-        // run_command). The model gets the read-only list; nothing here competes
+        // Mutations are CLI-only (`yolop mcp ...` everywhere, `/mcp ...`
+        // terminal-only reached through run_command). The model gets the read-only list; nothing here competes
         // with the command path, so there is no second reload story to forget.
         vec![Box::new(ListMcpServersTool {
             store: self.store.clone(),


### PR DESCRIPTION
## What changed

`run_command` description and parameters schema in `src/capabilities/agent_commands.rs` are now host-aware. Without a host UI (ACP, `--print`) they omit terminal-only commands (`help`, `tools`, `mcp`, `cwd`, `status`, `model`, `effort`, `clear`, `quit`) and point at the live list via `command: help`. The terminal variant is unchanged apart from backticking command names. MCP comments and `knowledge/specs/acp.md` now mark `/mcp` terminal-only and state ACP has no `/mcp` command.

## Why

In ACP the model was told about `/mcp` via `run_command`, then attempted it and failed with unknown command, since `ClientCommandsCapability` (which owns `/mcp`) is registered for TUI only. The agent should never be prompted with a command that does not exist on its host.

## Before / After

Before (ACP): `run_command` description listed `mcp` and schema examples referenced `/mcp` and `/model`, inviting a dispatch that errors with `unknown yolop command: /mcp`.

After (ACP): description lists only `setup`, `background`, `undo`, `redo`, `rewind`, `goal`, plus whatever the session registers, with `command: help` as the discovery path. No observable behavior change in the terminal.

Proof: `cargo test --workspace --features yolop-yep/schema capabilities::agent_commands`, 16/16 pass, including new `run_command_description_is_host_aware`.

## Validation

- `cargo fmt --check`, clean
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, clean
- `cargo test --workspace --features yolop-yep/schema capabilities::agent_commands`, 16/16 pass
- `python3 scripts/validate_okf.py knowledge --check-links`, 44 concepts, 0 errors
- `cargo run -- --provider llmsim -p "hi"`, binary starts and responds

## Security

Prompt-text-only change plus spec and comment wording. No filesystem, shell, key handling, capability registration, or dependency changes. No injection, traversal, or exposure surface.

## Follow-ups

No follow-ups.

## Knowledge

Updated concept: `knowledge/specs/acp.md` (Host-specific tool surface: MCP mutations CLI-only, `/mcp` terminal-only, ACP uses `command: help` for discovery).