### PR TITLE
refactor(capabilities): state when repo_map and ast_grep beat shell

### DIFF
--- a/src/capabilities/ast_grep.rs
+++ b/src/capabilities/ast_grep.rs
@@ -165,10 +165,13 @@ impl Tool for AstGrepTool {
         Some("AST grep")
     }
 
+    // Boundary note: the model reaches for shell grep/sed out of habit even for
+    // structural code tasks, so the description states the split explicitly:
+    // structural patterns here, plain text search for literals and docs.
     fn description(&self) -> &str {
         "Search workspace code with ast-grep structural patterns. Prefer this over repeated file \
          reads when locating functions, impl blocks, call shapes, field access, or repeated \
-         structural constructs. Supports Rust, Python, TypeScript/TSX, JavaScript/JSX, C#, Go, \
+         structural constructs. Choose it over line-oriented text search when matching code structure; for literal strings, comments, or docs, plain text search is more effective. Supports Rust, Python, TypeScript/TSX, JavaScript/JSX, C#, Go, \
          CSS, HTML, and Bash."
     }
 

--- a/src/capabilities/repo_map.rs
+++ b/src/capabilities/repo_map.rs
@@ -133,11 +133,16 @@ impl Tool for RepoMapTool {
         Some("Repo map")
     }
 
+    // Orientation note: without this, the model pages through large files with sed
+    // or shells out to grep for a first look. State the entry point explicitly:
+    // map first, then read the targeted regions.
     fn description(&self) -> &str {
         "Build a compact, grouped multi-language symbol map for the workspace or a subpath. \
          All arguments are optional; omit unused fields and omit `limit` for compact output. \
          The limit defaults to 50 without `query` and 200 with it; `max_file_bytes` defaults \
-         to 524288. Use this for broad orientation before targeted grep/read."
+         to 524288. Use this for broad orientation before targeted grep/read. \
+         Start here for unfamiliar code instead of paging through large files or \
+         shelling out for a first look."
     }
 
     fn parameters_schema(&self) -> Value {


### PR DESCRIPTION
## What

Adds one when-it-wins sentence plus a short boundary comment to two tool descriptions:

- `repo_map`: start here for unfamiliar code instead of paging through large files or shelling out for a first look.
- `ast_grep`: choose it over line-oriented text search when matching code structure; plain text search stays more effective for literal strings, comments, or docs.

## Why

The model reaches for shell grep/sed out of habit even for structural code tasks and first-look orientation (seen as `sed -n '3400,3445p'` paging plus piped greps). The previous descriptions never stated the boundary, so there was nothing to steer the choice. This keeps the fix in each tool's own description instead of a global bash-vs-builtins rule, and leaves the host-owned file/search/edit tools untouched.

## Before / After

Before: descriptions said what each tool does, not when it wins, so shell habits won by default. After: each description states its win condition; no observable CLI behavior change, prompt text only.

## Validation

- `cargo fmt --check`: clean.
- `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`: clean.
- `cargo test --workspace --features yolop-yep/schema`: all suites pass (1485 passed, 0 failed).
- `cargo run -- --provider llmsim -p "hi"`: binary starts and responds, offline smoke proof.

## Security

No security-relevant code changes: this edits user-visible description strings and code comments only. No exec paths, capability registration, filesystem access, prompt construction, keys, or dependencies change.

## Follow-ups

No follow-ups.

## Knowledge

No knowledge update required: comment-level prompt guidance with no architecture, policy, or process change.

Produced by [yolop](https://everruns.com/yolop)