### PR TITLE
chore(release): prepare v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ mechanical `### What's Changed` list of merged PRs.
 Releases are cut via [`/release`](./.agents/skills/release/SKILL.md), which
 tags the version and publishes to crates.io and the Homebrew tap.
 
+## [0.18.1] - 2026-09-12
+
+### Highlights
+
+- Named profiles can now be managed from the CLI and control plane (#698)
+- Configured MCP servers are listed in the agent system prompt (#700)
+- OpenRouter 402 billing pauses now guide users to wait or add credits, and validation errors are actionable (#701, #705)
+- Compaction checkpoints stamp rows and trace Codex compaction (#703)
+
+### What's Changed
+
+* fix(transcript), feat(runtime): actionable validation errors and eager spawn_background schema ([#705](https://github.com/everruns/yolop/pull/705)) by @chaliy
+* fix(ship): require human confirmation for safety-critical steps in agent workflow ([#704](https://github.com/everruns/yolop/pull/704)) by @chaliy
+* feat(compaction): stamp checkpoint rows and trace Codex compaction ([#703](https://github.com/everruns/yolop/pull/703)) by @chaliy
+* fix(config): advertise ProfilesSettings with its schema ([#702](https://github.com/everruns/yolop/pull/702)) by @chaliy
+* feat(openrouter): guide 402 in-flight billing pauses ([#701](https://github.com/everruns/yolop/pull/701)) by @chaliy
+* feat(mcp): list configured servers in agent system prompt ([#700](https://github.com/everruns/yolop/pull/700)) by @chaliy
+* fix(auth): surface everruns login branding ([#699](https://github.com/everruns/yolop/pull/699)) by @chaliy
+* feat(profiles): manage named profiles from CLI and control plane ([#698](https://github.com/everruns/yolop/pull/698)) by @chaliy
+* fix(ship): keep invoking the merge tool call ([#697](https://github.com/everruns/yolop/pull/697)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/yolop/compare/v0.18.0...v0.18.1
+
 ## [0.18.0] - 2026-09-11
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10065,7 +10065,7 @@ dependencies = [
 
 [[package]]
 name = "yolop"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "yolop"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 authors = ["Everruns <support@everruns.com>"]
 license = "MIT"


### PR DESCRIPTION
## [0.18.1] - 2026-09-12

### Highlights

- Named profiles can now be managed from the CLI and control plane (#698)
- Configured MCP servers are listed in the agent system prompt (#700)
- OpenRouter 402 billing pauses now guide users to wait or add credits, and validation errors are actionable (#701, #705)
- Compaction checkpoints stamp rows and trace Codex compaction (#703)

### What's Changed

* fix(transcript), feat(runtime): actionable validation errors and eager spawn_background schema ([#705](https://github.com/everruns/yolop/pull/705)) by @chaliy
* fix(ship): require human confirmation for safety-critical steps in agent workflow ([#704](https://github.com/everruns/yolop/pull/704)) by @chaliy
* feat(compaction): stamp checkpoint rows and trace Codex compaction ([#703](https://github.com/everruns/yolop/pull/703)) by @chaliy
* fix(config): advertise ProfilesSettings with its schema ([#702](https://github.com/everruns/yolop/pull/702)) by @chaliy
* feat(openrouter): guide 402 in-flight billing pauses ([#701](https://github.com/everruns/yolop/pull/701)) by @chaliy
* feat(mcp): list configured servers in agent system prompt ([#700](https://github.com/everruns/yolop/pull/700)) by @chaliy
* fix(auth): surface everruns login branding ([#699](https://github.com/everruns/yolop/pull/699)) by @chaliy
* feat(profiles): manage named profiles from CLI and control plane ([#698](https://github.com/everruns/yolop/pull/698)) by @chaliy
* fix(ship): keep invoking the merge tool call ([#697](https://github.com/everruns/yolop/pull/697)) by @chaliy

**Full Changelog**: https://github.com/everruns/yolop/compare/v0.18.0...v0.18.1

## Publish-readiness

- `cargo publish --dry-run --allow-dirty -p yolop-yep`: clean (yolop-yep stays 0.4.0, no wire changes)
- `cargo search yolop`: crates.io serves 0.18.0, below 0.18.1
- `Cargo.toml` version 0.18.1 agrees with `Cargo.lock` (`yolop` 0.18.1)
- `cargo fmt --check`: clean
- `cargo clippy --workspace --all-targets --features yolop-yep/schema`: clean
- `cargo test --workspace --features yolop-yep/schema`: green on retry (one timing flake `predictable_long_command_returns_immediately` passed on rerun)
- No `extensions/` or `crates/` changes since v0.18.0, so no extension or SDK bump needed

## Post-merge verification

- [ ] `release.yml` green on the merge commit
- [ ] `publish.yml` green
- [ ] `cli-binaries.yml` green
- [ ] crates.io reports `yolop` 0.18.1
- [ ] tap formula points at `v0.18.1`
