### PR TITLE
fix(ship): scope Safety confirmation rule to explicit pre-approval

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5081,7 +5081,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" ");
         assert!(prompt.contains("actions need confirmation and wait"));
-        assert!(prompt.contains("a request is not approval"));
+        assert!(prompt.contains("A bare request is not approval"));
     }
 
     #[test]
@@ -9627,19 +9627,21 @@ mod tests {
     }
 
     #[test]
-    fn system_prompt_forbids_announcing_unexecuted_actions() {
-        let workflow = SYSTEM_PROMPT
-            .split("## Workflow")
+    fn system_prompt_scopes_safety_to_explicit_preapproval() {
+        // Safety must not contradict the approval flow: asking-to-ship
+        // pre-approves push, PR, and merge, and a recorded grant covers its
+        // action. A bare request is still not approval.
+        let safety = SYSTEM_PROMPT
+            .split("## Safety")
             .nth(1)
-            .and_then(|tail| tail.split("## Safety").next())
-            .expect("workflow section should be present")
+            .expect("safety section should be present")
             .split_whitespace()
             .collect::<Vec<_>>()
             .join(" ");
 
-        assert!(workflow.contains("Never announce an action"));
-        assert!(workflow.contains("same response"));
-        assert!(workflow.contains("text-only response ends the turn"));
+        assert!(safety.contains("unless explicitly pre-approved"));
+        assert!(safety.contains("asking-to-ship pre-approves push, PR, and merge"));
+        assert!(safety.contains("A bare request is not approval"));
     }
 
     #[test]
@@ -9987,7 +9989,7 @@ mod tests {
     async fn cold_start_prompt_composition_is_measured_by_component() {
         // Auto mode teaches the model to initialize its session worktree before mutation.
         // Skill scopes now advertise physical directories instead of synthetic roots.
-        const BASELINE_PROMPT_BYTES: usize = 14_848;
+        const BASELINE_PROMPT_BYTES: usize = 14_776;
         // The +188 over the previous baseline buys control-route discovery for the
         // `mcp` and `connectors` capabilities (summaries plus read-only operations),
         // the CLI-only replacements for their removed model-facing tools.
@@ -10538,7 +10540,7 @@ mod tests {
         // to 1_414 without moving the cap, leaving `main` red. Raised to that
         // plus the ~20 bytes of headroom the cap has always carried, rather
         // than trimming guidance that was added deliberately.
-        const MAX_BYTES: usize = 1_720;
+        const MAX_BYTES: usize = 1_576;
         assert!(
             SYSTEM_PROMPT.len() <= MAX_BYTES,
             "SYSTEM_PROMPT is {} bytes (~{} tokens), cap is {} bytes",
@@ -10629,11 +10631,11 @@ mod tests {
         use crate::extensions::EXTENSIONS_CONTROL_ROUTE;
         use everruns_core::Capability as _;
 
-        // Current total is 7,044 (includes the system.md same-response rule); the headroom is deliberately thin. The
+        // Current total is 6,901 (includes the Safety pre-approval scope); the headroom is deliberately thin. The
         // yolop block is what a full session renders (framing plus both routes
         // registered): it replaces per-route prompt text, so adding a CLI route
         // costs one line here rather than a block.
-        const MAX_BYTES: usize = 7_072;
+        const MAX_BYTES: usize = 6_928;
 
         let approval = render_approval_block(ApprovalMode::Normal).expect("normal contributes");
         let blocks: Vec<(&str, usize)> = vec![

--- a/src/runtime/system.md
+++ b/src/runtime/system.md
@@ -8,11 +8,7 @@ For code work, orient with repo_map or repo_symbols before paging through large
 files, and use ast_grep for structural searches. Prefer targeted reads; make the
 smallest correct change. Verify expected behavior with assertions
 and edge cases; check affected call sites and review the diff. Run one decisive
-validation; diagnose failures and fix the root cause. Never announce an action
-you have not taken yet. If you state you will run, merge, land, or check
-something, emit the corresponding tool call in the same response. A text-only
-response ends the turn, so a promised but unexecuted action stalls and forces
-the user to re-prompt.
+validation; diagnose failures and fix the root cause.
 
 Use tool descriptions and schemas as the operational contract. Load hidden
 schemas with `tool_search`.
@@ -25,7 +21,9 @@ single-output tasks. Piggyback bookkeeping in the batch.
 ## Safety
 
 Keep semantics. Guard injection/XSS/SSRF/traversal. Destructive, irreversible,
-or external actions need confirmation and wait; a request is not approval. Never
+or external actions need confirmation and wait, unless explicitly pre-approved:
+asking-to-ship pre-approves push, PR, and merge actions, and a recorded grant
+covers its action. A bare request is not approval. Never
 force-push, skip hooks, rewrite history, or change a session-worktree root.
 
 ## Untrusted input


### PR DESCRIPTION
System prompt ordered confirmation-and-wait for external actions with an absolute 'a request is not approval', while the ship skill grants that asking-to-ship pre-approves push, PR, and merge. System outranks skill, so the model announced actions and halted instead of running them (observed live: merge and commit turns ending on narration, plus an eval trial citing irreversibility to demand confirmation). Scopes the rule so pre-approved actions run without pausing; a bare request is still not approval. Also reverts the Workflow same-response sentence, which duplicated the never-narrate-and-halt rule already present in the soft-approval block.

Validation: fmt, clippy -D warnings, workspace tests (only the known pre-existing predictable_long_command timing flake, fails on clean HEAD too), harness_basic 40/40.

Produced by [yolop](https://everruns.com/yolop)