### PR TITLE
fix(transcript), feat(runtime): actionable validation errors and eager spawn_background schema

### DIFF
--- a/knowledge/specs/tool-search.md
+++ b/knowledge/specs/tool-search.md
@@ -43,10 +43,11 @@ vendor was deleted and yolop now consumes upstream directly:
 2. **Static host-shaped eager profile.** Yolop passes first-turn repository
    discovery (`read_file`, `list_directory`, `grep_files`, `repo_map`,
    `repo_symbols`, `ast_grep`), bookkeeping (`write_todos`,
-   `write_session_title`), the shell (`bash`), and the mandatory
-   progress-guard transition (`progress_checkpoint`) to
-   `ToolSearchCapability::new().with_never_defer([...])`. Mutation,
-   background, release/control, skills, session history, web, LSP, and other
+   `write_session_title`), the shell (`bash`), background execution
+   (`spawn_background`), and the mandatory progress-guard transition
+   (`progress_checkpoint`) to
+   `ToolSearchCapability::new().with_never_defer([...])`. Mutation, other
+   background tools, release/control, skills, session history, web, LSP, and other
    specialized tools keep their names and descriptions visible but reveal their
    authoritative schemas through `tool_search` when the task calls for them.
    This is host/task shaped without a volatile classifier: the allowlist is
@@ -54,7 +55,11 @@ vendor was deleted and yolop now consumes upstream directly:
    deferred stub names no parameters while allowing extras, so a model fills the
    gap from other harnesses' shell schemas and yolop's
    `additionalProperties: false` schema then rejects the call: the most-used
