### PR TITLE
feat(capabilities): unify names and move self-configuration behind CLI control routes

### DIFF
--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -71,7 +71,7 @@ const HARNESS_VARIANTS: &[HarnessVariant] = &[
         name: "no-ast-grep",
         settings: "[[capabilities]]\nref = \"ast_grep\"\nenabled = false\n",
     },
-    // Reveal gating (`yolop_tool_reveal`) holds the `config` and `memory` how-to
+    // Reveal gating (`tool_reveal`) holds the `config` and `memory` how-to
     // prose back until `tool_search` loads one of their schemas. Disabling it
     // restores the always-on blocks, which is the A/B for the gate itself: does
     // withholding that prose until the tools are callable cost any task success?
@@ -81,7 +81,7 @@ const HARNESS_VARIANTS: &[HarnessVariant] = &[
     // not a settings toggle.
     HarnessVariant {
         name: "no-tool-reveal",
-        settings: "[[capabilities]]\nref = \"yolop_tool_reveal\"\nenabled = false\n",
+        settings: "[[capabilities]]\nref = \"tool_reveal\"\nenabled = false\n",
     },
 ];
 

--- a/knowledge/specs/approval.md
+++ b/knowledge/specs/approval.md
@@ -51,7 +51,7 @@ omitted from the file to keep it sparse.
 
 ### System-prompt injection
 
-The `yolop_approval` capability reads the level **live each turn** and
+The `approval` capability reads the level **live each turn** and
 contributes a `<soft_approval>` block to the system prompt:
 
 - `off` contributes nothing.

--- a/knowledge/specs/conversational-control.md
+++ b/knowledge/specs/conversational-control.md
@@ -29,16 +29,18 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 ## Required behavior
 
 1. **Live, agent-invocable, no confirmation.** Each control surface listed below
-   exposes a model-facing tool that (a) the agent can call from a natural-language
-   request or autonomously, (b) takes effect on the **live session** (at the latest,
-   the next turn, never "next process run only"), and (c) does not require the user
-   to confirm an interactive overlay.
+   is reachable conversationally, either through a model-facing tool or through the
+   attached CLI (`yolop <subcommand> ...` in the foreground Bash tool), that
+   (a) the agent can call from a natural-language request or autonomously,
+   (b) takes effect on the **live session** (at the latest, the next turn, never
+   "next process run only"), and (c) does not require the user to confirm an
+   interactive overlay.
 
 2. **One implementation, many front-ends.** A control's mutation logic lives in one
-   place; the slash command, any overlay, and the agent tool all route through it.
-   Adding a tool must not fork the logic, it shares the command's code path so
+   place; the slash command, any overlay, and the attached CLI all route through it.
+   Adding a front-end must not fork the logic, it shares the command's code path so
    validation, persistence, and live application are identical. (`SetupController` is
-   the reference: `/setup`, the model picker overlay, and the `set_*` tools all call
+   the reference: `/setup`, the model picker overlay, and `yolop setup ...` all call
    its `change_*` methods.) Model selection applies immediately but is persisted only
    after that model completes a successful turn, so an inaccessible or unsupported
    model does not become the next session's default.
@@ -53,19 +55,22 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
    smallest change; do not thrash").
 
 5. **New control surfaces inherit this contract.** Any future setting, mode, or
-   resource a user can change in a session ships with its conversational tool in the
-   same change, not as a follow-up. A control that is only a slash command, only an
-   overlay, or only a next-run settings key is incomplete and should be treated as a
-   bug against this spec.
+   resource a user can change in a session ships with its attached CLI
+   (`yolop <subcommand> ...` plus a control route for prompt discovery) in the
+   same change, not as a follow-up. Configuration capabilities do not get
+   model-invoked mutation tools: the CLI keeps secrets and credentials on the
+   human-driven path and out of tool schemas. A control that is only a slash
+   command, only an overlay, or only a next-run settings key is incomplete and
+   should be treated as a bug against this spec.
 
 ## Current control surfaces
 
 | Surface | Conversational tool | Front-ends sharing the logic |
 |---|---|---|
-| Reasoning effort | `set_reasoning_effort` | `/effort` overlay, `/setup effort` |
-| Model | `search_models` / `set_model` | `/model` overlay, `/setup model` |
+| Reasoning effort | `yolop model use <id>:<effort>` (attached CLI) | `/effort` overlay, `/setup effort` |
+| Model | `yolop model use <target>` (attached CLI) | `/model` overlay, `/setup model` |
 | Model list (the menu `/model` and ACP offer) | `yolop config models …` (attached CLI) | `/model` overlay, `[[models]]` in settings |
-| Provider | `set_provider` | `/setup provider` |
+| Provider | `yolop setup login <provider>` (attached CLI) | `/setup provider` |
 | Skills, list | `list_skills` (upstream) | system-prompt listing |
 | Skills, package management | `yolop skills` (attached CLI) | skills control route |
 | Hooks, configuration | `yolop config hooks` (attached CLI) | hooks control route |
@@ -74,17 +79,19 @@ command, an overlay confirmation, or a next-run-only settings write fail this ba
 
 Notes:
 
-- `set_model` / `set_provider` / `set_reasoning_effort` apply to the live session; the
+- `yolop model use` / `yolop setup login` apply to the live session; the
   `/model` and `/effort` overlays still exist for humans, but the agent no longer
   needs them (it does not pre-seed an overlay the user must confirm).
-- `search_models` queries usable providers through the runtime driver registry and
-  returns provider-qualified matches. `set_model` rejects a partial name when it
-  matches discovered models but is not an exact ID for the current provider.
+- `yolop model` (show) lists usable models through the runtime driver registry.
+  `yolop model use` rejects a partial name when it matches discovered models but
+  is not an exact ID for the current provider; append `:effort` to set effort
+  (`yolop model use openai/gpt-5.4:high`). Never guess an ID: list first.
 - `yolop config model show|set|clear` owns persistent model selection, while
   `yolop config models` edits the persisted ordered list. Attached list edits
   also refresh the current session menu; neither command switches the live model.
-- **Attached administration is the deliberate exception to "a model-facing tool".**
-  Extension, coordination, and model-list administration is reachable conversationally by
+- **Attached administration is the rule for configuration, not the exception.**
+  Extension, coordination, model-list, MCP, connector, model, and setup
+  administration is reachable conversationally by
   running `yolop <subcommand> ...` in the foreground Bash tool, which the host
   attaches to the live session, rather than by tool schemas that would cost
   context every turn. It still meets the rest of this contract: live effect,
@@ -103,12 +110,14 @@ Notes:
 
 - **Mid-turn reasoning-effort change** (within a single `run_turn`, not just at the
   next turn boundary) requires upstream `everruns-host` support and is tracked in
-  **EVE-595**. `set_reasoning_effort` delivers turn-boundary escalation today.
+  **EVE-595**. `yolop model use <id>:<effort>` delivers turn-boundary escalation today.
 
 ## Ownership boundary
 
 - This spec owns the conversational-control contract and the inventory above.
-- `crate::capabilities::host` owns `SetupController` and the `set_*` tools.
+- `crate::capabilities::host` owns `SetupController`; model and session
+  configuration reach it through `yolop model ...` and `yolop setup ...`, not
+  through model-invoked tools.
 - `crate::capabilities::skills` owns attached skill package management;
   `crate::capabilities::skill_registry` owns its skills.sh client. The upstream
   `ScopedSkillsCapability` owns model-visible `list_skills` and `activate_skill`

--- a/knowledge/specs/goal.md
+++ b/knowledge/specs/goal.md
@@ -6,7 +6,7 @@ description: Defines the product goal and principles that guide Yolop developmen
 
 # `/goal`, autonomous completion loops
 
-Status: implemented in yolop (`yolop_goal` capability).
+Status: implemented in yolop (`goal` capability).
 
 ## Why
 

--- a/knowledge/specs/reasoning-effort.md
+++ b/knowledge/specs/reasoning-effort.md
@@ -153,5 +153,5 @@ untouched.
 - [Model list](model-list.md), the menu of models a session offers, whose entries
   may pin an effort.
 - [Conversational control](conversational-control.md), the control surfaces
-  (`set_reasoning_effort`, `/effort`, `/setup effort`) this metadata feeds.
+  (`yolop model use <id>:<effort>`, `/effort`, `/setup effort`) this metadata feeds.
 - [ACP](acp.md), the `reasoning_effort` config option served to editors.

--- a/knowledge/specs/tool-search.md
+++ b/knowledge/specs/tool-search.md
@@ -116,7 +116,7 @@ contributing how-to prose. Discovery text stays ungated, see
 
 The registry reads `tool_search`'s own result rather than mirroring upstream
 state, so it cannot drift from what the model was shown. Gating is meaningless
-without deferral, so `yolop_tool_reveal` is enabled alongside
+without deferral, so `tool_reveal` is enabled alongside
 `TOOL_SEARCH_CAPABILITY_ID`.
 
 ## Non-goals

--- a/knowledge/specs/user-ask.md
+++ b/knowledge/specs/user-ask.md
@@ -6,7 +6,7 @@ description: Defines the user ask, request tracking and turn-end validation cont
 
 # User ask, request tracking and turn-end validation
 
-Status: experimental and opt-in through the `yolop_user_ask` capability.
+Status: experimental and opt-in through the `user_ask` capability.
 
 ## Why
 
@@ -58,7 +58,7 @@ with:
 
 ```toml
 [[capabilities]]
-ref = "yolop_user_ask"
+ref = "user_ask"
 enabled = true
 ```
 

--- a/knowledge/specs/yolop.md
+++ b/knowledge/specs/yolop.md
@@ -34,7 +34,7 @@ section listing only the routes actually registered. It exposes no tools and no
 slash commands.
 
 Concrete self-configuration, settings, memory, hooks, approval, skills, lives
