### PR TITLE
fix(config): advertise persistent settings in config route summary

### DIFF
--- a/src/capabilities/model_list.rs
+++ b/src/capabilities/model_list.rs
@@ -37,7 +37,7 @@ pub(crate) const MODEL_LIST_CONTROL_ROUTE: ControlRoute = ControlRoute {
     resource: "models",
     cli_subcommand: "config",
     read_only_operations: &["list"],
-    summary: "manage models and switch the session model",
+    summary: "inspect or change persistent settings and manage models",
 };
 
 #[derive(Subcommand, Debug)]

--- a/src/capabilities/yolop.rs
+++ b/src/capabilities/yolop.rs
@@ -78,6 +78,7 @@ impl Capability for YolopCapability {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities::model_list::MODEL_LIST_CONTROL_ROUTE;
     use crate::capabilities::session_coordination::COORDINATION_CONTROL_ROUTE;
     use crate::extensions::EXTENSIONS_CONTROL_ROUTE;
 
@@ -131,5 +132,16 @@ mod tests {
         let capability = YolopCapability::new(&[COORDINATION_CONTROL_ROUTE]);
         let block = capability.system_prompt_addition().expect("block");
         assert!(block.contains("Do not repeat `--help`"));
+    }
+
+    #[test]
+    fn administration_advertises_config_settings() {
+        let capability = YolopCapability::new(&[MODEL_LIST_CONTROL_ROUTE]);
+        let block = capability.system_prompt_addition().expect("block");
+        assert!(block.contains("`config`"));
+        assert!(
+            block.contains("persistent settings"),
+            "config route should advertise settings, not only models"
+        );
     }
 }


### PR DESCRIPTION
## What changed
The yolop system-prompt line for the `config` route now says it covers persistent settings as well as models. Agents see settings work as `yolop config get/set/clear` instead of a file edit.

## Why
The route was summarized models-only, so a settings request looked like a `settings.toml` edit. The `config` command already owns get, set, clear, model, models, and hooks.

## Before / After
Before: `- config, manage models and switch the session model`
After: `- config, inspect or change persistent settings and manage models`
Proof a reviewer can check: `cargo test -p yolop --bin yolop --features yolop-yep/schema capabilities::yolop` passes, including the new `administration_advertises_config_settings` test that builds the real yolop prompt block from `MODEL_LIST_CONTROL_ROUTE` and asserts it mentions `config` and persistent settings.

## Risk
- Low
- What can break: slightly longer prompt line for the config route; no behavior, CLI, or schema change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge
No knowledge update required, prompt wording fix with no durable behavior, architecture, or process change.

## Security
No security-relevant code changes. Prompt text only; no filesystem, shell, key handling, capability registration, or dependency changes (TM-FS, TM-BASH, TM-LLM, TM-TOOL, TM-DEP unaffected).

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)