### PR TITLE
feat(profiles): manage named profiles from CLI and control plane

### DIFF
--- a/knowledge/specs/configuration.md
+++ b/knowledge/specs/configuration.md
@@ -136,6 +136,23 @@ are global-only and make a selected profile fail validation. Invalid known
 values also fail startup; unknown keys produce a warning and are ignored for
 forward compatibility.
 
+### Managing profiles
+
+`yolop profiles` lists the profiles in the config root and marks the active
+one. `profiles show <name>` prints the sparse overlay, `profiles create <name>
+[--from <source>]` writes a new overlay file and refuses to overwrite an
+existing one, and `profiles delete <name> --yes` removes it. Deletion refuses
+the attached session's active profile. Profile edits apply to later sessions
+only; the running session keeps its own settings.
+
+`yolop config --profile <name> get|set|clear|model ...` targets a profile
+overlay instead of the attached session. Reads resolve that profile's overlay
+over global settings, and writes land in the profile file through the same
+validation and profile-scoped persistence as an active session. `--profile` is
+rejected for `config models` and `config hooks`. The option sits on the
+`config` command, so it never changes which profile the invoking process
+itself runs with.
+
 ### A profile is the unit of a purpose-built agent
 
 v1 profiles overlaid *execution* settings only, which was enough to switch

