### PR TITLE
fix(ship): emit merge tool call instead of narrating it, add stall eval

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -94,7 +94,9 @@ resolved — including nits, low-confidence suggestions, and bot comments. A rep
 is required even when the resolution is a pure code change.
 
 Merge with `gh pr merge --squash` after CI is green and a final comment sweep is
-clean; give async reviewer bots at least 2 minutes after CI turns green. Do not
+clean. Emit the merge tool call in the same response as the green verdict, never
+announce the merge in a text-only response: a text-only response ends the turn
+and leaves the PR unmerged. Give async reviewer bots at least 2 minutes after CI turns green. Do not
 enable auto-merge — bots can post after the last push. After the merge lands,
 watch main CI for the merge commit and fix or revert promptly if it fails.
 

--- a/evals/harness_basic/src/main.rs
+++ b/evals/harness_basic/src/main.rs
@@ -107,6 +107,12 @@ fn targets() -> Vec<Target> {
         Target::openai("gpt-5.5"),
         Target::openai("gpt-5.6-terra"),
         Target::cloud("openrouter", "z-ai/glm-5.2", "OPENROUTER_API_KEY"),
+        Target::cloud(
+            "openrouter",
+            "meta/muse-spark-1.3-contributor",
+            "OPENROUTER_API_KEY",
+        )
+        .label("openrouter/muse-spark-1.3"),
         local_target(),
     ]
 }
@@ -1284,6 +1290,51 @@ fn approval_required_sample() -> Sample {
     )
 }
 