-   tool in the harness spent a round trip on a correction. `repo_map`,
+   tool in the harness spent a round trip on a correction.
+   `spawn_background` is eager for the same reason: its deferred stub names no
+   parameters while allowing extras, so the model fills the gap from other
+   harnesses' background schemas and spends the turn on a validation correction
+   instead of starting the work. `repo_map`,
    `repo_symbols`, and `ast_grep` are eager so code work can move from broad
    orientation to symbol or structural navigation without a schema-reveal round
    trip. `repo_map` also stays eager for a contract reason: its deferred stub

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10005,7 +10005,12 @@ mod tests {
         // Includes the logical model, config, setup, and mandatory skill
         // discovery/activation schemas that are intentionally eager.
         const BASELINE_TOOL_DEFINITION_BYTES: usize = 28_901;
-        const BASELINE_SCHEMA_BYTES: usize = 13_700;
+        // 2026-09-12: 13,700 -> 14,350. `spawn_background` joined the
+        // never-defer allowlist, so its real 1061-byte schema replaced the
+        // ~45-byte deferred stub in the eager surface. Measured 14,302 locally
+        // and 13,938 in Linux CI for the same tree; the environment delta
+        // predates this change. Thin headroom kept on the larger number.
+        const BASELINE_SCHEMA_BYTES: usize = 14_350;
         let workspace = tempfile::tempdir().expect("workspace");
         let sessions = tempfile::tempdir().expect("sessions");
         let settings = Arc::new(SettingsStore::open(sessions.path().join("settings.toml")));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1238,6 +1238,11 @@ const YOLOP_NEVER_DEFER_TOOLS: &[&str] = &[
     // progress_guard can make this the only allowed transition, so the model
     // must never need tool_search to recover its argument shape.
     "progress_checkpoint",
+    // Background execution is called with free-form shell text. A deferred
+    // stub names no parameters while allowing extras, so the model guesses
+    // other harnesses' shapes and spends the turn on a validation correction
+    // instead of starting the work.
+    "spawn_background",
 ];
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
@@ -4224,9 +4229,10 @@ pub async fn build_with_options(
     // Provider-agnostic deferred tool loading (upstream `everruns-core`, 0.11.0+).
     // Defers the long tail behind a `tool_search` tool and restores real schemas
     // progressively (per-session reveal set). The `never_defer` allowlist keeps
-    // only first-turn discovery and bookkeeping eager. Mutation, background,
-    // control, release, and specialized tools retain visible names/descriptions
-    // but load schemas through `tool_search`. This static host profile preserves
+    // only first-turn discovery and bookkeeping eager. Mutation (except
+    // `spawn_background`), control, release, and specialized tools retain
+    // visible names/descriptions but load schemas through `tool_search`. This
+    // static host profile preserves
     // a stable provider-cache prefix; there is no volatile per-turn classifier.
     // Yolop does not own the eager tool definitions, so it sets the policy by
     // name here. Works on every provider/model, unlike the native
@@ -9702,6 +9708,7 @@ mod tests {
             "list_skills",
             "activate_skill",
             "progress_checkpoint",
+            "spawn_background",
             // The shell is eager: a stub costs a correction round trip on the
             // most-called tool in the harness.
             "bash",
@@ -9715,7 +9722,6 @@ mod tests {
             // Opt-in surfaces defer, LSP included.
             "lsp_definition",
             "lsp_hover",
-            "spawn_background",
             "run_command",
             "search_files",
         ];

--- a/src/tui/transcript.rs
+++ b/src/tui/transcript.rs
@@ -628,9 +628,38 @@ fn readable_tool_block(error: &str) -> Option<String> {
         .get("message")
         .and_then(Value::as_str)
         .unwrap_or("the arguments do not match the tool schema");
-    Some(format!(
-        "invalid arguments for `{tool}`: {message} — rejected before running; retrying"
-    ))
+    let mut summary = format!("invalid arguments for `{tool}`");
+    if let Some(path) = diagnostic.get("path").and_then(Value::as_str)
+        && !path.is_empty()
+        && path != "/"
+    {
+        summary.push_str(&format!(" at `{path}`"));
+    }
+    summary.push_str(&format!(": {message}"));
+    let expected_text = diagnostic
+        .get("expected")
+        .map(|value| serde_json::to_string(value).unwrap_or_default())
+        .unwrap_or_default();
+    let received = diagnostic.get("received").and_then(Value::as_str);
+    if !expected_text.is_empty() {
+        let expected_text = truncate_chars(&expected_text, 300);
+        match received {
+            Some(got) => {
+                summary.push_str(&format!(" (expected {expected_text}, got {got})"));
+            }
+            None => {
+                summary.push_str(&format!(" (expected {expected_text})"));
+            }
+        }
+    } else if let Some(got) = received {
+        summary.push_str(&format!(" (got {got})"));
+    }
+    summary.push_str(", rejected before running, retrying");
+    if let Some(correction) = diagnostic.get("correction").and_then(Value::as_str) {
+        summary.push(' ');
+        summary.push_str(correction);
+    }
+    Some(summary)
 }
 
 /// One-line summary of a tool result, used in the transcript and `--print` output.
@@ -874,6 +903,45 @@ mod tests {
         );
         assert!(summary.contains("unsupported argument"), "{summary}");
         assert!(!summary.contains("pre_tool_use"), "{summary}");
+    }
+
+    /// A wrong-type rejection must name the argument path and the expected
+    /// shape, otherwise the model and the user cannot tell what to fix (the
+    /// `spawn_background` retry loop in the screenshot showed only the generic
+    /// message).
+    #[test]
+    fn argument_validation_type_error_surfaces_path_and_shapes() {
+        let data = ToolCompletedData {
+            success: false,
+            error: Some(
+                "blocked by pre_tool_use hook: {\"error\":\"invalid_tool_arguments\",\
+                 \"tool\":\"spawn_background\",\"path\":\"/command\",\"message\":\"an argument \
+                 has the wrong JSON type\",\"expected\":{\"type\":\"string\"},\
+                 \"received\":\"object\",\"correction\":\"Correct the arguments to the \
+                 expected shape and call this tool once more.\",\"retryable\":true}"
+                    .into(),
+            ),
+            tool_call_id: "call-1".into(),
+            tool_name: "spawn_background".into(),
+            tool_call_fingerprint: None,
+            tool_result_fingerprint: None,
+            display_name: Some("Spawn background".into()),
+            status: "error".into(),
+            result: None,
+            duration_ms: None,
+            capability_id: None,
+            capability_name: None,
+            narration: None,
+        };
+        let summary = summarize_tool_result(&data);
+        assert!(
+            summary.contains("invalid arguments for `spawn_background`"),
+            "{summary}"
+        );
+        assert!(summary.contains("at `/command`"), "{summary}");
+        assert!(summary.contains("expected"), "{summary}");
+        assert!(summary.contains("got object"), "{summary}");
+        assert!(summary.contains("Correct the arguments"), "{summary}");
     }
 
     /// An actual user hook block keeps the engine's wording: it really was a hook.


### PR DESCRIPTION
## What changed
Validation rejections in the transcript now name the argument path and the expected vs received shapes, plus the correction hint, instead of only the generic message. `spawn_background` joined the never-defer allowlist, so its full argument schema ships on the first turn instead of a parameterless stub.

## Why
A `spawn_background` call with a wrong-typed argument failed with only "an argument has the wrong JSON type" and no pointer to what to fix, then retried blindly. The deferred stub schema names no parameters while allowing extras, so the model reconstructed the shape from other harnesses and guessed wrong.

## Before / After
Before: `invalid arguments for \`spawn_background\`: an argument has the wrong JSON type, rejected before running; retrying`

After: `invalid arguments for \`spawn_background\` at \`/command\`: an argument has the wrong JSON type (expected {"type":"string"}, got object), rejected before running, retrying Correct the arguments to the expected shape and call this tool once more.`

Proof a reviewer can check: new `argument_validation_type_error_surfaces_path_and_shapes` unit test pins the after text; cold-start composition output shows the real 1061-byte `spawn_background` schema eager with prompt bytes unchanged at 14893; live OpenAI smoke (`doppler run -- cargo run -- --provider openai`) completed a turn.

## Risk
- Low
- First-turn tool definitions grow ~1KB; a model flow that relied on the stub shape behaves differently by design. Guarded by the first-turn profile test and the cold-start composition test.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (pre-1.0; error text is display-only, diagnostic JSON unchanged)
- [x] Knowledge concepts updated

## Knowledge
Updated `knowledge/specs/tool-search.md`: eager profile lists background execution (`spawn_background`); defer sentence scoped to other background tools; rationale added.

## Security
- TM-TOOL: no new capability; one existing tool moved from deferred stub to full schema. No write-blocklist impact.
- TM-FS / TM-BASH / TM-LLM: untouched. No key handling, shell, or filesystem path changes. Display text renders owned diagnostic fields only.
- TM-DEP: no dependency changes.

## Follow-ups
- Cold-start budget test fails on main too (14893 vs 14848 baseline). Pre-existing, fails identically without this change, so left out of scope.
- `predictable_long_command_returns_immediately...` flakes under full-suite parallelism and passes in isolation. Pre-existing timing sensitivity, unrelated files.

Produced by [yolop](https://everruns.com/yolop)