--- a/src/capabilities/config.rs
+++ b/src/capabilities/config.rs
@@ -32,8 +32,19 @@ use std::sync::Arc;
 
 #[derive(Debug, Args)]
 pub(crate) struct ConfigCommandLine {
+    /// Target a named profile instead of the attached session settings.
+    #[arg(long, value_name = "NAME")]
+    profile: Option<String>,
+
     #[command(subcommand)]
     command: ConfigCommand,
+}
+
+fn profile_target(action: &Value) -> Option<String> {
+    action
+        .get("profile")
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 #[derive(Debug, Subcommand)]
@@ -144,8 +155,9 @@ enum ConfigAction {
 
 impl ConfigCommandLine {
     fn request(matches: &clap::ArgMatches) -> anyhow::Result<ControlRequest> {
-        let command = Self::from_arg_matches(matches)?.command;
-        let action = match command {
+        let parsed = Self::from_arg_matches(matches)?;
+        let profile = parsed.profile;
+        let action = match parsed.command {
             ConfigCommand::Get { key } => serde_json::to_value(ConfigAction::Get { key })?,
             ConfigCommand::Set { key, value, json } => {
                 if value.is_none() && json.is_none() {
@@ -176,6 +188,21 @@ impl ConfigCommandLine {
             })?,
             ConfigCommand::Hooks { command } => serde_json::json!({ "hooks": command }),
         };
+        let action = match serde_json::from_value::<ConfigAction>(action.clone()) {
+            Ok(action) => {
+                let mut action = serde_json::to_value(action)?;
+                if let Some(profile) = profile {
+                    action["profile"] = Value::String(profile);
+                }
+                action
+            }
+            Err(_) if profile.is_none() => action,
+            Err(_) => {
+                anyhow::bail!(
+                    "--profile is supported by config get, set, clear, and model commands"
+                )
+            }
+        };
         Ok(ControlRequest::new("models", action)?)
     }
 }
@@ -195,8 +222,9 @@ impl ControlCapability for ConfigCapability {
     }
 
     async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        let profile = profile_target(action);
         match serde_json::from_value::<ConfigAction>(action.clone()) {
-            Ok(action) => self.execute_config_action(action).await,
+            Ok(action) => self.execute_config_action(action, profile).await,
             Err(_) => self.model_list.execute_control(action).await,
         }
     }
@@ -293,11 +321,26 @@ impl ConfigCapability {
         ]
     }
 
-    async fn execute_config_action(&self, action: ConfigAction) -> ToolExecutionResult {
+    async fn execute_config_action(
+        &self,
+        action: ConfigAction,
+        profile: Option<String>,
+    ) -> ToolExecutionResult {
+        // An explicit profile target scopes reads and writes to that profile's
+        // overlay file. The attached session keeps its own settings.
+        let settings = match profile {
+            Some(name) => {
+                match SettingsStore::open_with_profile(self.settings.path().to_path_buf(), &name) {
+                    Ok(settings) => Arc::new(settings),
+                    Err(error) => return ToolExecutionResult::tool_error(error.to_string()),
+                }
+            }
+            None => self.settings.clone(),
+        };
         match action {
             ConfigAction::Get { key } => {
                 GetConfigTool {
-                    settings: self.settings.clone(),
+                    settings: settings.clone(),
                     catalog: self.catalog.clone(),
                 }
                 .execute(json!({ "key": key }))
@@ -312,7 +355,7 @@ impl ConfigCapability {
                     arguments["json"] = json;
                 }
                 SetConfigTool {
-                    settings: self.settings.clone(),
+                    settings: settings.clone(),
                     catalog: self.catalog.clone(),
                 }
                 .execute(arguments)
@@ -320,16 +363,16 @@ impl ConfigCapability {
             }
             ConfigAction::Clear { key } => {
                 SetConfigTool {
-                    settings: self.settings.clone(),
+                    settings: settings.clone(),
                     catalog: self.catalog.clone(),
                 }
                 .execute(json!({ "key": key, "value": "clear" }))
                 .await
             }
             ConfigAction::ModelShow => {
-                let settings = self.settings.snapshot();
-                let model = settings.default_provider.as_ref().and_then(|provider| {
-                    settings
+                let snapshot = settings.snapshot();
+                let model = snapshot.default_provider.as_ref().and_then(|provider| {
+                    snapshot
                         .default_models
                         .get(provider)
                         .map(|model| format!("{provider}/{model}"))
@@ -337,15 +380,14 @@ impl ConfigCapability {
                 ToolExecutionResult::success(json!({ "model": model }))
             }
             ConfigAction::ModelSet { model } => {
-                let models = self.settings.snapshot().model_list();
+                let models = settings.snapshot().model_list();
                 let index = match ModelListCapability::find(&models, &model) {
                     Ok(index) => index,
                     Err(error) => return ToolExecutionResult::tool_error(error),
                 };
                 let entry = &models[index];
-                if let Err(error) = self
-                    .settings
-                    .set_configured_model(entry.provider.clone(), entry.model.clone())
+                if let Err(error) =
+                    settings.set_configured_model(entry.provider.clone(), entry.model.clone())
                 {
                     return ToolExecutionResult::tool_error(error.to_string());
                 }
@@ -354,7 +396,7 @@ impl ConfigCapability {
                 )
             }
             ConfigAction::ModelClear => {
-                if let Err(error) = self.settings.clear_configured_model() {
+                if let Err(error) = settings.clear_configured_model() {
                     return ToolExecutionResult::tool_error(error.to_string());
                 }
                 ToolExecutionResult::success(json!({ "model": Value::Null }))

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod model_list;
 pub(crate) mod model_ranking;
 pub(crate) mod model_runtime_context;
 pub(crate) mod narration;
+pub(crate) mod profiles;
 pub(crate) mod progress_guard;
 pub(crate) mod repo_map;
 pub(crate) mod session_coordination;
@@ -76,6 +77,7 @@ pub(crate) use model_list::{ModelListCapability, offered_models};
 pub(crate) use model_runtime_context::{
     MODEL_RUNTIME_CONTEXT_CAPABILITY_ID, ModelRuntimeContextCapability,
 };
+pub(crate) use profiles::ProfilesCapability;
 pub(crate) use progress_guard::{PROGRESS_GUARD_CAPABILITY_ID, ProgressGuardCapability};
 pub(crate) use repo_map::{REPO_MAP_CAPABILITY_ID, RepoMapCapability};
 pub(crate) use session_coordination::{

--- a/src/capabilities/profiles.rs
+++ b/src/capabilities/profiles.rs
@@ -1,0 +1,438 @@
+//! Named configuration profile lifecycle management.
+//!
+//! Profiles are sparse TOML overlays stored at
+//! `<config_dir>/yolop/profiles/<name>.toml` and selected with `--profile`.
+//! This capability owns discovery and lifecycle (list, show, create, delete);
+//! per-key inspection and mutation live on `config --profile <name> ...`.
+
+use crate::config::profile::ActiveProfile;
+use crate::config::{SettingsStore, save_table_to};
+use crate::control::{
+    CliCapability, ControlCapability, ControlRequest, ControlResponse, ControlRoute,
+};
+use anyhow::{Context, bail};
+use async_trait::async_trait;
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
+use everruns_core::command::{
+    CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
+    ExecuteCommandRequest,
+};
+use everruns_core::{Capability, ToolExecutionResult};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+pub(crate) const PROFILES_CAPABILITY_ID: &str = "profiles";
+pub(crate) const PROFILES_CONTROL_ROUTE: ControlRoute = ControlRoute {
+    resource: PROFILES_CAPABILITY_ID,
+    cli_subcommand: PROFILES_CAPABILITY_ID,
+    read_only_operations: &["list", "show"],
+    summary: "list, show, create, and delete named configuration profiles",
+};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "profiles",
+    about = "Manage named configuration profiles",
+    after_help = "Examples:\n  Create a profile and point it at llmsim:\n    yolop profiles create review\n    yolop config --profile review set default_provider llmsim",
+    disable_help_subcommand = true
+)]
+struct ProfileCommandLine {
+    #[command(subcommand)]
+    command: Option<ProfileCommand>,
+}
+
+#[derive(Subcommand, Debug)]
+enum ProfileCommand {
+    /// List profiles (default when no subcommand is given).
+    List,
+    /// Print a profile's sparse TOML overlay.
+    Show {
+        /// Profile name.
+        name: String,
+    },
+    /// Create a profile, optionally copying another profile's overlay.
+    Create {
+        /// Profile name.
+        name: String,
+        /// Copy the overlay from this existing profile.
+        #[arg(long, value_name = "NAME")]
+        from: Option<String>,
+    },
+    /// Delete a profile file.
+    Delete {
+        /// Profile name.
+        name: String,
+        /// Required confirmation flag.
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+enum ProfileAction {
+    List,
+    Show { name: String },
+    Create { name: String, from: Option<String> },
+    Delete { name: String, yes: bool },
+}
+
+impl ProfileCommandLine {
+    fn request(self) -> anyhow::Result<ControlRequest> {
+        let action = match self.command {
+            None | Some(ProfileCommand::List) => ProfileAction::List,
+            Some(ProfileCommand::Show { name }) => ProfileAction::Show { name },
+            Some(ProfileCommand::Create { name, from }) => ProfileAction::Create { name, from },
+            Some(ProfileCommand::Delete { name, yes }) => ProfileAction::Delete { name, yes },
+        };
+        Ok(ControlRequest::new(
+            PROFILES_CAPABILITY_ID,
+            serde_json::to_value(action)?,
+        )?)
+    }
+}
+
+/// Parse `profiles ...` slash-command arguments into an action.
+fn parse_command(arguments: Option<&str>) -> anyhow::Result<ProfileAction> {
+    let arguments = arguments.unwrap_or_default();
+    let mut parts = arguments.split_whitespace();
+    let verb = parts.next().unwrap_or("list");
+    match verb {
+        "list" => Ok(ProfileAction::List),
+        "show" => {
+            let name = parts
+                .next()
+                .context("profiles show requires a profile name")?;
+            Ok(ProfileAction::Show {
+                name: name.to_string(),
+            })
+        }
+        "create" => {
+            let name = parts
+                .next()
+                .context("profiles create requires a profile name")?;
+            let mut from = None;
+            let rest: Vec<&str> = parts.collect();
+            let mut index = 0;
+            while index < rest.len() {
+                match rest[index] {
+                    "--from" => {
+                        index += 1;
+                        from = Some(
+                            rest.get(index)
+                                .context("profiles create --from requires a profile name")?
+                                .to_string(),
+                        );
+                    }
+                    other => bail!("unknown profiles create argument `{other}`"),
+                }
+                index += 1;
+            }
+            Ok(ProfileAction::Create {
+                name: name.to_string(),
+                from,
+            })
+        }
+        "delete" => {
+            let name = parts
+                .next()
+                .context("profiles delete requires a profile name")?;
+            let yes = parts.any(|part| part == "--yes");
+            Ok(ProfileAction::Delete {
+                name: name.to_string(),
+                yes,
+            })
+        }
+        other => {
+            bail!("unknown profiles command `{other}` (expected list, show, create, or delete)")
+        }
+    }
+}
+
+pub(crate) struct ProfilesCapability {
+    settings: Arc<SettingsStore>,
+}
+
+impl ProfilesCapability {
+    pub(crate) fn new(settings: Arc<SettingsStore>) -> Self {
+        Self { settings }
+    }
+
+    fn profiles_dir(&self) -> std::path::PathBuf {
+        self.settings
+            .path()
+            .parent()
+            .map(|parent| parent.join("profiles"))
+            .unwrap_or_else(|| std::path::PathBuf::from("profiles"))
+    }
+
+    async fn execute_action(&self, action: ProfileAction) -> ToolExecutionResult {
+        match action {
+            ProfileAction::List => self.list(),
+            ProfileAction::Show { name } => self.show(&name),
+            ProfileAction::Create { name, from } => self.create(&name, from.as_deref()),
+            ProfileAction::Delete { name, yes } => self.delete(&name, yes),
+        }
+    }
+
+    fn list(&self) -> ToolExecutionResult {
+        let dir = self.profiles_dir();
+        let mut profiles = BTreeMap::new();
+        match std::fs::read_dir(&dir) {
+            Ok(entries) => {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().is_some_and(|ext| ext == "toml") {
+                        let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                            continue;
+                        };
+                        let entry = match ActiveProfile::load(self.settings.path(), stem) {
+                            Ok(_) => json!({"name": stem, "valid": true}),
+                            Err(error) => {
+                                json!({"name": stem, "valid": false, "error": error.to_string()})
+                            }
+                        };
+                        profiles.insert(stem.to_string(), entry);
+                    }
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "read profiles directory {}: {error}",
+                    dir.display()
+                ));
+            }
+        }
+        let active = self.settings.active_profile_name();
+        ToolExecutionResult::success(json!({"profiles": profiles, "active": active}))
+    }
+
+    fn show(&self, name: &str) -> ToolExecutionResult {
+        match ActiveProfile::load(self.settings.path(), name) {
+            Ok(profile) => ToolExecutionResult::success(
+                json!({"name": profile.name.as_str(), "profile": profile.overlay.to_table()}),
+            ),
+            Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+        }
+    }
+
+    fn create(&self, name: &str, from: Option<&str>) -> ToolExecutionResult {
+        let (_, destination) = match ActiveProfile::path_for(self.settings.path(), name) {
+            Ok(resolved) => resolved,
+            Err(error) => return ToolExecutionResult::tool_error(error.to_string()),
+        };
+        if destination.exists() {
+            return ToolExecutionResult::tool_error(format!("profile `{name}` already exists"));
+        }
+        let table = match from {
+            Some(source) => match ActiveProfile::load(self.settings.path(), source) {
+                Ok(profile) => profile.overlay.to_table(),
+                Err(error) => return ToolExecutionResult::tool_error(error.to_string()),
+            },
+            None => toml::Table::new(),
+        };
+        if let Some(parent) = destination.parent()
+            && let Err(error) = std::fs::create_dir_all(parent)
+        {
+            return ToolExecutionResult::tool_error(format!(
+                "create profiles directory {}: {error}",
+                parent.display()
+            ));
+        }
+        match save_table_to(&destination, &table) {
+            Ok(()) => ToolExecutionResult::success(json!({"created": name})),
+            Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+        }
+    }
+
+    fn delete(&self, name: &str, yes: bool) -> ToolExecutionResult {
+        if !yes {
+            return ToolExecutionResult::tool_error("profile deletion requires --yes");
+        }
+        if self.settings.active_profile_name().as_deref() == Some(name) {
+            return ToolExecutionResult::tool_error(format!(
+                "refusing to delete the active profile `{name}`"
+            ));
+        }
+        let (_, destination) = match ActiveProfile::path_for(self.settings.path(), name) {
+            Ok(resolved) => resolved,
+            Err(error) => return ToolExecutionResult::tool_error(error.to_string()),
+        };
+        match std::fs::remove_file(&destination) {
+            Ok(()) => ToolExecutionResult::success(json!({"deleted": name})),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                ToolExecutionResult::tool_error(format!("profile `{name}` does not exist"))
+            }
+            Err(error) => {
+                ToolExecutionResult::tool_error(format!("delete profile `{name}`: {error}"))
+            }
+        }
+    }
+
+    fn render_response(&self, action: &ProfileAction, response: &ControlResponse) -> String {
+        if !response.ok {
+            return response.render_default();
+        }
+        let value = response.value.clone().unwrap_or(Value::Null);
+        match action {
+            ProfileAction::List => {
+                let profiles = value
+                    .get("profiles")
+                    .and_then(Value::as_object)
+                    .cloned()
+                    .unwrap_or_default();
+                let active = value
+                    .get("active")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                if profiles.is_empty() {
+                    return "No profiles configured.".to_string();
+                }
+                profiles
+                    .iter()
+                    .map(|(name, entry)| {
+                        let mut line = name.clone();
+                        if name == active {
+                            line.push_str(" (active)");
+                        }
+                        if entry.get("valid").and_then(Value::as_bool) == Some(false) {
+                            let detail = entry
+                                .get("error")
+                                .and_then(Value::as_str)
+                                .unwrap_or("invalid");
+                            line.push_str(&format!(" (invalid: {detail})"));
+                        }
+                        line
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+            ProfileAction::Show { .. } => value
+                .get("profile")
+                .map(|table| toml::to_string(table).unwrap_or_else(|_| value.to_string()))
+                .unwrap_or_else(|| response.render_default()),
+            ProfileAction::Create { .. } => value
+                .get("created")
+                .and_then(Value::as_str)
+                .map(|name| {
+                    format!(
+                        "Created profile `{name}`. New sessions using this profile will see it."
+                    )
+                })
+                .unwrap_or_else(|| response.render_default()),
+            ProfileAction::Delete { .. } => value
+                .get("deleted")
+                .and_then(Value::as_str)
+                .map(|name| format!("Deleted profile `{name}`."))
+                .unwrap_or_else(|| response.render_default()),
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for ProfilesCapability {
+    fn id(&self) -> &str {
+        PROFILES_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Profiles"
+    }
+
+    fn description(&self) -> &str {
+        "Manage named configuration profiles."
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: PROFILES_CAPABILITY_ID.to_string(),
+            description: "Manage configuration profiles using the `yolop profiles` grammar."
+                .to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "operation".to_string(),
+                description: "CLI-style operation and arguments; omit to list profiles."
+                    .to_string(),
+                required: false,
+                suggestions: vec![
+                    "list".to_string(),
+                    "show".to_string(),
+                    "create".to_string(),
+                    "delete".to_string(),
+                ],
+            }],
+        }]
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ExecuteCommandRequest,
+        _ctx: &CommandExecutionContext,
+    ) -> everruns_provider::error::Result<CommandResult> {
+        if request.name != PROFILES_CAPABILITY_ID {
+            return Err(everruns_provider::error::AgentLoopError::config(format!(
+                "{} cannot execute /{}",
+                self.id(),
+                request.name
+            )));
+        }
+        let action = parse_command(request.arguments.as_deref())
+            .map_err(|error| everruns_provider::error::AgentLoopError::config(error.to_string()))?;
+        let response = ControlResponse::from_tool_result(self.execute_action(action.clone()).await);
+        Ok(CommandResult {
+            success: response.ok,
+            message: self.render_response(&action, &response),
+            error_code: None,
+            error_fields: None,
+        })
+    }
+}
+
+#[async_trait]
+impl ControlCapability for ProfilesCapability {
+    fn control_route(&self) -> ControlRoute {
+        PROFILES_CONTROL_ROUTE
+    }
+
+    async fn execute_control(&self, action: &Value) -> ToolExecutionResult {
+        match serde_json::from_value(action.clone()) {
+            Ok(action) => self.execute_action(action).await,
+            Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+        }
+    }
+
+    fn render_control(&self, action: &Value, response: &ControlResponse) -> String {
+        let action: ProfileAction = match serde_json::from_value(action.clone()) {
+            Ok(action) => action,
+            Err(_) => return response.render_default(),
+        };
+        self.render_response(&action, response)
+    }
+}
+
+#[async_trait]
+impl CliCapability for ProfilesCapability {
+    fn cli_command(&self) -> clap::Command {
+        ProfileCommandLine::command()
+    }
+
+    fn control_request_from_cli(&self, matches: &ArgMatches) -> anyhow::Result<ControlRequest> {
+        ProfileCommandLine::from_arg_matches(matches)?.request()
+    }
+
+    async fn execute_cli(&self, request: &ControlRequest) -> anyhow::Result<()> {
+        let response =
+            ControlResponse::from_tool_result(self.execute_control(&request.action).await);
+        let action: ProfileAction = serde_json::from_value(request.action.clone())?;
+        let rendered = self.render_response(&action, &response);
+        if response.ok {
+            println!("{rendered}");
+            Ok(())
+        } else {
+            bail!(rendered)
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -649,7 +649,7 @@ fn save_profile_to(path: &Path, overlay: &profile::SettingsOverlay) -> Result<()
     save_table_to(path, &overlay.to_table())
 }
 
-fn save_table_to(path: &Path, table: &Table) -> Result<()> {
+pub(crate) fn save_table_to(path: &Path, table: &Table) -> Result<()> {
     let parent = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -378,12 +378,21 @@ pub struct ActiveProfile {
 }
 
 impl ActiveProfile {
-    pub fn load(settings_path: &Path, raw_name: &str) -> Result<Self> {
+    /// Resolve the canonical file for a validated profile name.
+    pub fn path_for(settings_path: &Path, raw_name: &str) -> Result<(ProfileName, PathBuf)> {
         let name = ProfileName::parse(raw_name)?;
         let parent = settings_path.parent().unwrap_or_else(|| Path::new("."));
-        let path = parent
-            .join("profiles")
-            .join(format!("{}.toml", name.as_str()));
+        Ok((
+            name.clone(),
+            parent
+                .join("profiles")
+                .join(format!("{}.toml", name.as_str())),
+        ))
+    }
+
+    pub fn load(settings_path: &Path, raw_name: &str) -> Result<Self> {
+        let (name, path) = Self::path_for(settings_path, raw_name)?;
+        let parent = settings_path.parent().unwrap_or_else(|| Path::new("."));
         let text = std::fs::read_to_string(&path)
             .with_context(|| format!("read profile `{}` from {}", name.as_str(), path.display()))?;
         let table: Table = toml::from_str(&text)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1575,6 +1575,9 @@ fn detached_cli_registry() -> Result<control::CliRegistry> {
         catalog: Arc::new(catalog),
         model_list: model_list.clone(),
     }))?;
+    registry.register(Arc::new(capabilities::ProfilesCapability::new(
+        settings.clone(),
+    )))?;
     registry.register(Arc::new(capabilities::ModelCliCapability::detached()))?;
     registry.register(Arc::new(capabilities::SetupCliCapability::detached()))?;
     registry.register(Arc::new(capabilities::WorktreeCapability::detached()))?;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4188,6 +4188,11 @@ pub async fn build_with_options(
         session_control_registry.register(management.clone())?;
         capabilities.register_arc(management);
     }
+    let profiles = Arc::new(crate::capabilities::ProfilesCapability::new(
+        settings.clone(),
+    ));
+    session_control_registry.register(profiles.clone())?;
+    capabilities.register_arc(profiles);
     // One shared `yolop` prompt block: self-address framing plus administration
     // derived from the routes actually registered above. Capabilities describe
     // their route via `ControlRoute::summary`; none of them contributes prompt

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -646,6 +646,137 @@ fn missing_named_profile_fails_before_starting_a_session() {
     assert!(stderr.contains("read profile `missing`"), "stderr={stderr}");
 }
 
+#[cfg(unix)]
+#[test]
+fn profiles_and_config_profile_manage_named_overlay() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_root = if cfg!(target_os = "macos") {
+        tmp.path().join("Library/Application Support")
+    } else {
+        tmp.path().join(".config")
+    };
+    let yolop_config = config_root.join("yolop");
+    std::fs::create_dir_all(&yolop_config).expect("config dir");
+    let base_path = yolop_config.join("settings.toml");
+    let profile_path = yolop_config.join("profiles").join("review.toml");
+    std::fs::write(
+        &base_path,
+        "default_provider = 'openai'\n[tokens]\nopenai = 'global-secret'\n",
+    )
+    .expect("base settings");
+
+    let run = |args: &[&str]| -> std::process::Output {
+        Command::new(yolop_binary())
+            .args(args)
+            .env("HOME", tmp.path())
+            .env("XDG_CONFIG_HOME", &config_root)
+            .env_remove("OPENAI_API_KEY")
+            .env_remove("ANTHROPIC_API_KEY")
+            .output()
+            .expect("spawn yolop")
+    };
+
+    // Lifecycle: create, list, show.
+    let output = run(&["profiles", "create", "review"]);
+    assert!(
+        output.status.success(),
+        "create failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["profiles", "create", "review"]);
+    assert!(!output.status.success(), "duplicate create must fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("already exists"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["profiles"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "list failed");
+    assert!(stdout.contains("review"), "stdout={stdout}");
+
+    // Targeted mutation: the overlay gains the key, the global file does not.
+    let output = run(&[
+        "config",
+        "--profile",
+        "review",
+        "set",
+        "default_provider",
+        "llmsim",
+    ]);
+    assert!(
+        output.status.success(),
+        "targeted set failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["config", "--profile", "review", "get", "default_provider"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "targeted get failed");
+    assert!(stdout.contains("llmsim"), "stdout={stdout}");
+    let output = run(&["profiles", "show", "review"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "show failed");
+    assert!(stdout.contains("default_provider"), "stdout={stdout}");
+    assert!(
+        !std::fs::read_to_string(&base_path)
+            .unwrap()
+            .contains("llmsim"),
+        "global settings must not receive the profile value"
+    );
+
+    // A fresh session resolves the managed value.
+    let output = Command::new(yolop_binary())
+        .args([
+            "--profile",
+            "review",
+            "--session-dir",
+            tmp.path().join("sessions").to_str().unwrap(),
+            "-p",
+            "hi",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", &config_root)
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .output()
+        .expect("spawn yolop with profile");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "profile run failed: stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("offline mode"), "stdout={stdout}");
+
+    // Guards: unknown profiles, missing confirmation, command scoping.
+    let output = run(&["config", "--profile", "missing", "get", "default_provider"]);
+    assert!(!output.status.success(), "unknown profile must fail");
+    let output = run(&["profiles", "delete", "review"]);
+    assert!(!output.status.success(), "delete without --yes must fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--yes"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = run(&["config", "--profile", "review", "models"]);
+    assert!(!output.status.success(), "scoped models must fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--profile is supported by"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Delete: removed, then gone.
+    let output = run(&["profiles", "delete", "review", "--yes"]);
+    assert!(output.status.success(), "delete failed");
+    assert!(!profile_path.exists(), "profile file must be removed");
+    let output = run(&["profiles", "show", "review"]);
+    assert!(!output.status.success(), "show after delete must fail");
+    let output = run(&["profiles"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("review"), "stdout={stdout}");
+}
+
 #[test]
 fn version_flag_succeeds() {
     let output = Command::new(yolop_binary())


### PR DESCRIPTION
## What
Adds profile lifecycle management on the same attached control-plane pattern as extensions, plus per-key profile targeting on `config`:

- `yolop profiles [list]`, `show <name>`, `create <name> [--from <source>]`, `delete <name> --yes`
- `yolop config --profile <name> get|set|clear|model ...` reads and writes that profile's sparse overlay through existing validation and profile-scoped persistence
- `--profile` is rejected for `config models` and `config hooks`; profile edits affect later sessions only, never the running one

## Why
Named profiles existed as startup overlays with no way to list, inspect, or mutate them conversationally. Management now lives next to the settings they change instead of duplicating the config schema field by field.

## How
- New `ProfilesCapability` (`src/capabilities/profiles.rs`) mirroring `ExtensionsCapability`: clap CLI, slash command, control route `profiles`, registered detached (`src/main.rs`) and attached (`src/runtime/mod.rs`)
- `ActiveProfile::path_for` helper reused by load/show/create/delete; `save_table_to` made `pub(crate)` for atomic profile writes
- `ConfigCommandLine` gains `--profile NAME`, injected into the control action; execution opens a temporary `SettingsStore::open_with_profile` so `Set`/`Clear`/`Model` arms persist to the profile file, not global settings
- `knowledge/specs/configuration.md` gains a Managing profiles subsection

## Risk
- Low. Additive commands plus a scoped execution path; existing config behavior without `--profile` is byte-identical (same store, same validation).
- Deletion refuses the active profile and requires `--yes`.

## Security
- TM-FS: profile paths derive from validated `ProfileName` joined under the config root, no traversal (`..`, `/\x5c`, case-ambiguous names rejected by existing validation). Writes go through the existing atomic temp-file-and-rename path.
- TM-TOOL: new capability respects the write blocklist, registered on the standard control registries.
- TM-BASH/TM-LLM: no shell, prompt, or key-handling changes.
- TM-DEP: no new dependencies.

## Before / After
Before: no way to manage profiles; `yolop profiles` was an unknown command.
After (offline run against a temp config root):
```
$ yolop profiles create review
Created profile `review`. New sessions using this profile will see it.
$ yolop config --profile review set default_provider llmsim
default_provider set to llmsim (saved to .../yolop/profiles/review.toml)
$ yolop profiles show review
default_provider = 'llmsim'
$ yolop profiles
review
```

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added: `profiles_and_config_profile_manage_named_overlay` drives create/list/set/get/show, a fresh `--profile` print run, global-file isolation, and the delete/--yes/scoping guards
- [x] Evidence attached above (CLI transcript from a real run)
- [x] Backward compatibility considered: default `config` behavior unchanged; new commands only
- [x] Security review performed (see Security)
- [x] Knowledge updated: `knowledge/specs/configuration.md` Managing profiles

## Validation
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --features yolop-yep/schema -- -D warnings`, `cargo test --workspace --features yolop-yep/schema` green except one load-flaky timing test (`predictable_long_command_returns_immediately`) that passes in isolation and is unrelated
- `--provider llmsim` smoke: binary starts and answers offline