### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.18.0] - 2026-09-11
+
+### Highlights
+
+- `yolop sessions` CLI replaces the `search_sessions` model tool, with `search` and `list` subcommands.
+- Capability names unify behind CLI routes: `yolop` prefix stripped to bare IDs, MCP/provider/model self-configuration moves through CLI control routes.
+- First-class env-context entries with `--env-context` flag and Paseo detection.
+- OpenRouter attestation-gate guidance, account gates surfaced as links, plus `yolop mcp login` for remote OAuth servers.
+- Root-managed cancellation with automatic conflict choice, and upstream v0.25.0 cone batch adoption.
+
+### Breaking Changes
+
+- The `search_sessions` model tool is removed; use `yolop sessions search` and `yolop sessions list` via Bash instead. The `session_history` capability id is renamed to `sessions`.
+- `yolop_*` capability IDs are stripped to bare IDs; settings overrides using the old names fail validation, rename them to the bare IDs.
+- Model-invoked mutation tools are removed in favor of CLI routes: use `yolop mcp`, `yolop connectors`, `yolop sessions`, and provider/model commands via Bash instead of `list_mcp_servers`, `set_reasoning_effort`/`search_models`/`set_model`/`set_provider`, and connector list/get/connect/disconnect tools.
+
+### What's Changed
+
+* refactor(capabilities): state when repo_map and repo_symbols are unavailable ([#695](https://github.com/everruns/yolop/pull/695)) by @chaliy
+* feat(deps): adopt upstream v0.25.0 cone batch ([#694](https://github.com/everruns/yolop/pull/694)) by @chaliy
+* feat(capabilities): unify MCP, provider, and coordination names behind CLI routes ([#693](https://github.com/everruns/yolop/pull/693)) by @chaliy
+* chore(ci): parallelize live-smoke across providers ([#692](https://github.com/everruns/yolop/pull/692)) by @chaliy
+* feat(sessions): replace search_sessions with sessions CLI ([#691](https://github.com/everruns/yolop/pull/691)) by @chaliy
+* feat(env-context): first-class entries with --env-context flag and Paseo detection ([#690](https://github.com/everruns/yolop/pull/690)) by @chaliy
+* feat(coordination): root-managed cancellation and automatic conflict choice ([#689](https://github.com/everruns/yolop/pull/689)) by @chaliy
+* fix(mcp): stop advertising /mcp when the command is unknown ([#688](https://github.com/everruns/yolop/pull/688)) by @chaliy
+* fix(runtime): prefer advertised reasoning-effort scales, keep curated registry as fallback ([#687](https://github.com/everruns/yolop/pull/687)) by @chaliy
+* fix(runtime): surface OpenRouter account gates as links and redirects ([#686](https://github.com/everruns/yolop/pull/686)) by @chaliy
+* MCP mutations go through CLI with auto-reload ([#685](https://github.com/everruns/yolop/pull/685)) by @chaliy
+* refactor(capabilities): merge control-plane and domain tags into one block ([#684](https://github.com/everruns/yolop/pull/684)) by @chaliy
+* fix(approval): make a soft-approval pause a tool call, and let /ship merge ([#683](https://github.com/everruns/yolop/pull/683)) by @chaliy
+* fix(models): strip pinned effort from model option names ([#682](https://github.com/everruns/yolop/pull/682)) by @chaliy
+* fix(capabilities): wrap attribution prompt in capability tags ([#681](https://github.com/everruns/yolop/pull/681)) by @chaliy
+* fix(runtime): order control-plane before agent-instructions ([#680](https://github.com/everruns/yolop/pull/680)) by @chaliy
+* fix(prompt): avoid seam and other LLM-isms in output ([#679](https://github.com/everruns/yolop/pull/679)) by @chaliy
+* fix(capabilities): remove duplicate capability tags from system prompt ([#678](https://github.com/everruns/yolop/pull/678)) by @chaliy
+* feat(mcp): add yolop mcp login command ([#677](https://github.com/everruns/yolop/pull/677)) by @chaliy
+* feat(runtime): guide users through OpenRouter attestation gate ([#676](https://github.com/everruns/yolop/pull/676)) by @chaliy
+* fix(runtime): give host-built turns the model's reasoning level ([#675](https://github.com/everruns/yolop/pull/675)) by @chaliy
+* fix(tui): support mouse clicks in setup option pickers ([#674](https://github.com/everruns/yolop/pull/674)) by @chaliy
+* fix(runtime): judge a repaired turn by the effort it sent ([#673](https://github.com/everruns/yolop/pull/673)) by @chaliy
+* chore(deps): bump dirs from 6.0.0 to 7.0.0 ([#669](https://github.com/everruns/yolop/pull/669)) by @dependabot
+* chore(deps): bump jsonschema from 0.52.1 to 0.55.0 ([#668](https://github.com/everruns/yolop/pull/668)) by @dependabot
+* chore(deps): bump the cargo-minor-and-patch group across 1 directory with 2 updates ([#667](https://github.com/everruns/yolop/pull/667)) by @dependabot
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.17.3...v0.18.0
+
 ## [0.17.3] - 2026-09-10
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10065,7 +10065,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.17.3"
+version = "0.18.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.17.3"
+version = "0.18.0"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ yolop --provider llmsim -p "hi"         # offline demo, no API key required
   checkpoint, and `/undo`, `/redo`, and `/rewind` restore conversation or
   workspace state without touching `HEAD` or the Git index. See
   [Session persistence](#session-persistence).
-- **Session search**: `search_sessions` finds recent local sessions by a
-  distinctive phrase, keeping investigations grounded in the saved event log.
+- **Session search**: `yolop sessions search` finds recent local sessions by a
+  distinctive phrase (also `yolop sessions list`), keeping investigations grounded in the saved event log.
 
 ### Providers
 


### PR DESCRIPTION
## [0.18.0] - 2026-09-11

### Highlights

- `yolop sessions` CLI replaces the `search_sessions` model tool, with `search` and `list` subcommands.
- Capability names unify behind CLI routes: `yolop` prefix stripped to bare IDs, MCP/provider/model self-configuration moves through CLI control routes.
- First-class env-context entries with `--env-context` flag and Paseo detection.
- OpenRouter attestation-gate guidance, account gates surfaced as links, plus `yolop mcp login` for remote OAuth servers.
- Root-managed cancellation with automatic conflict choice, and upstream v0.25.0 cone batch adoption.

### Breaking Changes

- The `search_sessions` model tool is removed; use `yolop sessions search` and `yolop sessions list` via Bash instead. The `session_history` capability id is renamed to `sessions`.
- `yolop_*` capability IDs are stripped to bare IDs; settings overrides using the old names fail validation, rename them to the bare IDs.
- Model-invoked mutation tools are removed in favor of CLI routes: use `yolop mcp`, `yolop connectors`, `yolop sessions`, and provider/model commands via Bash instead of `list_mcp_servers`, `set_reasoning_effort`/`search_models`/`set_model`/`set_provider`, and connector list/get/connect/disconnect tools.

### What's Changed

* refactor(capabilities): state when repo_map and repo_symbols are unavailable ([#695](https://github.com/everruns/yolop/pull/695)) by @chaliy
* feat(deps): adopt upstream v0.25.0 cone batch ([#694](https://github.com/everruns/yolop/pull/694)) by @chaliy
* feat(capabilities): unify MCP, provider, and coordination names behind CLI routes ([#693](https://github.com/everruns/yolop/pull/693)) by @chaliy
* chore(ci): parallelize live-smoke across providers ([#692](https://github.com/everruns/yolop/pull/692)) by @chaliy
* feat(sessions): replace search_sessions with sessions CLI ([#691](https://github.com/everruns/yolop/pull/691)) by @chaliy
* feat(env-context): first-class entries with --env-context flag and Paseo detection ([#690](https://github.com/everruns/yolop/pull/690)) by @chaliy
* feat(coordination): root-managed cancellation and automatic conflict choice ([#689](https://github.com/everruns/yolop/pull/689)) by @chaliy
* fix(mcp): stop advertising /mcp when the command is unknown ([#688](https://github.com/everruns/yolop/pull/688)) by @chaliy
* fix(runtime): prefer advertised reasoning-effort scales, keep curated registry as fallback ([#687](https://github.com/everruns/yolop/pull/687)) by @chaliy
* fix(runtime): surface OpenRouter account gates as links and redirects ([#686](https://github.com/everruns/yolop/pull/686)) by @chaliy
* MCP mutations go through CLI with auto-reload ([#685](https://github.com/everruns/yolop/pull/685)) by @chaliy
* refactor(capabilities): merge control-plane and domain tags into one block ([#684](https://github.com/everruns/yolop/pull/684)) by @chaliy
* fix(approval): make a soft-approval pause a tool call, and let /ship merge ([#683](https://github.com/everruns/yolop/pull/683)) by @chaliy
* fix(models): strip pinned effort from model option names ([#682](https://github.com/everruns/yolop/pull/682)) by @chaliy
* fix(capabilities): wrap attribution prompt in capability tags ([#681](https://github.com/everruns/yolop/pull/681)) by @chaliy
* fix(runtime): order control-plane before agent-instructions ([#680](https://github.com/everruns/yolop/pull/680)) by @chaliy
* fix(prompt): avoid seam and other LLM-isms in output ([#679](https://github.com/everruns/yolop/pull/679)) by @chaliy
* fix(capabilities): remove duplicate capability tags from system prompt ([#678](https://github.com/everruns/yolop/pull/678)) by @chaliy
* feat(mcp): add yolop mcp login command ([#677](https://github.com/everruns/yolop/pull/677)) by @chaliy
* feat(runtime): guide users through OpenRouter attestation gate ([#676](https://github.com/everruns/yolop/pull/676)) by @chaliy
* fix(runtime): give host-built turns the model's reasoning level ([#675](https://github.com/everruns/yolop/pull/675)) by @chaliy
* fix(tui): support mouse clicks in setup option pickers ([#674](https://github.com/everruns/yolop/pull/674)) by @chaliy
* fix(runtime): judge a repaired turn by the effort it sent ([#673](https://github.com/everruns/yolop/pull/673)) by @chaliy
* chore(deps): bump dirs from 6.0.0 to 7.0.0 ([#669](https://github.com/everruns/yolop/pull/669)) by @dependabot
* chore(deps): bump jsonschema from 0.52.1 to 0.55.0 ([#668](https://github.com/everruns/yolop/pull/668)) by @dependabot
* chore(deps): bump the cargo-minor-and-patch group across 1 directory with 2 updates ([#667](https://github.com/everruns/yolop/pull/667)) by @dependabot

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.17.3...v0.18.0

---

## Publish-readiness

- `cargo publish --dry-run --allow-dirty -p yolop-yep`: pass (SDK unchanged at 0.4.0; plain dry-run only complains about dirty worktree from these release edits).
- `cargo publish --dry-run --allow-dirty -p yolop`: pass (yolop-yep unchanged, so no waiting on SDK propagation).
- `cargo search yolop --limit 1`: `yolop = "0.17.3"` (crates.io behind local 0.18.0, publishable).
- `grep '^version' Cargo.toml`: `0.18.0`; `Cargo.lock` `yolop` entry: `0.18.0` (agree).
- `yolop-yep` stays at 0.4.0 (no `crates/` changes since v0.17.3); logfire extension stays at 0.2.0 (no `extensions/` changes); `python3 scripts/publish_order.py` publishes yolop-yep, then yolop.
- Local: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo test --workspace --features yolop-yep/schema` all green.
- Also in this PR: README session-search bullet updated from `search_sessions` to `yolop sessions search/list` to describe the released behavior.

## Post-merge verification

- [ ] `release.yml` workflow green on merge (tag `v0.18.0` created)
- [ ] `publish.yml` workflow green
- [ ] `cli-binaries.yml` workflow green
- [ ] crates.io reports `yolop 0.18.0` (plus `yolop-yep` if bumped; not bumped here)
- [ ] each bumped extension (none here) has its `<crate>-v<version>` release with three server archives
- [ ] Homebrew tap formula points at `v0.18.0`

Produced by [yolop](https://everruns.com/yolop)
