### PR TITLE
feat(deps): adopt upstream v0.25.0 cone batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac54a475d72bf165139dc84f964cc84ea0b4cb160970c9455455c73a17117eba"
+checksum = "1fee2c71f93a93ebe8120f415b52a98081f00789c83cb332655ac12f77c03c7c"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8527f35f92b638e7501cf2f1b5c59c12a1dce4728ddc587dfb676e1177308252"
+checksum = "916af1500ec3ff21035734a6c70325d1a013d08bff3564b4937ea83a4ac72aef"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.6"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c521fd3e9e4132b31dff76c3f93e27c3d083201a45942be2cbd2af467a14f21"
+checksum = "f36ee4ea328376452347a6647e8bb21db772e072e33fee322d0d5ca28a71efa1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2214,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f98e1c32cac6efc7ca16ffe91f47cbff91c3566ee69b5155af0763afc8a667"
+checksum = "998a8703eff3ff776a67dddeba58e3c2d7a311e7f5b79f4caa5bf29e477fde4b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2228,7 +2228,7 @@ dependencies = [
  "futures",
  "globset",
  "inventory",
- "jsonschema 0.52.1",
+ "jsonschema 0.54.0",
  "rand 0.10.2",
  "regex",
  "serde",
@@ -2246,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95eb14f580d691730b6a60c46ea98658a87fbb6fa3e7bc69df6ecf04c0007291"
+checksum = "f96566451f61dab2e8d8e1640a5f17a74a43af14cb490daed7236a708bae059c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2267,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e438ee09577a11da2052fd365715db50429cefedae833bac6d17e6073f33a2"
+checksum = "8028e7b7d5fc86024972422884e78875621eca4c19d7416095c1958a58d9e46e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2295,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98449a0c88f8e98eb1b00d13b2e912dc0f3cc16931c9fd1a1b1ddee5eaac9723"
+checksum = "7c222105fe7494b7b3de90f35c5e711eea35a87ff8c990ce0e12cd6af0b67b54"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2314,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffaa4d4815137a99b168db7c1a53efbfe590ccb0a164b97d758114196ae70e4"
+checksum = "36bc773e97f46832d48904870846198a001d3ee1582cbe6a22c650c0d51bef05"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2332,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfeffe5a28af27dd5efbba0bbda07f5a971dbd9d7cf1949e7bfec6477fe8251"
+checksum = "e833d596ca0e621041dd774b467b2621e525868b9c2c3d8eaad33788ccd473f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2350,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236d8a218342441dfc6334917e5bc7dec5c62dfc6609e7ab90d785717b396898"
+checksum = "145d1542ca284f051c67e43f2e91ed611d2ff3438998b28be6e9293b4cb6096a"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-web-fetch"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6f7539d7e506ce2cdf91fb6a699103ec1ff2f4935176075e24c45525b02b12"
+checksum = "9993e9e703fdce9c129c445e9665c61512daf5c0e389494490c170ac476648e6"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2386,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.5"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa3cd68acc6dedf6c16b6e94ebfbebdb4c869fa1d99c93b601a976798c295db"
+checksum = "5712c4098ae47cff5035f8909f68a992f06cbb77e4e4218cc4dd0937e3ce61bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2402,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9143be2c4fafaf57bae896172b27af047ef6467431e2157a140270d2195bfac"
+checksum = "a5703a9e1db7b480b2f647eb3928a6958fec835360476062321fc8d983ccb13c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2427,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1591ec4a9fac26b9f2082d2c222a6bc35e326f0a18aeba97058f2c8addd12dae"
+checksum = "909ab83e66744c6956befbc6cdfe4679b399011ea30844e675390d30461a616d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e284f619d5c15ed5808f48a074e5962f1d34c494f204c04597bb8674bd5d86c4"
+checksum = "d03d75734721386ca81e7d0107c3fe38f38be13b2314a2663f15998a24c83a1e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2465,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5303d86d817daa57db293668a02e36e4594b9c79538fd98bf70f262fe51905cb"
+checksum = "733c36fd18eaf17614b3677a2931d813e7ad01eaca5e19158b87d2a6e6f22947"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2479,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4a81dac9eea4f3c62017b8123f84284b64a84ad57f01f44f2da6d5b7ed0745"
+checksum = "d08672b53bc8251406abdf99d4ab758bac65aea7401a5208eaee44798c8589db"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2492,7 +2492,7 @@ dependencies = [
  "everruns-host",
  "everruns-provider",
  "inventory",
- "jsonschema 0.52.1",
+ "jsonschema 0.54.0",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -2503,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638de963dfa6441bef7a5694b30db4911e60cf4239279b3cdb2e288ee481aa10"
+checksum = "e66862d1f5ebf86712975de0a72b800bf67141743f3ebaf3f975332db19bab0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4020,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
+checksum = "7070bf0681439ff992bb94947cb3a361f57c880561c1e9e90ddb5941c7ec2d04"
 dependencies = [
  "ahash",
  "bytecount",
@@ -4032,12 +4032,12 @@ dependencies = [
  "fraction",
  "getrandom 0.3.4",
  "itoa",
- "jsonschema-regex 0.52.1",
- "jsonschema-value 0.52.1",
+ "jsonschema-regex 0.54.0",
+ "jsonschema-value 0.54.0",
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing 0.52.1",
+ "referencing 0.54.0",
  "regex",
  "serde",
  "serde_json",
@@ -4076,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
+checksum = "b6525f2f72c37c1a09f59a6d0d33f60ecf8beabd00be92fe8d49555cae15289c"
 dependencies = [
  "regex-syntax",
 ]
@@ -4094,13 +4094,14 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-value"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
+checksum = "4309c6b52390b1ebdd2053e513e9f23d4bb18d0c3c2df8142eded3eb188a85bf"
 dependencies = [
  "ahash",
  "bytecount",
  "fraction",
+ "getrandom 0.3.4",
  "num-cmp",
  "num-traits",
  "serde_json",
@@ -6437,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
+checksum = "0304d4734d208eaf24528093715e2cb5260c977b1be1eb81cd487f601e3ff35d"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,11 +152,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # release, while the published `everruns` facade 0.19.1 still calls the two-arg
 # form and accepts host `^0.20.3`. Caret ranges resolved both together and broke
 # every fresh install. Upstream has already fixed the call site in git but has
-# not republished the facade, so 0.20.4 and the whole batch published alongside
-# it (core 0.19.1, platform 0.19.2, provider 0.20.1, mcp 0.19.3, builtins 0.18.6,
-# llmsim 0.18.5, openai/anthropic/meta/openrouter 0.18.3) stay unadoptable: they
-# all require host `^0.20.4` directly or transitively. Lift these pins in one
-# commit once a facade release that compiles against host 0.20.4 is on crates.io.
+# not republished the facade, so the batch published alongside host 0.20.4
+# (core 0.19.1, platform 0.19.2, provider 0.20.1, mcp 0.19.3, builtins 0.18.6,
+# llmsim 0.18.5, openai/anthropic/meta/openrouter 0.18.3) briefly stayed
+# unadoptable: they all require host `^0.20.4` directly or transitively. The
+# `everruns` 0.20.0 facade release closed that hole and this tree adopts that
+# batch. The next upstream product release (v0.25.0: core 0.20.0, platform
+# 0.20.0, provider 0.21.0, host 0.20.6, mcp 0.19.4, facade 0.20.1, builtins
+# 0.18.7, drivers 0.18.4, llmsim 0.18.6) stays unadoptable until its facade,
+# host, mcp, and platform cone patches are all on crates.io; the drivers and
+# builtins in that batch already require provider 0.21 / core 0.20. Lift those
+# pins as a set once the full cone is published.
 # `everruns-local` is not an escape hatch: its latest release (0.18.0) is yanked,
 # so the facade's `local` feature is the only supported route to the SQLite,
 # git-workspace, and durable-log backends.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,13 +156,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # (core 0.19.1, platform 0.19.2, provider 0.20.1, mcp 0.19.3, builtins 0.18.6,
 # llmsim 0.18.5, openai/anthropic/meta/openrouter 0.18.3) briefly stayed
 # unadoptable: they all require host `^0.20.4` directly or transitively. The
-# `everruns` 0.20.0 facade release closed that hole and this tree adopts that
-# batch. The next upstream product release (v0.25.0: core 0.20.0, platform
-# 0.20.0, provider 0.21.0, host 0.20.6, mcp 0.19.4, facade 0.20.1, builtins
-# 0.18.7, drivers 0.18.4, llmsim 0.18.6) stays unadoptable until its facade,
-# host, mcp, and platform cone patches are all on crates.io; the drivers and
-# builtins in that batch already require provider 0.21 / core 0.20. Lift those
-# pins as a set once the full cone is published.
+# `everruns` 0.20.0 facade release closed that hole and this tree adopted that
+# batch. The upstream v0.25.0 product release (core 0.20.0, platform 0.20.0,
+# provider 0.21.0, host 0.20.6, mcp 0.19.4, facade 0.20.1, builtins 0.18.7,
+# drivers and openai/anthropic/meta/openrouter 0.18.4, llmsim 0.18.6,
+# integrations-filesystem 0.18.4 and web-fetch/duckduckgo/parallel/daytona
+# 0.18.3) is the batch this tree adopts.
 # `everruns-local` is not an escape hatch: its latest release (0.18.0) is yanked,
 # so the facade's `local` feature is the only supported route to the SQLite,
 # git-workspace, and durable-log backends.
@@ -175,17 +174,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # transports, the driver registry). Adopting it today would collapse two of nine
 # dependencies and route the rest through escape hatches. Revisit when the
 # facade promotes provider registration, MCP, and capability wiring.
-everruns-anthropic = "=0.18.3"
-everruns-core = "=0.19.1"
+everruns-anthropic = "=0.18.4"
+everruns-core = "=0.20.0"
 # The identity/platform family (PlatformStore and friends) moved out of
 # everruns-core into its own crate in 0.17.24; yolop implements PlatformStore
 # to route background-task wakes (src/runtime/background_wake.rs).
-everruns-platform = "=0.19.2"
-everruns-openai = "=0.18.3"
-everruns-meta = "=0.18.3"
+everruns-platform = "=0.20.0"
+everruns-openai = "=0.18.4"
+everruns-meta = "=0.18.4"
 # OpenRouter's first-class driver was split out of everruns-openai into its own
 # crate in 0.13.0; register it alongside openai to keep DriverId::OpenRouter.
-everruns-openrouter = "=0.18.3"
+everruns-openrouter = "=0.18.4"
 # Filesystem persistence comes from the `everruns` facade's `local` feature, not
 # the standalone `everruns-local` crate: same SQLite, git-workspace, and durable
 # log backend, re-exported under `everruns::local`. `everruns-local` is not a
@@ -193,37 +192,37 @@ everruns-openrouter = "=0.18.3"
 # its latest release (0.18.0) is yanked outright.
 # Only the `local` feature is wanted; the facade's provider and capability
 # re-exports would duplicate the direct dependencies below.
-everruns = { version = "=0.20.0", default-features = false, features = ["local"] }
-everruns-mcp = { version = "=0.19.3", features = ["stdio"] }
+everruns = { version = "=0.20.1", default-features = false, features = ["local"] }
+everruns-mcp = { version = "=0.19.4", features = ["stdio"] }
 # `mcp-stdio` lets yolop talk to local-process MCP servers; the hosted
 # everruns server/worker never enable it (knowledge/specs/mcp.md, upstream runtime-mcp.md D2).
 #
 # everruns-host replaces everruns-runtime, which upstream deleted in #3101 as a
 # 0.18 breaking change. Every host symbol yolop used moved here unchanged except
 # EventBus, which the canonical event log replaces.
-everruns-host = { version = "=0.20.5", features = ["mcp-stdio"] }
+everruns-host = { version = "=0.20.6", features = ["mcp-stdio"] }
 # DirectEgressService, which yolop uses for MCP OAuth discovery, is host's own
 # `direct-egress` module; `mcp-stdio` already turns that feature on. The
 # standalone everruns-http crate that used to carry it is yanked on crates.io,
 # and a yanked dependency would make yolop unpublishable.
 # #3182 completed the library boundary cleanup: driver/model/provider types
 # and the built-in capabilities left everruns-core for their own crates.
-everruns-provider = "=0.20.1"
-everruns-builtins = "=0.18.6"
+everruns-provider = "=0.21.0"
+everruns-builtins = "=0.18.7"
 everruns-capability = "=0.18.1"
 # Yolop ships `--provider llmsim` as a user-facing offline mode, not just a test
 # fixture, so the simulator is a production dependency. 0.18 split it into the
 # production-safe `everruns-llmsim`; `everruns-test-support` documents itself as
 # test-only and must not be used from production code. The `host` feature carries
 # the runtime-builder extension trait.
-everruns-llmsim = { version = "=0.18.5", features = ["host"] }
+everruns-llmsim = { version = "=0.18.6", features = ["host"] }
 # Filesystem and web-fetch capability implementations moved out of
 # everruns-core into their own integration crates (#3119).
-everruns-integrations-filesystem = "=0.18.3"
-everruns-integrations-web-fetch = "=0.18.2"
-everruns-integrations-duckduckgo = "=0.18.2"
-everruns-integrations-parallel = "=0.18.2"
-everruns-integrations-daytona = "=0.18.2"
+everruns-integrations-filesystem = "=0.18.4"
+everruns-integrations-web-fetch = "=0.18.3"
+everruns-integrations-duckduckgo = "=0.18.3"
+everruns-integrations-parallel = "=0.18.3"
+everruns-integrations-daytona = "=0.18.3"
 arboard = { version = "3", features = ["wayland-data-control"] }
 futures = "0.3"
 html-escape = "0.2"

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -441,6 +441,23 @@ fn codex_response_error(
             "Codex access was denied. Run `/setup` to sign in again, or choose another provider.",
         );
     }
+    if kind == LlmErrorKind::AttestationRequired
+        && let Some(requirement) =
+            everruns_provider::user_facing_error::parse_attestation_requirement(&body)
+    {
+        let detail = if requirement.missing_types.is_empty() {
+            "additional verification".to_owned()
+        } else {
+            requirement.missing_types.join(", ")
+        };
+        return AgentLoopError::llm_kind(
+            kind,
+            format!(
+                "Codex access requires {detail}. Confirm at {}",
+                requirement.confirm_url
+            ),
+        );
+    }
     AgentLoopError::llm_kind(kind, format!("Codex {operation} error ({status}): {body}"))
 }
 
@@ -1446,6 +1463,39 @@ mod tests {
     use std::sync::Mutex as StdMutex;
     use std::sync::mpsc;
     use std::thread;
+
+    #[test]
+    fn forbidden_attestation_gate_points_at_confirm_url() {
+        let body = "Access requires you to complete the following before use: \
+            https://openrouter.ai/settings/preferences."
+            .to_owned();
+        let err = codex_response_error("chat", StatusCode::FORBIDDEN, body, None);
+        let AgentLoopError::Llm(llm) = err else {
+            panic!("expected LLM error, got {err:?}");
+        };
+        assert_eq!(llm.kind, LlmErrorKind::AttestationRequired);
+        assert!(
+            llm.message
+                .contains("Confirm at https://openrouter.ai/settings/preferences"),
+            "unexpected message: {}",
+            llm.message
+        );
+    }
+
+    #[test]
+    fn forbidden_attestation_metadata_names_missing_types() {
+        let body = r#"{"error":{"code":403,"message":"Access requires you to complete the following before use","metadata":{"missing_attestation_types":["age_18plus"]}}}"#.to_owned();
+        let err = codex_response_error("chat", StatusCode::FORBIDDEN, body, None);
+        let AgentLoopError::Llm(llm) = err else {
+            panic!("expected LLM error, got {err:?}");
+        };
+        assert_eq!(llm.kind, LlmErrorKind::AttestationRequired);
+        assert!(
+            llm.message.contains("age_18plus") && llm.message.contains("Confirm at "),
+            "unexpected message: {}",
+            llm.message
+        );
+    }
 
     #[derive(Default)]
     struct MemoryAuthStore {

--- a/src/runtime/attestation.rs
+++ b/src/runtime/attestation.rs
@@ -15,7 +15,10 @@
 //! target. Compact work also shows Assistant lines, while a System hint would
 //! sit in collapsed details. Replace this with the upstream structured error
 //! once `everruns-openrouter` reports these gates as first-class kinds.
-
+//! Provider 0.21 added `LlmErrorKind::AttestationRequired` plus a structured
+//! parser, but the parser drops overlong types and returns `None` where this
+//! module promises truncation and an empty fallback, so the string-level
+//! contract here stays until the driver itself surfaces the gate.
 /// Fallback confirm page when an attestation body carries no usable URL.
 pub(crate) const OPENROUTER_PREFERENCES_URL: &str = "https://openrouter.ai/settings/preferences";
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10224,23 +10224,27 @@ mod tests {
         std::fs::write(workspace.path().join("note.txt"), "before\n").expect("seed note");
         let sessions = tempfile::tempdir().expect("sessions");
         let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));
+        let messages = Arc::new(std::sync::Mutex::new(Vec::new()));
         let options = BuildOptions {
-            llmsim_override: Some(LlmSimConfig::scripted(vec![
-                SimTurn::ToolCalls(vec![SimToolCall {
-                    name: "tool_search".to_string(),
-                    arguments: serde_json::json!({"query": "write_file"}),
-                    id: None,
-                }]),
-                SimTurn::ToolCalls(vec![SimToolCall {
-                    name: "write_file".to_string(),
-                    arguments: serde_json::json!({
-                        "path": "note.txt",
-                        "content": "after\n"
-                    }),
-                    id: None,
-                }]),
-                SimTurn::Assistant("DONE".to_string()),
-            ])),
+            llmsim_override: Some(
+                LlmSimConfig::scripted(vec![
+                    SimTurn::ToolCalls(vec![SimToolCall {
+                        name: "tool_search".to_string(),
+                        arguments: serde_json::json!({"query": "write_file"}),
+                        id: None,
+                    }]),
+                    SimTurn::ToolCalls(vec![SimToolCall {
+                        name: "write_file".to_string(),
+                        arguments: serde_json::json!({
+                            "path": "note.txt",
+                            "content": "after\n"
+                        }),
+                        id: None,
+                    }]),
+                    SimTurn::Assistant("DONE".to_string()),
+                ])
+                .with_message_capture(messages.clone()),
+            ),
             ..BuildOptions::default()
         };
         let built = build_with_options(
@@ -10260,13 +10264,9 @@ mod tests {
             .load_context(built.handles.session_id)
             .await
             .expect("initial context");
-        assert!(
-            initial
-                .runtime_agent
-                .system_prompt
-                .contains("MANDATORY_DISCLOSURE_POLICY"),
-            "AGENTS.md must remain in the model-visible prompt"
-        );
+        // AGENTS.md now rides the provider-visible conversation context instead
+        // of the system prompt. The model-visibility assertion lives after the
+        // turn, against the captured provider messages.
         let initial_write = initial
             .runtime_agent
             .tools
@@ -10290,6 +10290,19 @@ mod tests {
             .expect("run turn");
         assert!(result.success, "scripted disclosure turn: {result:?}");
         assert_eq!(result.tool_calls_count, 2);
+        let provider_text = {
+            let captured = messages.lock().expect("captured provider messages");
+            captured
+                .iter()
+                .flat_map(|turn| turn.iter())
+                .map(|message| message.content_as_text())
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        assert!(
+            provider_text.contains("MANDATORY_DISCLOSURE_POLICY"),
+            "AGENTS.md must remain in the model-visible prompt"
+        );
         assert_eq!(
             std::fs::read_to_string(workspace.path().join("note.txt")).expect("read note"),
             "after\n"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2281,8 +2281,9 @@ fn print_mode_attaches_images_to_provider_request() {
         .expect("messages array in request");
     let user = messages
         .iter()
-        .find(|msg| msg["role"] == "user")
-        .expect("user message in request");
+        .filter(|msg| msg["role"] == "user")
+        .find(|msg| msg["content"].is_array())
+        .expect("multimodal user message in request");
     let content = user["content"].as_array().expect("multimodal user content");
     let image_part = content
         .iter()


### PR DESCRIPTION
Adopts the upstream v0.25.0 product batch: facade 0.20.1, host 0.20.6, mcp 0.19.4, core/platform 0.20.0, provider 0.21.0, builtins 0.18.7, llmsim 0.18.6, openai/anthropic/meta/openrouter 0.18.4, integrations-filesystem 0.18.4, web-fetch/duckduckgo/parallel/daytona 0.18.3.

Adaptations:
- Codex driver surfaces the new `LlmErrorKind::AttestationRequired` with the parsed confirm URL instead of the generic 403 error (new regression tests).
- Deferred-mutation test asserts AGENTS.md in captured provider messages: the engine now injects instruction files as leading conversation context rather than system prompt (upstream security fix; policy stays model-visible every turn).
- Image-attach test skips the injected context message when finding the multimodal user message.
- `CapabilityStatus::Retired` needs no handling: the tree only constructs `Available`, never matches exhaustively. No `platform_management` references.

Blocked on publish: daytona/parallel 0.18.3 are versioned upstream but not yet on crates.io, so resolution (and CI) stays red until they land. `Cargo.lock` regenerates at that point. Do not merge before CI is green.

Validated pre-publish against the identical upstream sources via a temporary whole-cone path patch (since removed): fmt clean, clippy `-D warnings` clean, full suite green (1407 passed, 0 failed).