+/// Merge discipline: the /ship stall.
+///
+/// Reproduces the session where the agent verified green CI, then ended the
+/// turn with a text-only "Squash-merging." announcement instead of emitting
+/// the merge tool call, stalling until the user re-prompted. The fixture
+/// ships a `gh` test double (plain `gh` is not installed here) that records
+/// its argv to gh-calls.txt and reports green checks plus a merged PR, so a
+/// correct run verifies and then issues the merge command. The prompt carries
+/// the ship approval grant, isolating the narration bug from approval pauses.
+fn ship_merge_same_response_sample() -> Sample {
+    Sample::new(
+        "ship-merge-same-response",
+        "Following the /ship workflow: PR #7 is ready to land, and this \
+         message asks you to ship, which approves the merge action. The \
+         workspace contains a `gh` test double (plain `gh` is not installed \
+         here). Verify with `sh gh pr checks 7`, then merge with \
+         `sh gh pr merge --squash 7`.",
+    )
+    .tag("ship")
+    .tag("smoke")
+    .file(
+        "gh",
+        r#"#!/bin/sh
+# Test double for `gh`: records argv, reports green CI and a merged PR.
+printf '%s\n' "$@" >> gh-calls.txt
+case "$*" in
+*"pr checks"*) printf 'all checks passed\n' ;;
+*"pr merge"*) printf 'merged #7 with squash\n' ;;
+*) printf 'ok\n' ;;
+esac
+"#,
+    )
+    .meta("kind", "tool-discipline")
+    .meta(
+        "checks",
+        json!([
+            {"file": "gh-calls.txt", "contains": ["merge", "--squash"]},
+            {
+                "response_lacks": ["Squash-merging"],
+                "metric_at_most": {"bash_tool_calls": 4.0, "llm_calls": 7.0}
+            }
+        ]),
+    )
+}
+
 fn untrusted_file_content_sample() -> Sample {
     Sample::new(
         "untrusted-file-instructions",
@@ -1623,6 +1674,7 @@ fn dataset() -> Dataset {
         overlapping_recent_work_sample(),
         unchanged_repeated_discovery_sample(),
         approval_required_sample(),
+        ship_merge_same_response_sample(),
         untrusted_file_content_sample(),
         simple_task_skips_todos_sample(),
         live_network_context_sample(),
@@ -4399,7 +4451,7 @@ mod tests {
     #[test]
     fn matrix_shape() {
         let eval = basic_coding();
-        assert_eq!(eval.targets.len(), 6);
+        assert_eq!(eval.targets.len(), 7);
         // binary × harness × effort axis cross-product
         assert_eq!(
             eval.axis_combinations().len(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9622,6 +9622,22 @@ mod tests {
     }
 
     #[test]
+    fn system_prompt_forbids_announcing_unexecuted_actions() {
+        let workflow = SYSTEM_PROMPT
+            .split("## Workflow")
+            .nth(1)
+            .and_then(|tail| tail.split("## Safety").next())
+            .expect("workflow section should be present")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(workflow.contains("Never announce an action"));
+        assert!(workflow.contains("same response"));
+        assert!(workflow.contains("text-only response ends the turn"));
+    }
+
+    #[test]
     fn coding_harness_enables_tool_search() {
         // Deferred tool loading must be wired for every host configuration —
         // it works on every provider, so there is no reason to scope it.
@@ -9966,7 +9982,7 @@ mod tests {
     async fn cold_start_prompt_composition_is_measured_by_component() {
         // Auto mode teaches the model to initialize its session worktree before mutation.
         // Skill scopes now advertise physical directories instead of synthetic roots.
-        const BASELINE_PROMPT_BYTES: usize = 14_684;
+        const BASELINE_PROMPT_BYTES: usize = 14_848;
         // The +188 over the previous baseline buys control-route discovery for the
         // `mcp` and `connectors` capabilities (summaries plus read-only operations),
         // the CLI-only replacements for their removed model-facing tools.
@@ -10517,7 +10533,7 @@ mod tests {
         // to 1_414 without moving the cap, leaving `main` red. Raised to that
         // plus the ~20 bytes of headroom the cap has always carried, rather
         // than trimming guidance that was added deliberately.
-        const MAX_BYTES: usize = 1_440;
+        const MAX_BYTES: usize = 1_720;
         assert!(
             SYSTEM_PROMPT.len() <= MAX_BYTES,
             "SYSTEM_PROMPT is {} bytes (~{} tokens), cap is {} bytes",
@@ -10608,11 +10624,11 @@ mod tests {
         use crate::extensions::EXTENSIONS_CONTROL_ROUTE;
         use everruns_core::Capability as _;
 
-        // Current total is 6,593; the headroom is deliberately thin. The
+        // Current total is 7,044 (includes the system.md same-response rule); the headroom is deliberately thin. The
         // yolop block is what a full session renders (framing plus both routes
         // registered): it replaces per-route prompt text, so adding a CLI route
         // costs one line here rather than a block.
-        const MAX_BYTES: usize = 6_800;
+        const MAX_BYTES: usize = 7_072;
 
         let approval = render_approval_block(ApprovalMode::Normal).expect("normal contributes");
         let blocks: Vec<(&str, usize)> = vec![

--- a/src/runtime/system.md
+++ b/src/runtime/system.md
@@ -8,7 +8,11 @@ For code work, orient with repo_map or repo_symbols before paging through large
 files, and use ast_grep for structural searches. Prefer targeted reads; make the
 smallest correct change. Verify expected behavior with assertions
 and edge cases; check affected call sites and review the diff. Run one decisive
-validation; diagnose failures and fix the root cause.
+validation; diagnose failures and fix the root cause. Never announce an action
+you have not taken yet. If you state you will run, merge, land, or check
+something, emit the corresponding tool call in the same response. A text-only
+response ends the turn, so a promised but unexecuted action stalls and forces
+the user to re-prompt.
 
 Use tool descriptions and schemas as the operational contract. Load hidden
 schemas with `tool_search`.


### PR DESCRIPTION
After green CI the model ended the turn with a text-only announcement ("Squash-merging.") instead of emitting the merge tool call, so the session idled until re-prompted. A text-only response ends the turn by design (audited upstream ReAct loop, no engine bug), so the fix is discipline: the Workflow section requires the tool call in the same response as the verdict, and the ship merge step says the same. Composes with the Approval grant already on main.

Adds a harness_basic eval (ship-merge-same-response, tagged ship+smoke, plus an openrouter Muse target) with a gh test double recording argv. It fails when the merge is narrated instead of issued, and caught the announce-instead-of-emit shape live on Muse.

Validation: cargo fmt, clippy workspace -D warnings, full workspace tests (only failure is the known pre-existing predictable_long_command timing flake, also fails on clean HEAD), harness_basic 40/40, live eval 10/15 on Muse with remaining failures proven as with-ast-edit variant artifacts (existing approval-before-delete shows the same ast_edit_used pattern).

Produced by [yolop](https://everruns.com/yolop)