-in the capabilities that own those surfaces (`yolop_config`, `memory`, `hooks`,
+in the capabilities that own those surfaces (`config`, `memory`, `hooks`,
 and so on). This capability does not route to them; their own prompts and skills
 carry that guidance.
 

--- a/src/capabilities/agent_commands.rs
+++ b/src/capabilities/agent_commands.rs
@@ -30,7 +30,7 @@ use everruns_provider::ToolCall;
 use serde_json::{Value, json};
 use std::sync::Arc;
 
-pub(crate) const AGENT_COMMANDS_CAPABILITY_ID: &str = "yolop_agent_commands";
+pub(crate) const AGENT_COMMANDS_CAPABILITY_ID: &str = "agent_commands";
 
 /// Raw text on purpose: the host wraps `system_prompt_addition` in `<capability>`
 /// tags once, so tags here would render twice.

--- a/src/capabilities/approval.rs
+++ b/src/capabilities/approval.rs
@@ -38,7 +38,7 @@ use everruns_provider::{BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition}
 use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 
-pub(crate) const APPROVAL_CAPABILITY_ID: &str = "yolop_approval";
+pub(crate) const APPROVAL_CAPABILITY_ID: &str = "approval";
 
 /// A critical action yolop has stopped in front of, waiting for the user to
 /// say yes.

--- a/src/capabilities/attribution.rs
+++ b/src/capabilities/attribution.rs
@@ -12,13 +12,13 @@ use async_trait::async_trait;
 use everruns_core::{Capability, CapabilityStatus, SystemPromptContext};
 use std::sync::Arc;
 
-pub(crate) const ATTRIBUTION_CAPABILITY_ID: &str = "yolop_attribution";
+pub(crate) const ATTRIBUTION_CAPABILITY_ID: &str = "attribution";
 pub(crate) const YOLOP_ATTRIBUTION_TRAILER: &str = "Co-Authored-By: yolop <yolop@everruns.com>";
 pub(crate) const YOLOP_PR_ATTRIBUTION: &str = "Produced by [yolop](https://everruns.com/yolop)";
 
 /// Render the `## Attribution` system-prompt block. Pure so it is unit-testable
 /// without a `SystemPromptContext`.
-pub(crate) fn yolop_attribution_prompt() -> String {
+pub(crate) fn attribution_prompt() -> String {
     format!(
         "<capability id=\"{ATTRIBUTION_CAPABILITY_ID}\">\n\
 ## Attribution
@@ -59,12 +59,10 @@ impl Capability for AttributionCapability {
         Some("Examples")
     }
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        self.config
-            .attribution_enabled()
-            .then(yolop_attribution_prompt)
+        self.config.attribution_enabled().then(attribution_prompt)
     }
     fn system_prompt_preview(&self) -> Option<String> {
-        Some(yolop_attribution_prompt())
+        Some(attribution_prompt())
     }
 }
 
@@ -88,7 +86,7 @@ mod tests {
             .await
             .expect("enabled attribution prompt");
         assert!(enabled.contains(YOLOP_ATTRIBUTION_TRAILER));
-        assert!(enabled.starts_with("<capability id=\"yolop_attribution\">\n"));
+        assert!(enabled.starts_with("<capability id=\"attribution\">\n"));
         assert!(enabled.trim_end().ends_with("</capability>"));
         assert_eq!(
             YOLOP_PR_ATTRIBUTION,

--- a/src/capabilities/checkpoint.rs
+++ b/src/capabilities/checkpoint.rs
@@ -12,7 +12,7 @@ use everruns_provider::{ToolCall, ToolHints};
 use serde_json::{Value, json};
 use std::sync::Arc;
 
-pub(crate) const CHECKPOINT_CAPABILITY_ID: &str = "yolop_checkpoint";
+pub(crate) const CHECKPOINT_CAPABILITY_ID: &str = "checkpoint";
 
 pub(crate) struct CheckpointCapability {
     pub(crate) manager: Arc<CheckpointManager>,

--- a/src/capabilities/client_commands.rs
+++ b/src/capabilities/client_commands.rs
@@ -26,7 +26,7 @@ use everruns_core::command::{
 use everruns_core::{Capability, CapabilityStatus};
 use std::sync::Arc;
 
-pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "yolop_client_commands";
+pub(crate) const CLIENT_COMMANDS_CAPABILITY_ID: &str = "client_commands";
 
 /// Raw text on purpose: the host wraps `system_prompt_addition` in `<capability>`
 /// tags once, so tags here would render twice.

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -180,7 +180,7 @@ impl ConfigCommandLine {
     }
 }
 
-pub(crate) const CONFIG_CAPABILITY_ID: &str = "yolop_config";
+pub(crate) const CONFIG_CAPABILITY_ID: &str = "config";
 
 pub(crate) struct ConfigCapability {
     pub(crate) settings: Arc<SettingsStore>,

--- a/src/capabilities/host.rs
+++ b/src/capabilities/host.rs
@@ -1,8 +1,6 @@
 // Host/example capabilities for yolop: local environment context, bash, and
 // TUI-facing slash commands that mutate this process's provider selection.
 
-use crate::capabilities::model_discovery::search_configured_models;
-use crate::capabilities::narration::stable_labeled;
 use crate::config::service::ConfigService;
 use crate::config::{ApprovalMode, SettingsStore};
 use crate::exec::tools::{BashTool, Workspace};
@@ -13,12 +11,10 @@ use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
-use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
 use everruns_core::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::{Tool, ToolExecutionResult};
 use everruns_host::RuntimeProviderStore;
-use everruns_provider::ToolCall;
-use serde_json::{Value, json};
+use serde_json::json;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -512,7 +508,7 @@ fn git_output(workspace_root: &Path, args: &[&str]) -> Option<String> {
 
 // ---------- bash ----------
 
-pub(crate) const CODING_BASH_CAPABILITY_ID: &str = "yolop_bash";
+pub(crate) const CODING_BASH_CAPABILITY_ID: &str = "bash";
 
 pub(crate) struct CodingBashCapability {
     pub(crate) workspace: Workspace,
@@ -700,10 +696,10 @@ pub(crate) struct ModelsCapability {
 }
 
 impl ModelsCapability {
-    /// The shared, cloneable handle the `/setup` command and the model-facing
-    /// `set_*` tools both drive. Everything that mutates the live provider/model
-    /// lives on [`SetupController`] so the slash command and the agent tools
-    /// route through one implementation — there is no second config path.
+    /// The shared, cloneable handle the `/setup` command and the `yolop model ...` /
+    /// `yolop setup ...` commands both drive. Everything that mutates the live
+    /// provider/model lives on [`SetupController`] so the slash command and the
+    /// CLI route through one implementation — there is no second config path.
     fn controller(&self) -> SetupController {
         SetupController {
             provider: self.provider.clone(),
@@ -736,8 +732,8 @@ pub(crate) fn setup_controller(
 /// Live provider/model/effort controller. Holds the same handles as
 /// [`ModelsCapability`] and owns every mutation (`change_provider`,
 /// `change_model`, `change_effort`, tokens, urls, attribution, approval). The
-/// slash command (`execute_command`) and the agent-facing `set_*` tools both
-/// call these methods, so a natural-language request and a typed `/setup`
+/// slash command (`execute_command`) and the `yolop setup ...` commands both
+/// call these methods, so a CLI invocation and a typed `/setup`
 /// apply identically and take effect on the live session.
 #[derive(Clone)]
 pub(crate) struct SetupController {
@@ -778,25 +774,9 @@ impl Capability for ModelsCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        // The model-facing surface for live session control. Each tool routes
-        // through the same `SetupController` the `/setup` command uses, so a
-        // natural-language request ("switch to high effort", "use gpt-5.4")
-        // applies to the running session exactly like the slash command — no
-        // overlay, no next-run-only deferral. See knowledge/specs/conversational-control.md.
-        vec![
-            Box::new(SetReasoningEffortTool {
-                controller: self.controller(),
-            }),
-            Box::new(SearchModelsTool {
-                settings: self.settings.clone(),
-            }),
-            Box::new(SetModelTool {
-                controller: self.controller(),
-            }),
-            Box::new(SetProviderTool {
-                controller: self.controller(),
-            }),
-        ]
+        // Model and session configuration is CLI-driven (`yolop model ...`,
+        // `yolop setup ...`); no model-invoked mutation tools.
+        Vec::new()
     }
 
     async fn execute_command(
@@ -843,9 +823,7 @@ impl Capability for ModelsCapability {
 // mid-task, are judgement calls left to the model.
 /// Raw text on purpose: the host wraps `system_prompt_addition` in `<capability>`
 /// tags once, so tags here would render twice.
-pub(crate) const MODELS_PROMPT: &str = "`set_reasoning_effort`, `set_model`, and `set_provider` apply \
-    next turn. For partial model names, call `search_models`, show ambiguous matches, \
-    and never guess an ID. Unknown effort levels return accepted values.";
+pub(crate) const MODELS_PROMPT: &str = "Configure models through `yolop model ...` and \n    `yolop setup ...` (foreground Bash) or `/model`, `/setup`, `/effort`. Changes apply \n    next turn. Never guess IDs: run `yolop model` or `yolop setup status` first. Switch \n    with `yolop model use <target>` (label, id, or provider/model with optional `:effort`); \n    authenticate providers with `yolop setup login <provider>.";
 
 fn setup_command_arg() -> CommandArg {
     let mut suggestions = vec![
@@ -1043,10 +1021,6 @@ impl SetupController {
             error_code: None,
             error_fields: None,
         })
-    }
-
-    async fn change_model(&self, raw: &str) -> everruns_provider::error::Result<CommandResult> {
-        self.change_model_with_persistence(raw, false).await
     }
 
     async fn change_model_and_persist(
@@ -1464,292 +1438,6 @@ fn failed_result(message: String) -> CommandResult {
     }
 }
 
-// ---------- model-facing live-config tools ----------
-//
-// These expose the `SetupController` mutations as agent tools so the model can
-// reconfigure the running session from a natural-language request (or on its
-// own), instead of asking the user to type `/setup` or confirm an overlay. They
-// reuse the exact `change_*` logic the slash command uses, so behavior — live
-// application, validation, persistence — is identical across both entry points.
-
-/// Map a `change_*` outcome onto a tool result: a failed (but non-erroring)
-/// `CommandResult` becomes a recoverable tool error carrying the same message
-/// (e.g. an unknown effort plus the valid set), so the model can correct itself.
-fn into_tool_result(
-    outcome: everruns_provider::error::Result<CommandResult>,
-) -> ToolExecutionResult {
-    match outcome {
-        Ok(result) if result.success => ToolExecutionResult::success(json!({
-            "success": true,
-            "message": result.message,
-        })),
-        Ok(result) => ToolExecutionResult::tool_error(result.message),
-        Err(err) => ToolExecutionResult::tool_error(err.to_string()),
-    }
-}
-
-fn required_str_arg<'a>(arguments: &'a Value, key: &str) -> Result<&'a str, ToolExecutionResult> {
-    match arguments.get(key).and_then(Value::as_str) {
-        Some(value) if !value.trim().is_empty() => Ok(value.trim()),
-        _ => Err(ToolExecutionResult::tool_error(format!(
-            "'{key}' is required"
-        ))),
-    }
-}
-
-struct SetReasoningEffortTool {
-    controller: SetupController,
-}
-
-#[async_trait]
-impl Tool for SetReasoningEffortTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let effort = arg_str(&tool_call.arguments, &["effort"]).map(|value| truncate(value, 24));
-        Some(stable_labeled("Set reasoning effort", effort, phase))
-    }
-
-    fn name(&self) -> &str {
-        "set_reasoning_effort"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Set reasoning effort")
-    }
-    fn description(&self) -> &str {
-        "Change the current model's reasoning effort for this session (e.g. escalate to think \
-         harder before a difficult step, or deescalate for cheap follow-ups). Applies on the next \
-         turn — no restart. The valid set is model-specific; if the level is unknown the tool \
-         returns the accepted values so you can retry."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "effort": {
-                    "type": "string",
-                    "description": "Reasoning-effort level for the active model, e.g. low / medium / high (model-specific)."
-                }
-            },
-            "required": ["effort"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let effort = match required_str_arg(&arguments, "effort") {
-            Ok(value) => value,
-            Err(err) => return err,
-        };
-        into_tool_result(self.controller.change_effort(effort).await)
-    }
-}
-
-struct SearchModelsTool {
-    settings: Arc<SettingsStore>,
-}
-
-#[async_trait]
-impl Tool for SearchModelsTool {
-    fn name(&self) -> &str {
-        "search_models"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Search models")
-    }
-    fn description(&self) -> &str {
-        "Search model IDs and display names across all currently usable providers. Use this before set_model for a partial or unqualified model name."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({"type":"object","properties":{"query":{"type":"string"}},"required":["query"],"additionalProperties":false})
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let Some(query) = arguments.get("query").and_then(Value::as_str) else {
-            return ToolExecutionResult::tool_error("missing required string 'query'");
-        };
-        if query.trim().is_empty() {
-            return ToolExecutionResult::tool_error("'query' must not be empty");
-        }
-        let result = search_configured_models(&self.settings.snapshot(), query).await;
-        ToolExecutionResult::success(
-            json!({"query":query,"matches":result.matches.into_iter().map(|item| json!({"provider":item.provider,"model":item.model_id,"display_name":item.display_name})).collect::<Vec<_>>(),"providers_searched":result.providers_searched,"provider_errors":result.provider_errors}),
-        )
-    }
-}
-
-struct SetModelTool {
-    controller: SetupController,
-}
-
-#[async_trait]
-impl Tool for SetModelTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let model = arg_str(&tool_call.arguments, &["model"]).map(|value| truncate(value, 48));
-        Some(stable_labeled("Set model", model, phase))
-    }
-
-    fn name(&self) -> &str {
-        "set_model"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Set model")
-    }
-    fn description(&self) -> &str {
-        "Switch to an exact model ID for the current provider. For a partial name, call search_models first; never pass an unresolved fragment."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "model": {
-                    "type": "string",
-                    "description": "Model id for the active provider, e.g. `gpt-5.4` or `claude-sonnet-4-5`."
-                },
-                "reasoning_effort": {
-                    "type": "string",
-                    "description": "Optional reasoning-effort level to apply with the model (model-specific)."
-                }
-            },
-            "required": ["model"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let query = match required_str_arg(&arguments, "model") {
-            Ok(value) => value,
-            Err(err) => return err,
-        };
-        let search = search_configured_models(&self.controller.settings.snapshot(), query).await;
-        let current_provider = self
-            .controller
-            .provider
-            .read()
-            .expect("provider lock poisoned")
-            .provider_name()
-            .to_string();
-        let resolved = match resolve_model_match(query, &search.matches) {
-            Ok(model) => Some(model),
-            Err(_) if search.matches.is_empty() => None,
-            Err(message) => return ToolExecutionResult::tool_error(message),
-        };
-        let model_id = resolved.map_or(query, |model| model.model_id.as_str());
-        let spec = match arguments.get("reasoning_effort").and_then(Value::as_str) {
-            Some(effort) if !effort.trim().is_empty() => {
-                format!("{model_id} {}", effort.trim())
-            }
-            _ => model_id.to_string(),
-        };
-        let result = match resolved {
-            Some(model) if model.provider != current_provider => {
-                self.controller
-                    .change_provider(&format!("{} {spec}", model.provider))
-                    .await
-            }
-            _ => self.controller.change_model(&spec).await,
-        };
-        into_tool_result(result)
-    }
-}
-
-fn resolve_model_match<'a>(
-    query: &str,
-    matches: &'a [crate::capabilities::model_discovery::ModelSearchMatch],
-) -> Result<&'a crate::capabilities::model_discovery::ModelSearchMatch, String> {
-    if let Some(exact) = matches.iter().find(|candidate| candidate.model_id == query) {
-        return Ok(exact);
-    }
-    match matches {
-        [model] => Ok(model),
-        [] => Err(format!(
-            "No configured model matches `{query}`. Call search_models to see available models."
-        )),
-        _ => {
-            let choices = matches
-                .iter()
-                .take(5)
-                .map(|model| format!("{}: {}", model.provider, model.model_id))
-                .collect::<Vec<_>>()
-                .join(", ");
-            Err(format!(
-                "Multiple configured models match `{query}`. Top matches: {choices}. Pass one exact model ID to set_model."
-            ))
-        }
-    }
-}
-
-struct SetProviderTool {
-    controller: SetupController,
-}
-
-#[async_trait]
-impl Tool for SetProviderTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let provider =
-            arg_str(&tool_call.arguments, &["provider"]).map(|value| truncate(value, 24));
-        Some(stable_labeled("Set provider", provider, phase))
-    }
-
-    fn name(&self) -> &str {
-        "set_provider"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Set provider")
-    }
-    fn description(&self) -> &str {
-        "Switch the LLM provider for this session. Applies on the next turn — no restart. \
-         Optionally pin a model for the new provider at the same time. Requires that provider's \
-         credentials to already be configured."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "provider": {
-                    "type": "string",
-                    "description": "Provider name.",
-                    "enum": SUPPORTED_PROVIDERS
-                },
-                "model": {
-                    "type": "string",
-                    "description": "Optional model id to select for the new provider."
-                }
-            },
-            "required": ["provider"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let provider = match required_str_arg(&arguments, "provider") {
-            Ok(value) => value,
-            Err(err) => return err,
-        };
-        // `change_provider` accepts `provider [model]`, switching both at once.
-        let spec = match arguments.get("model").and_then(Value::as_str) {
-            Some(model) if !model.trim().is_empty() => format!("{provider} {}", model.trim()),
-            _ => provider.to_string(),
-        };
-        into_tool_result(self.controller.change_provider(&spec).await)
-    }
-}
-
 impl ModelsCapability {
     /// True when no provider preference is saved and no API token is set —
     /// either via env var or in the settings file. Used by the TUI at
@@ -1884,32 +1572,7 @@ mod tests {
     use super::*;
     use test_support::test_controller;
 
-    // ---------- live-config tools (set_model / set_provider / set_reasoning_effort) ----------
-
-    #[tokio::test]
-    async fn set_reasoning_effort_tool_applies_live_and_validates() {
-        let (controller, provider, _dir) = test_controller(ProviderChoice::OpenAi {
-            model: "gpt-5.5".to_string(),
-            reasoning_effort: Some("medium".to_string()),
-        });
-        let tool = SetReasoningEffortTool {
-            controller: controller.clone(),
-        };
-
-        // Escalate: the shared handle reflects the new effort immediately.
-        let result = tool.execute(json!({ "effort": "high" })).await;
-        assert!(result.is_success(), "escalate: {result:?}");
-        assert_eq!(provider.read().unwrap().reasoning_effort(), Some("high"));
-
-        // A missing argument is a tool error before anything is mutated.
-        let result = tool.execute(json!({})).await;
-        assert!(result.is_error(), "missing effort should error");
-
-        // An unknown level errors and leaves the prior selection intact.
-        let result = tool.execute(json!({ "effort": "ludicrous" })).await;
-        assert!(result.is_error(), "unknown effort should error");
-        assert_eq!(provider.read().unwrap().reasoning_effort(), Some("high"));
-    }
+    // ---------- live-config persistence (via SetupController; tools removed) ----------
 
     #[tokio::test]
     async fn model_choice_is_persisted_only_after_a_successful_turn() {
@@ -1940,58 +1603,7 @@ mod tests {
     }
 
     #[test]
-    fn model_match_resolution_returns_five_actionable_choices() {
-        use crate::capabilities::model_discovery::ModelSearchMatch;
-
-        let mut matches = vec![ModelSearchMatch {
-            provider: "openrouter".to_string(),
-            model_id: "openrouter/terra".to_string(),
-            display_name: Some("Terra".to_string()),
-        }];
-        assert_eq!(
-            resolve_model_match("terra", &matches).unwrap().model_id,
-            "openrouter/terra"
-        );
-
-        for index in 2..=6 {
-            matches.push(ModelSearchMatch {
-                provider: format!("provider-{index}"),
-                model_id: format!("terra-v{index}"),
-                display_name: Some(format!("Terra v{index}")),
-            });
-        }
-        let error = resolve_model_match("terra", &matches).unwrap_err();
-        assert!(error.contains("openrouter: openrouter/terra"));
-        assert!(error.contains("provider-5: terra-v5"));
-        assert!(!error.contains("provider-6: terra-v6"));
-        assert!(error.contains("Pass one exact model ID to set_model"));
-        assert_eq!(
-            resolve_model_match("terra-v2", &matches).unwrap().provider,
-            "provider-2"
-        );
-    }
-
-    #[tokio::test]
-    async fn set_model_tool_switches_model_and_optional_effort() {
-        let (controller, provider, _dir) = test_controller(ProviderChoice::OpenAi {
-            model: "gpt-5.5".to_string(),
-            reasoning_effort: Some("medium".to_string()),
-        });
-        let tool = SetModelTool { controller };
-
-        let result = tool
-            .execute(json!({ "model": "gpt-5.4", "reasoning_effort": "high" }))
-            .await;
-        assert!(result.is_success(), "set_model: {result:?}");
-        assert_eq!(provider.read().unwrap().model_id(), "gpt-5.4");
-        assert_eq!(provider.read().unwrap().reasoning_effort(), Some("high"));
-
-        let result = tool.execute(json!({})).await;
-        assert!(result.is_error(), "missing model should error");
-    }
-
-    #[test]
-    fn models_capability_exposes_live_config_tools() {
+    fn models_capability_is_cli_driven() {
         let (controller, _provider, _dir) = test_controller(ProviderChoice::Sim);
         let capability = ModelsCapability {
             provider: controller.provider.clone(),
@@ -2000,46 +1612,16 @@ mod tests {
             settings: controller.settings.clone(),
             pending_model_choice: controller.pending_model_choice.clone(),
         };
-        let names: Vec<String> = capability
-            .tools()
-            .iter()
-            .map(|t| t.name().to_string())
-            .collect();
-        for expected in [
-            "set_reasoning_effort",
-            "search_models",
-            "set_model",
-            "set_provider",
-        ] {
-            assert!(
-                names.iter().any(|n| n == expected),
-                "{expected} should be exposed by ModelsCapability: {names:?}"
-            );
-        }
-        // The agent is told these tools exist so it uses them instead of asking
-        // the user to type a slash command.
+        // Model and session configuration goes through `yolop model ...` and
+        // `yolop setup ...`; no model-invoked mutation tools remain.
+        assert!(capability.tools().is_empty());
         let prompt = capability.system_prompt_addition().expect("setup prompt");
         // system_prompt_addition is raw text: the host wraps it once. Tags here
         // would render twice (see agent_commands, client_commands).
         assert!(!prompt.contains("<capability"));
         assert!(!prompt.contains("</capability>"));
-        assert!(prompt.contains("set_reasoning_effort"));
-        assert!(prompt.contains("set_model"));
-        assert!(prompt.contains("search_models"));
-        assert!(prompt.contains("set_provider"));
-    }
-
-    #[tokio::test]
-    async fn set_provider_tool_switches_provider_live() {
-        let (controller, provider, _dir) = test_controller(ProviderChoice::Sim);
-        let tool = SetProviderTool { controller };
-
-        let result = tool.execute(json!({ "provider": "openai" })).await;
-        assert!(result.is_success(), "set_provider: {result:?}");
-        assert_eq!(provider.read().unwrap().provider_name(), "openai");
-
-        let result = tool.execute(json!({ "provider": "nope" })).await;
-        assert!(result.is_error(), "unknown provider should error");
+        assert!(prompt.contains("yolop model"));
+        assert!(prompt.contains("yolop setup"));
     }
 
     #[test]

--- a/src/capabilities/mcp.rs
+++ b/src/capabilities/mcp.rs
@@ -1,14 +1,18 @@
-use crate::capabilities::narration::stable_labeled;
 use crate::config::mcp::McpConfigStore;
+use crate::control::{ControlCapability, ControlResponse, ControlRoute};
 use async_trait::async_trait;
-use everruns_core::tool_narration::ToolNarrationPhase;
-use everruns_core::{Capability, CapabilityStatus};
-use everruns_core::{Tool, ToolExecutionResult};
-use everruns_provider::ToolCall;
+use everruns_core::{Capability, CapabilityStatus, Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub(crate) const MCP_CAPABILITY_ID: &str = "mcp";
+
+pub(crate) const MCP_CONTROL_ROUTE: ControlRoute = ControlRoute {
+    resource: MCP_CAPABILITY_ID,
+    cli_subcommand: "mcp",
+    read_only_operations: &["list"],
+    summary: "Inspect and manage MCP servers. Listing is served inline; every mutation runs through `yolop mcp ...`.",
+};
 
 pub(crate) struct McpCapability {
     pub(crate) store: Arc<McpConfigStore>,
@@ -32,48 +36,33 @@ impl Capability for McpCapability {
         Some("Extensibility")
     }
 
-    // No system-prompt contribution: mutations live on the CLI command path
-    // (`yolop mcp ...` everywhere, `/mcp ...` terminal-only via run_command),
-    // documented there.
+    // No system-prompt contribution: everything lives on the control route
+    // (`yolop mcp ...`), documented there.
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        // Mutations are CLI-only (`yolop mcp ...` everywhere, `/mcp ...`
-        // terminal-only reached through run_command). The model gets the read-only list; nothing here competes
-        // with the command path, so there is no second reload story to forget.
-        vec![Box::new(ListMcpServersTool {
-            store: self.store.clone(),
-        })]
+        // Fully CLI-driven (`yolop mcp ...` everywhere, `/mcp ...`
+        // terminal-only reached through run_command). The read-only list is
+        // served by the control route below; no model-invoked tools remain.
+        Vec::new()
     }
-}
-
-struct ListMcpServersTool {
-    store: Arc<McpConfigStore>,
 }
 
 #[async_trait]
-impl Tool for ListMcpServersTool {
-    fn narrate(
-        &self,
-        _tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        _locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        Some(stable_labeled("List MCP servers", None, phase))
+impl ControlCapability for McpCapability {
+    fn control_route(&self) -> ControlRoute {
+        MCP_CONTROL_ROUTE
     }
-    fn name(&self) -> &str {
-        "list_mcp_servers"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("List MCP servers")
-    }
-    fn description(&self) -> &str {
-        "List global and workspace MCP server configuration, including enabled state and override source."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({ "type": "object", "properties": {}, "additionalProperties": false })
-    }
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let operation = action
+            .get("operation")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if operation != "list" {
+            return ToolExecutionResult::tool_error(format!(
+                "unknown or write operation `{operation}`: manage MCP servers with `yolop mcp ...`"
+            ));
+        }
         match self.store.effective() {
             Ok(effective) => ToolExecutionResult::success(json!({
                 "ok": true,
@@ -84,10 +73,14 @@ impl Tool for ListMcpServersTool {
             Err(err) => ToolExecutionResult::tool_error(err),
         }
     }
+
+    fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+        response.render_default()
+    }
 }
 
 // MCP mutations live on the command path (`yolop mcp ...`, `/mcp ...`);
-// this capability intentionally exposes no mutation tools.
+// this capability intentionally exposes no model-invoked tools.
 
 #[cfg(test)]
 mod tests {
@@ -103,28 +96,46 @@ mod tests {
     }
 
     #[test]
-    fn tools_exposes_only_read_operations() {
+    fn tools_exposes_no_model_tools() {
         let (_tmp, store) = test_store();
         let capability = McpCapability { store };
-        let names: Vec<_> = capability
-            .tools()
-            .iter()
-            .map(|tool| tool.name().to_string())
-            .collect();
-        assert_eq!(names, vec!["list_mcp_servers".to_string()]);
+        assert!(capability.tools().is_empty());
+    }
+
+    #[test]
+    fn control_route_points_at_mcp_cli() {
+        let (_tmp, store) = test_store();
+        let capability = McpCapability { store };
+        let route = capability.control_route();
+        assert_eq!(route.resource, "mcp");
+        assert_eq!(route.cli_subcommand, "mcp");
+        assert_eq!(route.read_only_operations, &["list"]);
     }
 
     #[tokio::test]
-    async fn list_tool_reports_effective_configuration() {
+    async fn control_list_reports_effective_configuration() {
         let (_tmp, store) = test_store();
-        let tool = ListMcpServersTool {
-            store: store.clone(),
-        };
-        let result = tool.execute(json!({})).await;
-        let everruns_core::ToolExecutionResult::Success(value) = result else {
-            panic!("expected JSON success, got {result:?}");
+        let capability = McpCapability { store };
+        let response = capability
+            .execute_control(&json!({ "operation": "list" }))
+            .await;
+        let ToolExecutionResult::Success(value) = response else {
+            panic!("expected JSON success, got {response:?}");
         };
         assert_eq!(value["ok"], true);
         assert!(value["servers"].is_array());
+    }
+
+    #[tokio::test]
+    async fn control_rejects_mutations_toward_cli() {
+        let (_tmp, store) = test_store();
+        let capability = McpCapability { store };
+        let response = capability
+            .execute_control(&json!({ "operation": "remove", "name": "x" }))
+            .await;
+        let ToolExecutionResult::ToolError(message) = response else {
+            panic!("expected error, got {response:?}");
+        };
+        assert!(message.contains("yolop mcp"), "{message}");
     }
 }

--- a/src/capabilities/model_discovery.rs
+++ b/src/capabilities/model_discovery.rs
@@ -8,7 +8,7 @@
 // names and descriptions even when the provider's API returns bare ids.
 
 use crate::config::Settings;
-use crate::runtime::{ProviderChoice, SUPPORTED_PROVIDERS};
+use crate::runtime::ProviderChoice;
 use anyhow::{Context, Result, anyhow};
 use everruns_provider::model_profiles::get_model_profile;
 use everruns_provider::{DiscoveredModel, DriverRegistry, ProviderConfig};
@@ -342,74 +342,6 @@ fn provider_env_present(provider: &str) -> bool {
             .map(|value| !value.is_empty())
             .unwrap_or(false)
     })
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ModelSearchMatch {
-    pub(crate) provider: String,
-    pub(crate) model_id: String,
-    pub(crate) display_name: Option<String>,
-}
-
-#[derive(Debug, Default)]
-pub(crate) struct ModelSearchResult {
-    pub(crate) matches: Vec<ModelSearchMatch>,
-    pub(crate) providers_searched: Vec<String>,
-    pub(crate) provider_errors: Vec<String>,
-}
-
-/// Search driver-provided model catalogs across every currently usable provider.
-/// A provider failure is isolated so successful catalogs still contribute results.
-pub(crate) async fn search_configured_models(
-    settings: &Settings,
-    query: &str,
-) -> ModelSearchResult {
-    let needle = query.trim().to_lowercase();
-    let mut result = ModelSearchResult::default();
-    if needle.is_empty() {
-        return result;
-    }
-    for provider_name in SUPPORTED_PROVIDERS {
-        if !provider_is_usable(settings, provider_name) {
-            continue;
-        }
-        let choice = match ProviderChoice::default_for_provider_name(provider_name) {
-            Ok(choice) => choice,
-            Err(error) => {
-                result
-                    .provider_errors
-                    .push(format!("{provider_name}: {error}"));
-                continue;
-            }
-        };
-        result.providers_searched.push((*provider_name).to_string());
-        match discover_provider_models(&choice, settings).await {
-            Ok(Some(models)) => result
-                .matches
-                .extend(models.into_iter().filter_map(|model| {
-                    let display_name = model.display_name.clone();
-                    let display = display_name.as_deref().unwrap_or("");
-                    (model.model_id.to_lowercase().contains(&needle)
-                        || display.to_lowercase().contains(&needle))
-                    .then(|| ModelSearchMatch {
-                        provider: (*provider_name).to_string(),
-                        model_id: model.model_id,
-                        display_name,
-                    })
-                })),
-            Ok(None) => {}
-            Err(error) => result
-                .provider_errors
-                .push(format!("{provider_name}: {error}")),
-        }
-    }
-    result
-        .matches
-        .sort_by(|a, b| (&a.provider, &a.model_id).cmp(&(&b.provider, &b.model_id)));
-    result
-        .matches
-        .dedup_by(|a, b| a.provider == b.provider && a.model_id == b.model_id);
-    result
 }
 
 #[cfg(test)]

--- a/src/capabilities/skills.rs
+++ b/src/capabilities/skills.rs
@@ -346,7 +346,7 @@ fn write_if_changed(target: &Path, contents: &[u8]) -> std::io::Result<()> {
     std::fs::rename(&tmp, target)
 }
 
-pub(crate) const SKILL_MANAGEMENT_CAPABILITY_ID: &str = "yolop_skill_management";
+pub(crate) const SKILL_MANAGEMENT_CAPABILITY_ID: &str = "skill_management";
 
 /// Detached skill package and registry administration.
 pub(crate) struct SkillManagementCapability {

--- a/src/capabilities/tool_argument_validation.rs
+++ b/src/capabilities/tool_argument_validation.rs
@@ -17,7 +17,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-pub(crate) const TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID: &str = "yolop_tool_argument_validation";
+pub(crate) const TOOL_ARGUMENT_VALIDATION_CAPABILITY_ID: &str = "tool_argument_validation";
 const VALIDATOR_CACHE_LIMIT: usize = 128;
 const EXPECTED_SHAPE_DEPTH: usize = 3;
 const EXPECTED_OBJECT_PROPERTIES: usize = 32;

--- a/src/capabilities/tool_reveal.rs
+++ b/src/capabilities/tool_reveal.rs
@@ -30,7 +30,7 @@ use serde_json::Value;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-pub(crate) const TOOL_REVEAL_CAPABILITY_ID: &str = "yolop_tool_reveal";
+pub(crate) const TOOL_REVEAL_CAPABILITY_ID: &str = "tool_reveal";
 
 /// Upper bound on tracked sessions. The registry is process-wide (one harness
 /// serves every session), so without eviction a long-lived process would grow

--- a/src/capabilities/user_ask.rs
+++ b/src/capabilities/user_ask.rs
@@ -1,4 +1,4 @@
-//! Experimental `yolop_user_ask` — track the user's request and validate it
+//! Experimental `user_ask` — track the user's request and validate it
 //! after each turn.
 //!
 //! Independent of `/goal`: records what the user wants, allows updates when they

--- a/src/connectors/capability.rs
+++ b/src/connectors/capability.rs
@@ -1,28 +1,143 @@
-//! The `connectors` capability — discover, connect, and disconnect sandbox
-//! and integration backends through a uniform tool surface.
+//! External connector credentials (Daytona, …).
+//!
+//! The management surface is CLI-only: `yolop connectors ...` owns every
+//! mutation, and the control route below serves read-only inspection. No
+//! model-invoked tools remain.
 
-use crate::capabilities::narration::stable_labeled;
 use crate::connectors::catalog::{ConnectionCatalog, ConnectorInfo};
 use crate::connectors::store::ConnectionStore;
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
 use async_trait::async_trait;
-use everruns_core::tool_narration::{ToolNarrationPhase, arg_str, truncate};
-use everruns_core::{Capability, CapabilityStatus, SystemPromptContext};
-use everruns_core::{Tool, ToolExecutionResult};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use everruns_core::{Capability, CapabilityStatus, SystemPromptContext, ToolExecutionResult};
 use everruns_platform::ConnectorType;
-use everruns_provider::ToolCall;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub(crate) const CONNECTORS_CAPABILITY_ID: &str = "connectors";
 
+pub(crate) const CONNECTORS_CONTROL_ROUTE: ControlRoute = ControlRoute {
+    resource: CONNECTORS_CAPABILITY_ID,
+    cli_subcommand: "connectors",
+    read_only_operations: &["list", "get"],
+    summary: "Inspect and manage external connector credentials. Reads are served inline; connect and disconnect run through `yolop connectors ...`.",
+};
+
+#[derive(Clone)]
 pub(crate) struct ConnectorsCapability {
-    pub(crate) catalog: Arc<ConnectionCatalog>,
-    pub(crate) store: Arc<ConnectionStore>,
-    /// ACP has no secure model-facing credential input. Its optional loopback
-    /// setup page handles LLM providers, not connector forms, so exposing
-    /// `connect` there would invite users to paste secrets into the transcript.
-    pub(crate) expose_connect_tool: bool,
+    catalog: Arc<ConnectionCatalog>,
+    store: Arc<ConnectionStore>,
+}
+
+impl ConnectorsCapability {
+    pub(crate) fn new(catalog: Arc<ConnectionCatalog>, store: Arc<ConnectionStore>) -> Self {
+        Self { catalog, store }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub(crate) enum ConnectorsAction {
+    List,
+    Get {
+        provider: String,
+    },
+    Connect {
+        provider: String,
+        fields: HashMap<String, String>,
+    },
+    Disconnect {
+        provider: String,
+    },
+}
+
+impl ConnectorsCapability {
+    async fn execute_action(&self, action: &ConnectorsAction) -> ToolExecutionResult {
+        match action {
+            ConnectorsAction::List => {
+                let path = self.store.path().display().to_string();
+                let connectors: Vec<Value> = self
+                    .catalog
+                    .list_connectors(&self.store)
+                    .iter()
+                    .map(|info| connector_json_with_path(info, &path))
+                    .collect();
+                ToolExecutionResult::success(json!({
+                    "connectors": connectors,
+                    "count": connectors.len(),
+                    "storage_path": path,
+                }))
+            }
+            ConnectorsAction::Get { provider } => {
+                let provider = provider.trim();
+                if provider.is_empty() {
+                    return ToolExecutionResult::tool_error("Missing required parameter: provider");
+                }
+                let Some(entry) = self.catalog.get(provider) else {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Unknown connector `{provider}`"
+                    ));
+                };
+                let info = self.catalog.connector_info(entry, &self.store);
+                ToolExecutionResult::success(connector_json_with_path(
+                    &info,
+                    &self.store.path().display().to_string(),
+                ))
+            }
+            ConnectorsAction::Connect { provider, fields } => {
+                let provider = provider.trim();
+                if provider.is_empty() {
+                    return ToolExecutionResult::tool_error("Missing required parameter: provider");
+                }
+                let Some(entry) = self.catalog.get(provider) else {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Unknown connector `{provider}`"
+                    ));
+                };
+                if entry.connection_type() == ConnectorType::OAuth {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Connector `{provider}` uses OAuth and cannot be configured through the CLI yet"
+                    ));
+                }
+                match self
+                    .catalog
+                    .validate_and_store(&self.store, provider, fields.clone())
+                    .await
+                {
+                    Ok(validation) => ToolExecutionResult::success(json!({
+                        "provider": provider,
+                        "connected": true,
+                        "provider_username": validation.provider_username,
+                        "storage_path": self.store.path().display().to_string(),
+                    })),
+                    Err(message) => ToolExecutionResult::tool_error(message),
+                }
+            }
+            ConnectorsAction::Disconnect { provider } => {
+                let provider = provider.trim();
+                if provider.is_empty() {
+                    return ToolExecutionResult::tool_error("Missing required parameter: provider");
+                }
+                if self.catalog.get(provider).is_none() {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Unknown connector `{provider}`"
+                    ));
+                }
+                match self.store.clear(provider) {
+                    Ok(existed) => ToolExecutionResult::success(json!({
+                        "disconnected": true,
+                        "provider": provider,
+                        "removed": existed,
+                    })),
+                    Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -30,72 +145,152 @@ impl Capability for ConnectorsCapability {
     fn id(&self) -> &str {
         CONNECTORS_CAPABILITY_ID
     }
-
     fn name(&self) -> &str {
         "Connectors"
     }
-
     fn description(&self) -> &str {
         "Connect external sandbox and integration backends (Daytona, …) with a uniform interface."
     }
-
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
     }
-
     fn category(&self) -> Option<&str> {
         Some("Integrations")
     }
 
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        // The four tool descriptions cover discovery, setup, and credential
-        // management. What they cannot say is what a *connected* provider unlocks,
-        // because the `daytona_*` tools belong to another capability — so
-        // contribute that routing hint, and only once Daytona is actually
-        // connected. Nothing connected means nothing to route to, and the block
-        // costs zero.
-        self.store.is_connected("daytona").then(|| {
-            format!(
-                "<capability id=\"{id}\">\n\
-                 Daytona is connected: use the `daytona_*` tools to create isolated sandboxes \
-                 and outsource risky or heavy work away from the host workspace. Host `bash` \
-                 and file tools still operate on the local workspace.\n\
-                 </capability>",
-                id = self.id()
-            )
-        })
+        // Only Daytona currently has runtime behavior worth routing; without it
+        // connected this whole capability costs zero prompt tokens.
+        if !self.store.is_connected("daytona") {
+            return None;
+        }
+        let id = self.id();
+        Some(format!(
+            "<capability id=\"{id}\">\n\
+            The `daytona` connector is active: prefer the `daytona_*` tools over raw shell for \
+            sandbox work. Manage credentials with `yolop connectors ...` (foreground Bash).\n\
+            </capability>",
+        ))
     }
 
-    fn tools(&self) -> Vec<Box<dyn Tool>> {
-        let shared = ConnectorTools {
-            catalog: self.catalog.clone(),
-            store: self.store.clone(),
-        };
-        let mut tools: Vec<Box<dyn Tool>> = vec![
-            Box::new(ListConnectorsTool {
-                catalog: self.catalog.clone(),
-                store: self.store.clone(),
-            }),
-            Box::new(GetConnectorTool {
-                catalog: self.catalog.clone(),
-                store: self.store.clone(),
-            }),
-        ];
-        if self.expose_connect_tool {
-            tools.push(Box::new(ConnectTool { inner: shared }));
-        }
-        tools.push(Box::new(DisconnectTool {
-            catalog: self.catalog.clone(),
-            store: self.store.clone(),
-        }));
-        tools
+    fn tools(&self) -> Vec<Box<dyn everruns_core::Tool>> {
+        // Fully CLI-driven (`yolop connectors ...`); no model-invoked tools remain.
+        Vec::new()
     }
 }
 
-#[derive(Clone)]
-struct ConnectorTools {
-    catalog: Arc<ConnectionCatalog>,
-    store: Arc<ConnectionStore>,
+#[async_trait]
+impl ControlCapability for ConnectorsCapability {
+    fn control_route(&self) -> ControlRoute {
+        CONNECTORS_CONTROL_ROUTE
+    }
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let parsed: ConnectorsAction = match serde_json::from_value(action.clone()) {
+            Ok(action) => action,
+            Err(err) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "invalid connectors action: {err}"
+                ));
+            }
+        };
+        match &parsed {
+            ConnectorsAction::List | ConnectorsAction::Get { .. } => {
+                return self.execute_action(&parsed).await;
+            }
+            ConnectorsAction::Connect { .. } | ConnectorsAction::Disconnect { .. } => {
+                ToolExecutionResult::tool_error(
+                    "connect and disconnect run through `yolop connectors ...` so credentials stay on the human-driven path",
+                )
+            }
+        }
+    }
+
+    fn render_control(&self, _action: &Value, response: &ControlResponse) -> String {
+        response.render_default()
+    }
+}
+
+#[async_trait]
+impl CliCapability for ConnectorsCapability {
+    fn cli_command(&self) -> Command {
+        Command::new(CONNECTORS_CONTROL_ROUTE.cli_subcommand)
+            .about("Inspect and manage external connector credentials")
+            .subcommand_required(true)
+            .arg_required_else_help(true)
+            .subcommand(
+                Command::new("list").about("List connector providers with connection status"),
+            )
+            .subcommand(
+                Command::new("get")
+                    .about("Show setup instructions and form fields for one provider")
+                    .arg(Arg::new("provider").required(true)),
+            )
+            .subcommand(
+                Command::new("connect")
+                    .about("Validate and store credentials for one provider")
+                    .arg(Arg::new("provider").required(true))
+                    .arg(
+                        Arg::new("field")
+                            .long("field")
+                            .action(ArgAction::Append)
+                            .value_names(["KEY=VALUE"])
+                            .help("Credential field; repeat per field"),
+                    ),
+            )
+            .subcommand(
+                Command::new("disconnect")
+                    .about("Remove stored credentials for one provider")
+                    .arg(Arg::new("provider").required(true)),
+            )
+    }
+
+    fn control_request_from_cli(&self, matches: &ArgMatches) -> anyhow::Result<ControlRequest> {
+        let action = match matches.subcommand() {
+            Some(("list", _)) => ConnectorsAction::List,
+            Some(("get", args)) => ConnectorsAction::Get {
+                provider: args
+                    .get_one::<String>("provider")
+                    .cloned()
+                    .unwrap_or_default(),
+            },
+            Some(("connect", args)) => {
+                let mut fields = HashMap::new();
+                for raw in args.get_many::<String>("field").into_iter().flatten() {
+                    let Some((key, value)) = raw.split_once('=') else {
+                        anyhow::bail!("--field must look like KEY=VALUE, got `{raw}`");
+                    };
+                    fields.insert(key.trim().to_string(), value.trim().to_string());
+                }
+                ConnectorsAction::Connect {
+                    provider: args
+                        .get_one::<String>("provider")
+                        .cloned()
+                        .unwrap_or_default(),
+                    fields,
+                }
+            }
+            Some(("disconnect", args)) => ConnectorsAction::Disconnect {
+                provider: args
+                    .get_one::<String>("provider")
+                    .cloned()
+                    .unwrap_or_default(),
+            },
+            _ => anyhow::bail!("unknown connectors command"),
+        };
+        Ok(ControlRequest::new(CONNECTORS_CAPABILITY_ID, action)?)
+    }
+
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let action: ConnectorsAction = serde_json::from_value(request.action.clone())?;
+        let response = ControlResponse::from_tool_result(self.execute_action(&action).await);
+        let rendered = self.render_control(&serde_json::to_value(&action)?, &response);
+        println!("{rendered}");
+        if !response.ok {
+            anyhow::bail!("connectors command failed");
+        }
+        Ok(())
+    }
 }
 
 fn connector_json_with_path(info: &ConnectorInfo, path: &str) -> Value {
@@ -111,349 +306,99 @@ fn connector_json_with_path(info: &ConnectorInfo, path: &str) -> Value {
     })
 }
 
-struct ListConnectorsTool {
-    catalog: Arc<ConnectionCatalog>,
-    store: Arc<ConnectionStore>,
-}
-
-#[async_trait]
-impl Tool for ListConnectorsTool {
-    fn narrate(
-        &self,
-        _tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let detail = None;
-        Some(stable_labeled("List connectors", detail, phase))
-    }
-
-    fn name(&self) -> &str {
-        "list_connectors"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("List connectors")
-    }
-    fn description(&self) -> &str {
-        "List available connector providers (Daytona, …) with connection status and form hints."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({ "type": "object", "additionalProperties": false })
-    }
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        let path = self.store.path().display().to_string();
-        let connectors: Vec<Value> = self
-            .catalog
-            .list_connectors(&self.store)
-            .iter()
-            .map(|info| connector_json_with_path(info, &path))
-            .collect();
-        ToolExecutionResult::success(json!({
-            "connectors": connectors,
-            "count": connectors.len(),
-            "storage_path": path,
-        }))
-    }
-}
-
-struct GetConnectorTool {
-    catalog: Arc<ConnectionCatalog>,
-    store: Arc<ConnectionStore>,
-}
-
-#[async_trait]
-impl Tool for GetConnectorTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let detail = arg_str(&tool_call.arguments, &["provider"]).map(|value| truncate(value, 48));
-        Some(stable_labeled("Get connector", detail, phase))
-    }
-
-    fn name(&self) -> &str {
-        "get_connector"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Get connector")
-    }
-    fn description(&self) -> &str {
-        "Describe one connector provider: setup instructions, form fields, and whether it is connected."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "provider": {
-                    "type": "string",
-                    "description": "Connector provider id, e.g. `daytona`."
-                }
-            },
-            "required": ["provider"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let provider = match arguments.get("provider").and_then(Value::as_str) {
-            Some(p) if !p.trim().is_empty() => p.trim(),
-            _ => {
-                return ToolExecutionResult::tool_error("Missing required parameter: provider");
-            }
-        };
-        let Some(entry) = self.catalog.get(provider) else {
-            return ToolExecutionResult::tool_error(format!("Unknown connector `{provider}`"));
-        };
-        let info = self.catalog.connector_info(entry, &self.store);
-        ToolExecutionResult::success(connector_json_with_path(
-            &info,
-            &self.store.path().display().to_string(),
-        ))
-    }
-}
-
-struct ConnectTool {
-    inner: ConnectorTools,
-}
-
-#[async_trait]
-impl Tool for ConnectTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let detail = arg_str(&tool_call.arguments, &["provider"]).map(|value| truncate(value, 48));
-        Some(stable_labeled("Connect provider", detail, phase))
-    }
-
-    fn name(&self) -> &str {
-        "connect"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Connect")
-    }
-    fn description(&self) -> &str {
-        "Validate and save connector credentials. For API-key providers pass `fields.api_key`. \
-         Credentials are stored locally and never echoed back."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "provider": {
-                    "type": "string",
-                    "description": "Connector provider id, e.g. `daytona`."
-                },
-                "fields": {
-                    "type": "object",
-                    "description": "Provider form fields (typically `{ \"api_key\": \"...\" }`).",
-                    "additionalProperties": { "type": "string" }
-                }
-            },
-            "required": ["provider", "fields"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let provider = match arguments.get("provider").and_then(Value::as_str) {
-            Some(p) if !p.trim().is_empty() => p.trim().to_string(),
-            _ => {
-                return ToolExecutionResult::tool_error("Missing required parameter: provider");
-            }
-        };
-        let fields_value = match arguments.get("fields") {
-            Some(v) if v.is_object() => v,
-            _ => {
-                return ToolExecutionResult::tool_error(
-                    "Missing required parameter: fields (object of form field names to values)",
-                );
-            }
-        };
-        let mut fields = HashMap::new();
-        if let Some(obj) = fields_value.as_object() {
-            for (key, value) in obj {
-                let Some(text) = value.as_str() else {
-                    return ToolExecutionResult::tool_error(format!(
-                        "Field `{key}` must be a string"
-                    ));
-                };
-                if text.trim().is_empty() {
-                    continue;
-                }
-                fields.insert(key.clone(), text.to_string());
-            }
-        }
-        if fields.is_empty() {
-            return ToolExecutionResult::tool_error(
-                "fields must include at least one non-empty value",
-            );
-        }
-
-        let Some(entry) = self.inner.catalog.get(&provider) else {
-            return ToolExecutionResult::tool_error(format!("Unknown connector `{provider}`"));
-        };
-        if entry.connection_type() == ConnectorType::OAuth {
-            return ToolExecutionResult::tool_error(format!(
-                "Connector `{provider}` uses OAuth and cannot be configured through this tool yet"
-            ));
-        }
-
-        match self
-            .inner
-            .catalog
-            .validate_and_store(&self.inner.store, &provider, fields)
-            .await
-        {
-            Ok(validation) => ToolExecutionResult::success(json!({
-                "provider": provider,
-                "connected": true,
-                "provider_username": validation.provider_username,
-                "storage_path": self.inner.store.path().display().to_string(),
-            })),
-            Err(message) => ToolExecutionResult::tool_error(message),
-        }
-    }
-}
-
-struct DisconnectTool {
-    catalog: Arc<ConnectionCatalog>,
-    store: Arc<ConnectionStore>,
-}
-
-#[async_trait]
-impl Tool for DisconnectTool {
-    fn narrate(
-        &self,
-        tool_call: &ToolCall,
-        phase: ToolNarrationPhase,
-        locale: Option<&str>,
-        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
-    ) -> Option<String> {
-        let _ = locale;
-        let detail = arg_str(&tool_call.arguments, &["provider"]).map(|value| truncate(value, 48));
-        Some(stable_labeled("Disconnect provider", detail, phase))
-    }
-
-    fn name(&self) -> &str {
-        "disconnect"
-    }
-    fn display_name(&self) -> Option<&str> {
-        Some("Disconnect")
-    }
-    fn description(&self) -> &str {
-        "Remove stored credentials for a connector provider. Does not delete remote resources."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "provider": {
-                    "type": "string",
-                    "description": "Connector provider id, e.g. `daytona`."
-                }
-            },
-            "required": ["provider"],
-            "additionalProperties": false
-        })
-    }
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
-        let provider = match arguments.get("provider").and_then(Value::as_str) {
-            Some(p) if !p.trim().is_empty() => p.trim(),
-            _ => {
-                return ToolExecutionResult::tool_error("Missing required parameter: provider");
-            }
-        };
-        if self.catalog.get(provider).is_none() {
-            return ToolExecutionResult::tool_error(format!("Unknown connector `{provider}`"));
-        }
-        match self.store.clear(provider) {
-            Ok(existed) => ToolExecutionResult::success(json!({
-                "provider": provider,
-                "connected": false,
-                "cleared": existed,
-            })),
-            Err(err) => {
-                ToolExecutionResult::internal_error_msg(format!("disconnect failed: {err}"))
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn connect_tool_can_be_omitted_for_hosts_without_secure_secret_input() {
+    fn test_capability() -> (tempfile::TempDir, ConnectorsCapability) {
         let tmp = tempfile::tempdir().expect("tmp");
-        let capability = ConnectorsCapability {
-            store: Arc::new(ConnectionStore::open(tmp.path().join("connections.toml"))),
-            catalog: Arc::new(ConnectionCatalog::with_defaults()),
-            expose_connect_tool: false,
-        };
-        let names = capability
-            .tools()
-            .into_iter()
-            .map(|tool| tool.name().to_string())
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            names,
-            vec!["list_connectors", "get_connector", "disconnect"]
+        let capability = ConnectorsCapability::new(
+            Arc::new(ConnectionCatalog::with_defaults()),
+            Arc::new(ConnectionStore::open(tmp.path().join("connections.toml"))),
         );
+        (tmp, capability)
     }
 
     #[test]
-    fn connector_narration_names_action_and_provider() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
-        let catalog = Arc::new(ConnectionCatalog::with_defaults());
-        let tool = GetConnectorTool { catalog, store };
-        let call = ToolCall {
-            id: "call-1".into(),
-            name: "get_connector".into(),
-            arguments: json!({ "provider": "daytona" }),
-        };
+    fn tools_exposes_no_model_tools() {
+        let (_tmp, capability) = test_capability();
+        assert!(capability.tools().is_empty());
+    }
 
-        assert_eq!(
-            tool.narrate(
-                &call,
-                ToolNarrationPhase::Started,
-                None,
-                everruns_core::tool_narration::ToolNarrationContext::default(),
-            ),
-            Some("Get connector: daytona".into())
-        );
+    #[test]
+    fn control_route_points_at_connectors_cli() {
+        let (_tmp, capability) = test_capability();
+        let route = capability.control_route();
+        assert_eq!(route.resource, "connectors");
+        assert_eq!(route.cli_subcommand, "connectors");
+        assert_eq!(route.read_only_operations, &["list", "get"]);
     }
 
     #[tokio::test]
-    async fn list_connectors_includes_daytona() {
-        let tmp = tempfile::tempdir().expect("tmp");
-        let store = Arc::new(ConnectionStore::open(tmp.path().join("connections.toml")));
-        let catalog = Arc::new(ConnectionCatalog::with_defaults());
-        let tool = ListConnectorsTool { catalog, store };
-        let result = tool.execute(json!({})).await;
-        assert!(result.is_success(), "{result:?}");
-        match result {
-            everruns_core::tools::ToolExecutionResult::Success(value) => {
-                let names: Vec<&str> = value["connectors"]
-                    .as_array()
-                    .expect("array")
-                    .iter()
-                    .filter_map(|c| c["provider"].as_str())
-                    .collect();
-                assert!(names.contains(&"daytona"));
-            }
-            other => panic!("expected success, got {other:?}"),
-        }
+    async fn control_list_reports_providers() {
+        let (_tmp, capability) = test_capability();
+        let response = capability
+            .execute_action(&ConnectorsAction::List)
+            .await;
+        let ToolExecutionResult::Success(value) = response else {
+            panic!("expected JSON success, got {response:?}");
+        };
+        assert!(value["connectors"].is_array());
+        assert!(value["count"].as_u64().unwrap_or(0) >= 1);
+    }
+
+    #[tokio::test]
+    async fn control_get_rejects_unknown_provider() {
+        let (_tmp, capability) = test_capability();
+        let response = capability
+            .execute_action(&ConnectorsAction::Get {
+                provider: "nope".to_string(),
+            })
+            .await;
+        let ToolExecutionResult::ToolError(message) = response else {
+            panic!("expected error, got {response:?}");
+        };
+        assert!(message.contains("Unknown connector"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn control_rejects_mutations_toward_cli() {
+        let (_tmp, capability) = test_capability();
+        let response = capability
+            .execute_control(&json!({
+                "operation": "connect",
+                "provider": "daytona",
+                "fields": {},
+            }))
+            .await;
+        let ToolExecutionResult::ToolError(message) = response else {
+            panic!("expected error, got {response:?}");
+        };
+        assert!(message.contains("yolop connectors"), "{message}");
+    }
+
+    #[test]
+    fn cli_parses_connect_fields() {
+        let (_tmp, capability) = test_capability();
+        let matches = capability
+            .cli_command()
+            .try_get_matches_from([
+                "connectors",
+                "connect",
+                "daytona",
+                "--field",
+                "api_key=secret",
+            ])
+            .expect("cli parses");
+        let request = capability
+            .control_request_from_cli(&matches)
+            .expect("control request");
+        let action: ConnectorsAction = serde_json::from_value(request.action.clone())
+            .expect("round-trips through the control request");
+        let ConnectorsAction::Connect { provider, fields } = action else {
+            panic!("expected connect, got {action:?}");
+        };
+        assert_eq!(provider, "daytona");
+        assert_eq!(fields.get("api_key").map(String::as_str), Some("secret"));
     }
 }

--- a/src/connectors/capability.rs
+++ b/src/connectors/capability.rs
@@ -337,9 +337,7 @@ mod tests {
     #[tokio::test]
     async fn control_list_reports_providers() {
         let (_tmp, capability) = test_capability();
-        let response = capability
-            .execute_action(&ConnectorsAction::List)
-            .await;
+        let response = capability.execute_action(&ConnectorsAction::List).await;
         let ToolExecutionResult::Success(value) = response else {
             panic!("expected JSON success, got {response:?}");
         };

--- a/src/editor/acp/mod.rs
+++ b/src/editor/acp/mod.rs
@@ -1981,49 +1981,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn model_tool_change_refreshes_config_options() {
-        let config = LlmSimConfig::scripted(vec![
-            SimTurn::ToolCalls(vec![SimToolCall {
-                name: "set_provider".to_string(),
-                arguments: json!({ "provider": "openai", "model": "gpt-5.5" }),
-                id: None,
-            }]),
-            SimTurn::Assistant("switched".to_string()),
-        ]);
-        let sessions = tempfile::tempdir().expect("sessions tempdir").keep();
-        let settings = Arc::new(SettingsStore::open(sessions.join("settings.toml")));
-        settings
-            .set_token("openai".to_string(), "test-token".to_string())
-            .expect("configure OpenAI for the provider switch");
-        let factory = Arc::new(ScriptedFactory {
-            config,
-            sessions_dir: sessions,
-            settings,
-        });
-        let run = with_factory(factory, |client| async move {
-            let mut session = client.new_session().await?;
-            let _ = collect_available_commands(&mut session).await?;
-            SdkClient::prompt(&mut session, "switch to OpenAI").await
-        })
-        .await;
-
-        let mut updates = run.updates_of_kind("config_option_update").into_iter();
-        let update = updates.next().unwrap_or_else(|| {
-            panic!(
-                "model-driven provider change must refresh ACP options: {:?}",
-                run.updates
-            )
-        });
-        let model = update["configOptions"]
-            .as_array()
-            .expect("config options")
-            .iter()
-            .find(|option| option["id"] == "model")
-            .expect("model option");
-        assert_eq!(model["currentValue"], "openai:gpt-5.5");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn opt_in_completion_gate_continues_tool_only_stop_to_one_final() {
         use everruns_llmsim::OnExhausted;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1548,7 +1548,7 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
         connectors::default_connections_path().unwrap_or_else(|| fallback.join("connections.toml"));
     let settings = Arc::new(SettingsStore::open(settings_path));
     let secrets = extensions::ExtensionSecrets::new(Arc::new(connectors::ConnectionStore::open(
-        connections_path,
+        connections_path.clone(),
     )));
     let workspace = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let capability = Arc::new(
@@ -1596,6 +1596,10 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
         .unwrap_or_else(|| workspace.join(".yolop").join("sessions"));
     registry.register(Arc::new(capabilities::SessionsCapability::detached(
         sessions_dir,
+    )))?;
+    registry.register(Arc::new(connectors::ConnectorsCapability::new(
+        Arc::new(connectors::ConnectionCatalog::with_defaults()),
+        Arc::new(connectors::ConnectionStore::open(connections_path)),
     )))?;
     Ok(registry)
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4301,11 +4301,10 @@ pub async fn build_with_options(
     // into the system prompt. Persists to the same `settings.toml`; provider/
     // model edits take effect next run. Registered after the catalog is built
     // (see below).
-    capabilities.register(ConnectorsCapability {
-        catalog: connection_catalog,
-        store: connections.clone(),
-        expose_connect_tool: !matches!(options.client_ui, ClientUiContext::Acp),
-    });
+    capabilities.register(ConnectorsCapability::new(
+        connection_catalog,
+        connections.clone(),
+    ));
     // `memory` — global, durable, structured user memory. Its MEMORY.md lives
     // beside settings.toml in the yolop config dir, so a tempdir settings path
     // in tests isolates memory automatically. Only titles are disclosed each
@@ -4759,7 +4758,7 @@ mod tests {
     #[test]
     fn enabled_extensions_are_owned_by_the_reversible_session_layer() {
         let mut harness = vec![
-            CapabilityRef::new("yolop_bash"),
+            CapabilityRef::new("bash"),
             CapabilityRef::new("ext:demo"),
             CapabilityRef::new("ext:other"),
         ];
@@ -4769,7 +4768,7 @@ mod tests {
                 .iter()
                 .map(|capability| capability.capability_id())
                 .collect::<Vec<_>>(),
-            vec!["yolop_bash"]
+            vec!["bash"]
         );
         assert_eq!(
             session
@@ -5046,7 +5045,7 @@ mod tests {
         let caps = default_coding_harness_capabilities(false);
         let validation = caps
             .iter()
-            .find(|capability| capability.capability_id() == "yolop_tool_argument_validation")
+            .find(|capability| capability.capability_id() == "tool_argument_validation")
             .expect("host-side tool argument validation must be enabled");
         let repair = caps
             .iter()
@@ -5175,18 +5174,13 @@ mod tests {
 
         assert!(built.startup.setup_recommended);
         assert_eq!(built.model.provider_name(), "llmsim");
-        assert!(
-            !built.startup.tool_names.contains(&"connect".to_string()),
-            "ACP must not expose model-facing connector credential entry: {:?}",
-            built.startup.tool_names
-        );
-        for connector_tool in ["list_connectors", "get_connector", "disconnect"] {
+        for connector_tool in ["list_connectors", "get_connector", "connect", "disconnect"] {
             assert!(
-                built
+                !built
                     .startup
                     .tool_names
                     .contains(&connector_tool.to_string()),
-                "non-secret connector operations remain available: {:?}",
+                "connector management is CLI-only (`yolop connectors ...`): {:?}",
                 built.startup.tool_names
             );
         }
@@ -5277,7 +5271,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn build_exposes_connector_tools_by_default() {
+    async fn build_keeps_connectors_cli_only() {
         use everruns_host::RuntimeHostAdapter;
 
         let workspace = tempfile::tempdir().expect("workspace");
@@ -5305,11 +5299,11 @@ mod tests {
         );
         for connector_tool in ["list_connectors", "connect", "disconnect", "get_connector"] {
             assert!(
-                built
+                !built
                     .startup
                     .tool_names
                     .contains(&connector_tool.to_string()),
-                "connector tools: {:?}",
+                "connector management is CLI-only (`yolop connectors ...`): {:?}",
                 built.startup.tool_names
             );
         }
@@ -9697,7 +9691,7 @@ mod tests {
             "lsp_hover",
             "spawn_background",
             "run_command",
-            "search_models",
+            "search_files",
         ];
         let mut tools = eager
             .iter()
@@ -9972,7 +9966,10 @@ mod tests {
     async fn cold_start_prompt_composition_is_measured_by_component() {
         // Auto mode teaches the model to initialize its session worktree before mutation.
         // Skill scopes now advertise physical directories instead of synthetic roots.
-        const BASELINE_PROMPT_BYTES: usize = 14_496;
+        const BASELINE_PROMPT_BYTES: usize = 14_684;
+        // The +188 over the previous baseline buys control-route discovery for the
+        // `mcp` and `connectors` capabilities (summaries plus read-only operations),
+        // the CLI-only replacements for their removed model-facing tools.
         // Includes the logical model, config, setup, and mandatory skill
         // discovery/activation schemas that are intentionally eager.
         const BASELINE_TOOL_DEFINITION_BYTES: usize = 28_901;
@@ -10370,7 +10367,7 @@ mod tests {
     }
 
     #[test]
-    fn coding_harness_enables_yolop_attribution() {
+    fn coding_harness_enables_attribution() {
         let ids = coding_harness_capabilities(false, None, &Settings::default());
 
         assert!(
@@ -10467,7 +10464,7 @@ mod tests {
         assert!(enabled(TOOL_SEARCH_CAPABILITY_ID));
         assert!(enabled(TOOL_REVEAL_CAPABILITY_ID));
         assert_eq!(
-            TOOL_REVEAL_CAPABILITY_ID, "yolop_tool_reveal",
+            TOOL_REVEAL_CAPABILITY_ID, "tool_reveal",
             "the eval variant's `ref` string tracks this constant"
         );
 
@@ -10484,7 +10481,7 @@ mod tests {
             false,
             None,
         )
-        .expect("`yolop_tool_reveal` should resolve in the capability catalog");
+        .expect("`tool_reveal` should resolve in the capability catalog");
 
         let disabled =
             crate::config::capability_settings::apply_capability_settings(ids, &[override_entry]);
@@ -10589,7 +10586,7 @@ mod tests {
     fn always_on_capability_prompts_within_budget() {
         use crate::capabilities::agent_commands::AGENT_COMMANDS_PROMPT;
         use crate::capabilities::approval::render_approval_block;
-        use crate::capabilities::attribution::yolop_attribution_prompt;
+        use crate::capabilities::attribution::attribution_prompt;
         use crate::capabilities::background::BACKGROUND_SYSTEM_PROMPT;
         use crate::capabilities::client_commands::CLIENT_COMMANDS_PROMPT;
         use crate::capabilities::host::MODELS_PROMPT;
@@ -10612,7 +10609,7 @@ mod tests {
             ("client_commands", CLIENT_COMMANDS_PROMPT.len()),
             ("agent_commands", AGENT_COMMANDS_PROMPT.len()),
             ("setup", MODELS_PROMPT.len()),
-            ("attribution", yolop_attribution_prompt().len()),
+            ("attribution", attribution_prompt().len()),
             (
                 "yolop",
                 YolopCapability::new(&[COORDINATION_CONTROL_ROUTE, EXTENSIONS_CONTROL_ROUTE])

--- a/src/session_state/goal.rs
+++ b/src/session_state/goal.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
-pub(crate) const GOAL_CAPABILITY_ID: &str = "yolop_goal";
+pub(crate) const GOAL_CAPABILITY_ID: &str = "goal";
 pub(crate) const GOAL_COMMAND_NAME: &str = "goal";
 /// Internal `execute_command` argument — not user-facing.
 pub(crate) const GOAL_EVALUATE_ARG: &str = "\x00evaluate";

--- a/src/session_state/user_ask.rs
+++ b/src/session_state/user_ask.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::RwLock;
 
-pub(crate) const USER_ASK_CAPABILITY_ID: &str = "yolop_user_ask";
+pub(crate) const USER_ASK_CAPABILITY_ID: &str = "user_ask";
 pub(crate) const USER_ASK_COMMAND_NAME: &str = "ask";
 /// Internal `execute_command` argument — not user-facing.
 pub(crate) const USER_ASK_EVALUATE_ARG: &str = "\x00evaluate";
@@ -375,7 +375,7 @@ pub(crate) fn system_prompt_block(status: &UserAskStatus) -> String {
         })
         .unwrap_or_default();
     format!(
-        "<capability id=\"yolop_user_ask\">\n\
+        "<capability id=\"user_ask\">\n\
 Track and satisfy the user's request. Call `set_user_ask` when they change direction; \
 `clear_user_ask` only when they abandon it.\n\
 Current user ask: {}\n\


### PR DESCRIPTION
## What changed

Self-configuration is now CLI-only and capability names are unified:

- Stripped the `yolop_` prefix from all 12 capability IDs (`config`, `approval`, `bash`, `skill_management`, `agent_commands`, `client_commands`, `attribution`, `checkpoint`, `tool_reveal`, `tool_argument_validation`, `goal`, `user_ask`). Generic nouns stay readable; distinctive integrations were already bare.
- Removed model-invoked mutation tools: `list_mcp_servers` (MCP), `set_reasoning_effort`/`search_models`/`set_model`/`set_provider` (models/setup), and all four connector tools (`list`/`get`/`connect`/`disconnect`).
- Added `mcp` and `connectors` control routes (read-only ops served inline, mutations directed to the CLI) and a real `yolop connectors list|get|connect|disconnect` command (`--field KEY=VALUE` for credentials), registered in the detached CLI.
- Net minus 565 lines across 27 files.

## Why

Configuration mutations (credentials, provider switches, server management) should not cross model tool boundaries. The attached CLI plus control-route discovery is the audited path, following the same move as #691 (sessions CLI).

## Before / After

Before: `search_models`, `set_model`, `list_mcp_servers`, `connect` etc. appeared in the model tool surface; `yolop connectors` did not exist.

After (verified against this branch):

```
$ yolop mcp list
Servers (3):
- firecrawl [enabled]
- linear [enabled]
- stend [enabled]

$ yolop connectors list
{"connectors":[{"connected":false, ... "provider":"daytona", ...}],"count":1,...}
```

Harness still carries 43 capabilities; prompt budgets updated with justification (always-on cap holds, cold-start baseline 14496 -> 14684 buys the two new route discoveries).

## Risk

- Medium. Anyone with `capabilities.yolop_*` overrides in settings will now fail validation with `unknown capability` (pre-1.0, no compat required). Migration: rename to the bare IDs.
- Agent loop can no longer call the removed tools; models must use `yolop <subcommand>` via Bash (prompts updated accordingly).

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (breaking, documented above; pre-1.0)
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `conversational-control` (contract inverted to CLI-first), `reasoning-effort`, `approval`, `goal`, `yolop`, `tool-search`, `user-ask` specs.

## Security

- TM-FS: no blocklist changes; connectors CLI writes through the existing credential store.
- TM-BASH: execution model untouched.
- TM-LLM: prompt surface reworked (9 tool schemas removed, 2 control routes added); keys still env-only, nothing logged. Renames change `capabilities.<ref>` keys; stale `yolop_*` overrides fail validation loudly.
- TM-TOOL: 9 tools removed, 2 routes + 1 CLI command added; connect/disconnect stay human-driven with catalog validation and OAuth rejection.
- TM-DEP: no new crates.
- Note: `--field KEY=VALUE` passes secrets via argv (process-list visible). Same class as shell history; stdin/env input is a follow-up.

## Follow-ups

- `--field` secret input via stdin/env to avoid argv exposure (rationale: reduces secret visibility).
- Live-provider agent smoke not run locally (no keys in this environment); CI live-smoke covers it (rationale: needs Doppler-backed secrets).

Produced by [yolop](https://everruns.com/yolop)